### PR TITLE
Verify that all pages are included in the design book

### DIFF
--- a/.github/workflows/design-book.yml
+++ b/.github/workflows/design-book.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check for missing pages in SUMMARY.md
+        working-directory: ./design
+        run: ./verify_summary.sh
+
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/design/verify_summary.sh
+++ b/design/verify_summary.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Verify that all pages of the design book are listed in `src/SUMMARY.md`.
+# This is required for them to show up in the book.
+
+function is_in_summary {
+  # Count the number of occurances of the file in the summary
+  occurances=`grep $1 ./SUMMARY.md -c`
+  
+  # If it's not in the summary, print out an error
+  if [[ $occurances -eq 0 ]]
+  then
+    echo "'$1' missing in 'SUMMARY.md'"
+    exit 1
+  fi
+}
+
+# Export the function to use with 'xargs' later
+export -f is_in_summary
+
+# The pages are the 'src' folder
+cd src
+
+`# Get all pages in the book` \
+find . -name "*.md" \
+`# ...except for SUMMARY.md` \
+| grep -F './SUMMARY.md' -v \
+`# ...and check if they are included in the summary` \
+`# see <https://stackoverflow.com/a/11003457>` \
+| xargs -I {} bash -c 'is_in_summary "$@"' $0 {}


### PR DESCRIPTION
Closes #132.

This PR adds a script that verifies that all pages of the design book are also included in the `SUMMARY.md` file, because they won't appear in the book otherwise.

This script is also run in CI.

P.S. Bash scripting is pain.