### PR TITLE
Plugin fields

### DIFF
--- a/emergence_game/src/main.rs
+++ b/emergence_game/src/main.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy::window::{PresentMode, WindowPlugin};
+use emergence_lib::simulation::generation::GenerationConfig;
 
 fn main() {
     App::new()
@@ -12,7 +13,9 @@ fn main() {
             },
             ..Default::default()
         }))
-        .add_plugin(emergence_lib::simulation::SimulationPlugin)
+        .add_plugin(emergence_lib::simulation::SimulationPlugin {
+            gen_config: GenerationConfig::default(),
+        })
         .add_plugin(emergence_lib::InteractionPlugin)
         .add_plugin(emergence_lib::graphics::GraphicsPlugin)
         .run();

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -34,6 +34,7 @@ impl Plugin for InteractionPlugin {
 /// Importing between files shared in the `tests` directory appears to be broken with this workspace config?
 /// Followed directions from <https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html>
 pub mod testing {
+    use crate::simulation::generation::GenerationConfig;
     use crate::simulation::SimulationPlugin;
     use bevy::prelude::*;
 
@@ -47,15 +48,15 @@ pub mod testing {
     }
 
     /// Just the game logic and simulation
-    pub fn simulation_app() -> App {
+    pub fn simulation_app(gen_config: GenerationConfig) -> App {
         let mut app = minimal_app();
-        app.add_plugin(SimulationPlugin);
+        app.add_plugin(SimulationPlugin { gen_config });
         app
     }
 
     /// Test users interacting with the app
-    pub fn interaction_app() -> App {
-        let mut app = simulation_app();
+    pub fn interaction_app(gen_config: GenerationConfig) -> App {
+        let mut app = simulation_app(gen_config);
         app.add_plugin(bevy::input::InputPlugin)
             .add_plugin(super::InteractionPlugin);
         app

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -139,15 +139,14 @@ pub fn generate_terrain(
     info!("Generating terrain...");
     let mut rng = thread_rng();
 
-    let mut entity_data = Vec::with_capacity(map_positions.n_positions());
-    for position in map_positions.iter_positions() {
+    let entity_data = map_positions.iter_positions().map(|position| {
         let terrain: TerrainType =
             TerrainType::choose_random(&mut rng, &config.terrain_weights).unwrap();
-        entity_data.push((*position, terrain.instantiate(&mut commands, position)));
-    }
+        (*position, terrain.instantiate(&mut commands, position))
+    });
 
     let terrain_entities = TerrainEntityMap {
-        inner: MapResource::new(&map_positions, entity_data.into_iter()),
+        inner: MapResource::new(&map_positions, entity_data),
     };
     commands.insert_resource(terrain_entities)
 }

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -1,4 +1,5 @@
 //! Generating starting terrain and organisms
+use crate::enum_iter::IterableEnum;
 use crate::organisms::structures::{FungiBundle, PlantBundle};
 use crate::organisms::units::AntBundle;
 use crate::simulation::map::resources::MapResource;
@@ -139,9 +140,19 @@ pub fn generate_terrain(
     info!("Generating terrain...");
     let mut rng = thread_rng();
 
+    let terrain_variants = TerrainType::variants().collect::<Vec<TerrainType>>();
+    let terrain_weights = &config.terrain_weights;
+
     let entity_data = map_positions.iter_positions().map(|position| {
-        let terrain: TerrainType =
-            TerrainType::choose_random(&mut rng, &config.terrain_weights).unwrap();
+        let terrain: TerrainType = terrain_variants
+            .choose_weighted(&mut rng, |terrain_type| {
+                terrain_weights
+                    .get(terrain_type)
+                    .copied()
+                    .unwrap_or_default()
+            })
+            .copied()
+            .unwrap();
         (*position, terrain.instantiate(&mut commands, position))
     });
 

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -71,7 +71,10 @@ impl Default for GenerationConfig {
 }
 
 /// Generate the world.
-pub struct GenerationPlugin;
+pub struct GenerationPlugin {
+    /// Configuration settings for world generation
+    pub config: GenerationConfig,
+}
 
 /// Stage labels required to organize our startup systems.
 ///
@@ -103,7 +106,7 @@ pub enum GenerationStage {
 impl Plugin for GenerationPlugin {
     fn build(&self, app: &mut App) {
         info!("Building Generation plugin...");
-        app.init_resource::<GenerationConfig>()
+        app.insert_resource(self.config.clone())
             .add_startup_stage_before(
                 StartupStage::Startup,
                 GenerationStage::OrganismGeneration,

--- a/emergence_lib/src/simulation/map/mod.rs
+++ b/emergence_lib/src/simulation/map/mod.rs
@@ -92,16 +92,10 @@ impl MapGeometry {
     }
 }
 
-impl From<&GenerationConfig> for MapGeometry {
-    fn from(config: &GenerationConfig) -> MapGeometry {
-        MapGeometry::new(config.map_radius)
-    }
-}
-
 /// Initialize the [`MapGeometry`] resource according to [`GenerationConfig`].
 pub fn configure_map_geometry(mut commands: Commands, config: Res<GenerationConfig>) {
     info!("Configuring map geometry...");
-    let map_geometry: MapGeometry = (&*config).into();
+    let map_geometry: MapGeometry = MapGeometry::new(config.map_radius);
 
     commands.insert_resource(map_geometry);
 }

--- a/emergence_lib/src/simulation/mod.rs
+++ b/emergence_lib/src/simulation/mod.rs
@@ -5,7 +5,7 @@
 use crate::organisms::structures::StructuresPlugin;
 use crate::organisms::units::UnitsPlugin;
 use crate::signals::SignalsPlugin;
-use crate::simulation::generation::GenerationPlugin;
+use crate::simulation::generation::{GenerationConfig, GenerationPlugin};
 use crate::simulation::map::MapPositions;
 use crate::simulation::pathfinding::{Impassable, PassabilityCache};
 use bevy::app::{App, CoreStage, Plugin, StartupStage};
@@ -18,17 +18,22 @@ pub mod map;
 pub mod pathfinding;
 
 /// All of the code needed to make the simulation run
-pub struct SimulationPlugin;
+pub struct SimulationPlugin {
+    /// Configuration settings for world generation, these will be passed to [`GenerationPlugin`]
+    pub gen_config: GenerationConfig,
+}
 
 impl Plugin for SimulationPlugin {
     fn build(&self, app: &mut App) {
         info!("Building simulation plugin...");
-        app.add_plugin(GenerationPlugin)
-            .add_plugin(StructuresPlugin)
-            .add_plugin(UnitsPlugin)
-            .add_plugin(SignalsPlugin)
-            .add_startup_system_to_stage(StartupStage::PostStartup, initialize_passable_filter)
-            .add_system_to_stage(CoreStage::PreUpdate, update_passable_filter);
+        app.add_plugin(GenerationPlugin {
+            config: self.gen_config.clone(),
+        })
+        .add_plugin(StructuresPlugin)
+        .add_plugin(UnitsPlugin)
+        .add_plugin(SignalsPlugin)
+        .add_startup_system_to_stage(StartupStage::PostStartup, initialize_passable_filter)
+        .add_system_to_stage(CoreStage::PreUpdate, update_passable_filter);
     }
 }
 

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -4,18 +4,15 @@ pub mod components;
 pub mod entity_map;
 
 use crate as emergence_lib;
-use crate::enum_iter::IterableEnum;
+
 use crate::simulation::pathfinding::Impassable;
 use crate::terrain::components::{HighTerrain, PlainTerrain, RockyTerrain};
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::system::Commands;
-use bevy::utils::HashMap;
+
 use bevy_ecs_tilemap::tiles::TilePos;
 use emergence_macros::IterableEnum;
-use rand::distributions::WeightedError;
-use rand::seq::SliceRandom;
-use rand::Rng;
 
 /// Available terrain types.
 #[derive(Component, Clone, Copy, Hash, Eq, PartialEq, IterableEnum)]
@@ -48,18 +45,5 @@ impl TerrainType {
         }
         builder.insert(*self);
         builder.id()
-    }
-
-    /// Choose a random terrain tile based on the given weights
-    pub fn choose_random<R: Rng + ?Sized>(
-        rng: &mut R,
-        weights: &HashMap<TerrainType, f32>,
-    ) -> Result<TerrainType, WeightedError> {
-        TerrainType::variants()
-            .collect::<Vec<TerrainType>>()
-            .choose_weighted(rng, |terrain_type| {
-                weights.get(terrain_type).copied().unwrap_or_default()
-            })
-            .copied()
     }
 }

--- a/emergence_lib/tests/structure_viability.rs
+++ b/emergence_lib/tests/structure_viability.rs
@@ -4,9 +4,8 @@ use emergence_lib::organisms::structures::Structure;
 use emergence_lib::simulation::generation::GenerationConfig;
 use emergence_lib::terrain::TerrainType;
 
-fn single_structure_app(generation_config: GenerationConfig) -> App {
-    let mut app = emergence_lib::testing::simulation_app();
-    app.insert_resource(generation_config);
+fn single_structure_app(gen_config: GenerationConfig) -> App {
+    let mut app = emergence_lib::testing::simulation_app(gen_config);
 
     // Run startup systems
     app.update();
@@ -22,7 +21,7 @@ fn plants_are_self_sufficient() {
     let mut terrain_type_weights: HashMap<TerrainType, f32> = HashMap::new();
     terrain_type_weights.insert(TerrainType::Plain, 1.0);
 
-    let generation_config = GenerationConfig {
+    let gen_config = GenerationConfig {
         map_radius: 1,
         n_ant: 0,
         n_plant: 1,
@@ -30,7 +29,7 @@ fn plants_are_self_sufficient() {
         terrain_weights: terrain_type_weights,
     };
 
-    let mut app = single_structure_app(generation_config);
+    let mut app = single_structure_app(gen_config);
 
     let mut plant_query = app.world.query::<&Structure>();
     let n_plants = plant_query.iter(&app.world).len();

--- a/emergence_lib/tests/test_setup.rs
+++ b/emergence_lib/tests/test_setup.rs
@@ -1,5 +1,6 @@
 // use common::{bevy_app, interaction_app, minimal_app, simulation_app};
 
+use emergence_lib::simulation::generation::GenerationConfig;
 use emergence_lib::testing::{interaction_app, minimal_app, simulation_app};
 
 #[test]
@@ -11,7 +12,7 @@ fn minimal_app_can_update() {
 
 #[test]
 fn simulation_app_can_update() {
-    let mut app = simulation_app();
+    let mut app = simulation_app(GenerationConfig::default());
 
     app.update()
 }
@@ -20,7 +21,7 @@ fn simulation_app_can_update() {
 #[ignore = "Cannot test interaction without a virtual window."]
 // Blocked on https://github.com/bevyengine/bevy/pull/6256
 fn interaction_app_can_update() {
-    let mut app = interaction_app();
+    let mut app = interaction_app(GenerationConfig::default());
 
     app.update()
 }


### PR DESCRIPTION
Addresses issue: #124 

I think there are some real benefits here: in particular, it makes it really straightforward to set up new apps that require particular initialization data. 

However, there is a minor issue that the initialization data needs to be cloned as it is plumbed down to the plugin that eventually handles that data. In our case: `SimulationPlugion -> GenerationPlugin -> GenerationConfig resource initialization` (3 clones!) But these are super cheap clones, so maybe it's not something to worry about?