### PR TITLE
Add workflow for design book

### DIFF
--- a/.github/workflows/design-book.yml
+++ b/.github/workflows/design-book.yml
@@ -28,3 +28,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./design/book
+          # Don't store history of gh-pages branch
+          # This ensures that the repository size doesn't grow too much
+          force_orphan: true

--- a/.github/workflows/design-book.yml
+++ b/.github/workflows/design-book.yml
@@ -1,3 +1,5 @@
+name: Design book
+
 on:
   push:
     branches:

--- a/.github/workflows/design-book.yml
+++ b/.github/workflows/design-book.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: "latest"
+
+      - name: Build
+        working-directory: ./design
+        run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # Only deploy if pushed to the main branch
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./design/book

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As the hive mind behind a growing, swarming, multi-species colony, you must lear
 ## About the game
 
 The design documents are stored in the [`design`](./design) directory, and are created using [`mdbook`](https://rust-lang.github.io/mdBook/index.html).
-Once you have `mdbook` installed, use `mdbook build --open` from the project root to read it in your browser!
+Once you have `mdbook` installed, use `mdbook build --open` in the [`design`](./design) directory to read it in your browser!
 
 For now, here are our high-level plans:
 


### PR DESCRIPTION
Closes #109.

This PR adds a new workflow that will build the design book on PRs and deploys it to the `gh-pages` branch when pushing to `main`.
We can then setup GitHub Pages to publish the `gh-pages` branch to have the book accessible via an URL.

I also fixed the instructions in the README, the book needs to be built in the `design` directory, otherwise you get an error.