### PR TITLE
Debug toggle functionality (issue #100)

### DIFF
--- a/emergence_lib/src/hive_mind.rs
+++ b/emergence_lib/src/hive_mind.rs
@@ -161,9 +161,6 @@ fn show_debug_info(
 ) {
     let dev = dev.single();
     let dev_mode = dev.just_pressed(DevAction::ToggleDevMode);
-    let tile_labels = dev.just_pressed(DevAction::ToggleTileLabels);
-    let fps_info = dev.just_pressed(DevAction::ToggleInfoText);
-    let inspector = dev.just_pressed(DevAction::ToggleInspector);
 
     // Toggle the dev mode so that what happens is intuitive to the user
     if dev_mode {
@@ -176,36 +173,31 @@ fn show_debug_info(
         }
     }
 
-    // Toggle the tile labels, but also make sure that is makes sense to do so
-    if tile_labels && debug_info.dev_mode {
-        if debug_info.show_tile_labels {
-            debug_info.show_tile_labels = false;
-            info!("Tile Labels off");
-        } else {
-            debug_info.show_tile_labels = true;
-            info!("Tile Labels on");
-        }
+    if !debug_info.dev_mode {
+        // There is no other work to be done on this callback
+        // The DebugInfo shouldn't be changed after it gets disabled, or is already disabled
+        return;
     }
 
-    // Toggle the FPS info
-    if fps_info && debug_info.dev_mode {
-        if debug_info.show_fps_info {
-            debug_info.show_fps_info = false;
-            info!("FPS info off");
-        } else {
-            debug_info.show_fps_info = true;
-            info!("FPS info on");
-        }
+    let tile_labels = dev.just_pressed(DevAction::ToggleTileLabels);
+    let fps_info = dev.just_pressed(DevAction::ToggleInfoText);
+    let inspector = dev.just_pressed(DevAction::ToggleInspector);
+
+    toggle_debug_var(tile_labels, &mut debug_info.show_tile_labels, "Tile labels");
+    toggle_debug_var(fps_info, &mut debug_info.show_fps_info, "FPS info");
+    toggle_debug_var(inspector, &mut debug_info.show_inspector, "Egui inspector");
+}
+
+fn toggle_debug_var(is_action_active: bool, var: &mut bool, log_str: &'static str) {
+    if !is_action_active {
+        return;
     }
 
-    // Toggle the inspector
-    if inspector && debug_info.dev_mode {
-        if debug_info.show_inspector {
-            debug_info.show_inspector = false;
-            info!("Egui inspector off");
-        } else {
-            debug_info.show_inspector = true;
-            info!("Egui inspector on");
-        }
+    if *var {
+        *var = false;
+        info!("{} off", log_str);
+    } else {
+        *var = true;
+        info!("{} on", log_str);
     }
 }

--- a/emergence_lib/src/hive_mind.rs
+++ b/emergence_lib/src/hive_mind.rs
@@ -69,7 +69,6 @@ impl Default for HiveMindControls {
     }
 }
 
-// TODO: rework this to use LWIM conventions for mapping controls
 /// Interface for developer controls
 pub struct DevControls {
     /// Toggle the dev mode

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -25,7 +25,8 @@ impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(camera::CameraPlugin)
             .add_plugin(cursor::CursorTilePosPlugin)
-            .add_plugin(hive_mind::HiveMindPlugin);
+            .add_plugin(hive_mind::HiveMindPlugin)
+            .add_plugin(debug_tools::DebugToolsPlugin);
     }
 }
 

--- a/tools/debug_tools/Cargo.toml
+++ b/tools/debug_tools/Cargo.toml
@@ -14,7 +14,8 @@ name = "debug_tools"
 bevy = "0.9"
 # TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
 # bevy_console = { git = "https://github.com/RichoDemus/bevy-console", rev = "fa09da33ee752facc8eb3b2ba93682005d179624" } # add bevy 0.9 revision
-#bevy_ecs_tilemap # may need to be added back but is unused and unplanned for use atm so it has been removed  
+#bevy_ecs_tilemap # may need to be added back but is unused and unplanned for use atm so it has been removed
 # bevy_egui = "0.18.0" # TODO add when we use bevy_egui for debug ui
 # ALERT: using bevy-inspector-egui > 0.14 might cause issues with bevy_console
 bevy-inspector-egui = "0.15"
+leafwing-input-manager = "0.7"

--- a/tools/debug_tools/src/debug_ui.rs
+++ b/tools/debug_tools/src/debug_ui.rs
@@ -20,7 +20,8 @@ pub fn initialize_infotext(mut commands: Commands, asset_server: Res<AssetServer
 
 fn init_dev_action(commands: &mut Commands) {
     let dev_controls = DevControls::default();
-    commands.spawn(DevControlMarker)
+    commands
+        .spawn(DevControlMarker)
         .insert(InputManagerBundle::<DevAction> {
             action_state: ActionState::default(),
             input_map: InputMap::new([

--- a/tools/debug_tools/src/debug_ui.rs
+++ b/tools/debug_tools/src/debug_ui.rs
@@ -40,10 +40,20 @@ pub fn initialize_infotext(mut commands: Commands, asset_server: Res<AssetServer
 pub fn change_infotext(
     time: Res<Time>,
     diagnostics: Res<Diagnostics>,
-    mut fpstext_query: Query<&mut Text, With<FpsText>>,
+    mut fps_text_query: Query<&mut Text, With<FpsText>>,
     debug_info: Res<DebugInfo>,
 ) {
-    for mut text in &mut fpstext_query {
+    let mut fps_text = fps_text_query.single_mut();
+
+    // Clear out any fps text if it shouldn't be showing
+    if !debug_info.dev_mode || !debug_info.show_fps_info {
+        if !fps_text.sections[0].value.is_empty() {
+            fps_text.sections[0].value = String::new();
+        }
+        return;
+    }
+
+    if debug_info.show_fps_info {
         let mut fps = 0.0;
         if let Some(fps_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(fps_smoothed) = fps_diagnostic.smoothed() {
@@ -59,12 +69,6 @@ pub fn change_infotext(
             }
         }
 
-        if debug_info.dev_mode {
-            text.sections[0].value = if debug_info.show_fps_info {
-                format!(" {fps:.1} fps, {frame_time:.3} ms/frame")
-            } else {
-                String::new()
-            };
-        }
+        fps_text.sections[0].value = format!(" {fps:.1} fps, {frame_time:.3} ms/frame");
     }
 }

--- a/tools/debug_tools/src/debug_ui.rs
+++ b/tools/debug_tools/src/debug_ui.rs
@@ -1,18 +1,40 @@
 //! Debugging user interface for development
 
 use crate::*;
+use bevy::prelude::*;
 
 // Modified text_debug example from the Bevy UI examples (https://github.com/bevyengine/bevy/blob/main/examples/ui/text_debug.rs)
 /// Tag for the changing fps text component.
 #[derive(Component)]
 pub struct FpsText;
-/// Geneal tag for prototyping changing text ui elements
+
+/// A marker entity for the developer controls
 #[derive(Component)]
-pub struct ChangingText;
+pub struct DevControlMarker;
 
 /// Generate text elements on the screen
 pub fn initialize_infotext(mut commands: Commands, asset_server: Res<AssetServer>) {
+    init_dev_action(&mut commands);
+    init_fps_text(&mut commands, asset_server);
+}
+
+fn init_dev_action(commands: &mut Commands) {
+    let dev_controls = DevControls::default();
+    commands.spawn(DevControlMarker)
+        .insert(InputManagerBundle::<DevAction> {
+            action_state: ActionState::default(),
+            input_map: InputMap::new([
+                (dev_controls.toggle_dev_mode, DevAction::ToggleDevMode),
+                (dev_controls.toggle_tile_labels, DevAction::ToggleTileLabels),
+                (dev_controls.toggle_fps, DevAction::ToggleInfoText),
+                (dev_controls.toggle_inspector, DevAction::ToggleInspector),
+            ]),
+        });
+}
+
+fn init_fps_text(commands: &mut Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+
     // Create a text section in the top left corner to draw the fps readout
     commands.spawn((
         TextBundle::from_sections([TextSection::new(
@@ -70,5 +92,55 @@ pub fn change_infotext(
         }
 
         fps_text.sections[0].value = format!(" {fps:.1} fps, {frame_time:.3} ms/frame");
+    }
+}
+
+/// Toggle showing debug info
+pub fn show_debug_info(
+    dev: Query<&ActionState<DevAction>, With<DevControlMarker>>,
+    mut debug_info: ResMut<DebugInfo>,
+) {
+    let dev = dev.single();
+    let dev_mode = dev.just_pressed(DevAction::ToggleDevMode);
+
+    // Toggle the dev mode so that what happens is intuitive to the user
+    if dev_mode {
+        if debug_info.dev_mode {
+            debug_info.disable();
+            info!("Debug Info disabled");
+        } else {
+            debug_info.enable();
+            info!("Debug Info enabled");
+        }
+    }
+
+    if !debug_info.dev_mode {
+        // There is no other work to be done on this callback
+        // The DebugInfo shouldn't be changed after it gets disabled, or is already disabled
+        return;
+    }
+
+    let tile_labels = dev.just_pressed(DevAction::ToggleTileLabels);
+    let fps_info = dev.just_pressed(DevAction::ToggleInfoText);
+    let inspector = dev.just_pressed(DevAction::ToggleInspector);
+
+    toggle_debug_var(tile_labels, &mut debug_info.show_tile_labels, "Tile labels");
+    toggle_debug_var(fps_info, &mut debug_info.show_fps_info, "FPS info");
+    toggle_debug_var(inspector, &mut debug_info.show_inspector, "Egui inspector");
+}
+
+/// Toggle a debug variable only if the given action is active.
+/// Also logs out which variable is being toggled.
+fn toggle_debug_var(is_action_active: bool, var: &mut bool, log_str: &'static str) {
+    if !is_action_active {
+        return;
+    }
+
+    if *var {
+        *var = false;
+        info!("{} off", log_str);
+    } else {
+        *var = true;
+        info!("{} on", log_str);
     }
 }

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -31,11 +31,29 @@ pub struct DebugInfo {
     // /// Toggle developer console
     // pub enable_console: bool,
     /// Toggle the debug tile labels
-    pub show_tile_label: bool,
+    pub show_tile_labels: bool,
     /// Toggle render info
     pub show_fps_info: bool,
     /// Toggle displaying the egui inspector
     pub show_inspector: bool,
+}
+
+impl DebugInfo {
+    /// Change all the values in this [DebugInfo] to be enabled
+    pub fn enable(&mut self) {
+        self.dev_mode = true;
+        self.show_tile_labels = true;
+        self.show_fps_info = true;
+        self.show_inspector = true;
+    }
+
+    /// Change all the values in this [DebugInfo] to be disabled
+    pub fn disable(&mut self) {
+        self.dev_mode = false;
+        self.show_tile_labels = false;
+        self.show_fps_info = false;
+        self.show_inspector = false;
+    }
 }
 
 impl Default for DebugInfo {
@@ -44,7 +62,7 @@ impl Default for DebugInfo {
             dev_mode: true,
             // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
             // enable_console: true,
-            show_tile_label: true,
+            show_tile_labels: true,
             show_fps_info: true,
             show_inspector: true,
         }

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -1,4 +1,12 @@
 //! Debugging dev tools for Emergence.
+//!
+//! Keybindings for the developer info toggles:
+//! - dev_mode is Ctrl+Shift+D.
+//! - show_tile_labels is Ctrl+Shift+T.
+//! - show_fps_info is Ctrl+Shift+V.
+//! - show_inspector is Ctrl+Shift+I.
+//! These keybindings were chosen because the average person will not want to touch these very
+//! often. Primary, non-modifier keys should be for main gameplay keys.
 
 use bevy::{
     asset::AssetServer,

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -12,12 +12,13 @@ use bevy::{
     asset::AssetServer,
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::{
-        default, Color, Commands, Component, Plugin, Query, Res, Resource, TextBundle, With,
+        default, Color, Commands, Component, Plugin, Query, Res, Resource, TextBundle, With, KeyCode,
     },
     text::{Text, TextSection, TextStyle},
     time::Time,
     ui::{PositionType, Style, UiRect, Val},
 };
+use leafwing_input_manager::prelude::*;
 
 // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
 // use bevy_console::*;
@@ -64,6 +65,7 @@ impl DebugInfo {
     }
 }
 
+// TODO: It might be good later in development or closer to release to make the default disabled
 impl Default for DebugInfo {
     fn default() -> Self {
         Self {
@@ -83,9 +85,50 @@ pub struct DebugToolsPlugin;
 impl Plugin for DebugToolsPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugin(WorldInspectorPlugin::new())
-            .add_plugin(FrameTimeDiagnosticsPlugin);
+            .add_plugin(FrameTimeDiagnosticsPlugin)
+            .init_resource::<DebugInfo>()
+            .add_plugin(InputManagerPlugin::<DevAction>::default())
+            .add_system(debug_ui::show_debug_info);
         // TODO: see: https://github.com/Leafwing-Studios/Emergence/issues/140
         // .add_plugin(ConsolePlugin)
         // .add_console_command::<PrintToLog, _>(print_to_log);
+    }
+}
+
+/// Enumerates the actions a developer can take.
+#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DevAction {
+    /// Toggle the overall developer mode setting
+    ToggleDevMode,
+    // TODO: make debug labels
+    /// Toggle tilemap labels tools
+    ToggleTileLabels,
+    /// Toggle rendering info
+    ToggleInfoText,
+    /// Toggle the inspector
+    ToggleInspector,
+}
+
+/// Interface for developer controls
+pub struct DevControls {
+    /// Toggle the dev mode
+    pub toggle_dev_mode: UserInput,
+    /// Toggle the tile label
+    pub toggle_tile_labels: UserInput,
+    /// Toggle the fps ui
+    pub toggle_fps: UserInput,
+    /// Toggle the inspector
+    pub toggle_inspector: UserInput,
+}
+
+/// Add default developer controls
+impl Default for DevControls {
+    fn default() -> Self {
+        Self {
+            toggle_dev_mode: UserInput::chord([KeyCode::LControl, KeyCode::LShift, KeyCode::D]),
+            toggle_tile_labels: UserInput::chord([KeyCode::LControl, KeyCode::LShift, KeyCode::T]),
+            toggle_fps: UserInput::chord([KeyCode::LControl, KeyCode::LShift, KeyCode::V]),
+            toggle_inspector: UserInput::chord([KeyCode::LControl, KeyCode::LShift, KeyCode::I]),
+        }
     }
 }

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -39,7 +39,7 @@ pub struct DebugInfo {
 }
 
 impl DebugInfo {
-    /// Change all the values in this [DebugInfo] to be enabled
+    /// Change all the values in this [`DebugInfo`] to be enabled
     pub fn enable(&mut self) {
         self.dev_mode = true;
         self.show_tile_labels = true;
@@ -47,7 +47,7 @@ impl DebugInfo {
         self.show_inspector = true;
     }
 
-    /// Change all the values in this [DebugInfo] to be disabled
+    /// Change all the values in this [`DebugInfo`] to be disabled
     pub fn disable(&mut self) {
         self.dev_mode = false;
         self.show_tile_labels = false;

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -12,7 +12,8 @@ use bevy::{
     asset::AssetServer,
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::{
-        default, Color, Commands, Component, Plugin, Query, Res, Resource, TextBundle, With, KeyCode,
+        default, Color, Commands, Component, KeyCode, Plugin, Query, Res, Resource, TextBundle,
+        With,
     },
     text::{Text, TextSection, TextStyle},
     time::Time,

--- a/tools/debug_tools/src/lib.rs
+++ b/tools/debug_tools/src/lib.rs
@@ -1,10 +1,10 @@
 //! Debugging dev tools for Emergence.
 //!
 //! Keybindings for the developer info toggles:
-//! - dev_mode is Ctrl+Shift+D.
-//! - show_tile_labels is Ctrl+Shift+T.
-//! - show_fps_info is Ctrl+Shift+V.
-//! - show_inspector is Ctrl+Shift+I.
+//! - `dev_mode` is Ctrl+Shift+D.
+//! - `show_tile`_labels is Ctrl+Shift+T.
+//! - `show_fps_info` is Ctrl+Shift+V.
+//! - `show_inspector` is Ctrl+Shift+I.
 //! These keybindings were chosen because the average person will not want to touch these very
 //! often. Primary, non-modifier keys should be for main gameplay keys.
 


### PR DESCRIPTION
Added toggles for each debug info setting.
Refactored some things to make more sense or not wasting work.

This is just the plumbing for most of the functionality. Only the FPS info can be toggled (either by dev_mode as a whole, or by the fps specific one).