### PR TITLE
Add stubs for glossary

### DIFF
--- a/design/src/SUMMARY.md
+++ b/design/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Draft Steam Page](./steam-page.md)
+- [Glossary](./glossary.md)
 - [High Level Analysis](./high-level/index.md)
   - [Game Thesis](./high-level/game-thesis.md)
   - [Genre Analysis](./high-level/genre-analysis.md)

--- a/design/src/SUMMARY.md
+++ b/design/src/SUMMARY.md
@@ -5,6 +5,6 @@
   - [Game Thesis](./high-level/game-thesis.md)
   - [Genre Analysis](./high-level/genre-analysis.md)
   - [Genre Mechanics](./high-level/genre-mechanics.md)
-  - [Mapping genre mechanics to *Emergence*](high-level/mechanical-translation.md)
+  - [Mapping genre mechanics to *Emergence*](./high-level/mechanical-translation.md)
   - [Creative Automation](./high-level/creative-automation.md)
   - [Creative Automation: Case Studies](./high-level/creative-automation-case-studies.md)

--- a/design/src/glossary.md
+++ b/design/src/glossary.md
@@ -1,7 +1,7 @@
 # Glossary
 
 These definitions are intended to be relatively brief and opinionated.
-They are not
+They are not authoritative!
 
 ## Game Design
 

--- a/design/src/glossary.md
+++ b/design/src/glossary.md
@@ -1,0 +1,91 @@
+# Glossary
+
+These definitions are intended to be relatively brief and opinionated.
+They are not
+
+## Game Design
+
+Key concepts and terms from game design.
+
+### Accessibility
+
+### Automation
+
+### Challenge
+
+### Design-by-stumble
+
+### Depth and complexity
+
+### Fun
+
+### Genre
+
+### Interesting choices
+
+### Loop
+
+### Mechanic
+
+### Progression
+
+### Tuning levers
+
+### Tutorialization
+
+## Factory Builders
+
+Terms defined here are standard elements of the factory builder genre.
+
+### Belt
+
+### Bot
+
+### Blueprint
+
+### Clipboard
+
+### Filter
+
+### Inserter
+
+### Lab
+
+### Logistic network
+
+### Overlay
+
+### Pipette
+
+### Power
+
+### Research
+
+### Resource
+
+### Train
+
+### Research
+
+### Science pack
+
+## Ecology
+
+These terms come from the science of ecology and its related fields.
+
+### Clay
+
+### Nutrient cycle
+
+### Sand
+
+### Silt
+
+### Soil
+
+### Water cycle
+
+## Emergence
+
+These terms are specific to the game design of *Emergence*.
+Even if they have an external meaning, when used in this book, they will reflect this meaning.


### PR DESCRIPTION
I used section headings for the definitions to let us link to specific terms.

Feel free to make more requests, or start filling these out! Links are great here.

Start of #151.
