### PR TITLE
Disable bevy console until licensing issues are fixed

### DIFF
--- a/tools/debug_tools/Cargo.toml
+++ b/tools/debug_tools/Cargo.toml
@@ -12,7 +12,9 @@ name = "debug_tools"
 
 [dependencies]
 bevy = "0.9"
-bevy_console = { git = "https://github.com/RichoDemus/bevy-console", rev = "fa09da33ee752facc8eb3b2ba93682005d179624" } # add bevy 0.9 revision
+# TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+# bevy_console = { git = "https://github.com/RichoDemus/bevy-console", rev = "fa09da33ee752facc8eb3b2ba93682005d179624" } # add bevy 0.9 revision
 #bevy_ecs_tilemap # may need to be added back but is unused and unplanned for use atm so it has been removed  
 # bevy_egui = "0.18.0" # TODO add when we use bevy_egui for debug ui
-bevy-inspector-egui = "0.14" # TODO: keep at 0.14 until finding a way to ensure 0.15 lets you use bevy console also
+# ALERT: using bevy-inspector-egui > 0.14 might cause issues with bevy_console
+bevy-inspector-egui = "0.15"

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -11,12 +11,15 @@ use bevy::{
     ui::{PositionType, Style, UiRect, Val},
 };
 
-use bevy_console::*;
+// TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+// use bevy_console::*;
 
 use bevy_inspector_egui::WorldInspectorPlugin;
-use console::{print_to_log, PrintToLog};
+// TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+// use console::{print_to_log, PrintToLog};
 
-pub mod console;
+// TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+// pub mod console;
 pub mod debug_ui;
 
 /// Creates a global resource that can be used to toggle actively displayed debug tools.
@@ -24,8 +27,9 @@ pub mod debug_ui;
 pub struct DebugInfo {
     /// Toggle global access to developer tools
     pub dev_mode: bool,
-    /// Toggle developer console
-    pub enable_console: bool,
+    // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+    // /// Toggle developer console
+    // pub enable_console: bool,
     /// Toggle the debug tile labels
     pub show_tile_label: bool,
     /// Toggle render info
@@ -38,7 +42,8 @@ impl Default for DebugInfo {
     fn default() -> Self {
         Self {
             dev_mode: true,
-            enable_console: true,
+            // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+            // enable_console: true,
             show_tile_label: true,
             show_fps_info: true,
             show_inspector: true,
@@ -52,8 +57,9 @@ pub struct DebugToolsPlugin;
 impl Plugin for DebugToolsPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugin(WorldInspectorPlugin::new())
-            .add_plugin(FrameTimeDiagnosticsPlugin)
-            .add_plugin(ConsolePlugin)
-            .add_console_command::<PrintToLog, _>(print_to_log);
+            .add_plugin(FrameTimeDiagnosticsPlugin);
+        // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
+        // .add_plugin(ConsolePlugin)
+        // .add_console_command::<PrintToLog, _>(print_to_log);
     }
 }


### PR DESCRIPTION
Unblocks PR #141 

Addresses Issue: #140 

Solution: I commented out `bevy_console` usage, and put in `TODO` statements with a link to the relevant issue. 

Side effect: we can now use the latest version of `bevy-inspector-egui`, because `bevy_console` doesn't play totally nicely with it either. 