### PR TITLE
Enable optimizations for dependencies in debug mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [
     "tools/debug_tools",
 ]
 default-members = ["emergence_game", "emergence_lib"]
+
+# Enable max optimizations for dependencies, but not for our code:
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
Closes #136.

This enables optimizations for dependencies even on debug mode.
On my laptop this increases FPS from ~20 to ~100.

Optionally we could also enable a small amount of optimizations for the game itself, like this:

```toml
# Enable only a small amount of optimization in debug mode
[profile.dev]
opt-level = 1
```

However, on my machine the difference of the setup in this PR in debug mode and release mode is insignificant, so it's probably not worth the increase in compile times.