### PR TITLE
Fix crafting with empty recipes

### DIFF
--- a/emergence_lib/src/items.rs
+++ b/emergence_lib/src/items.rs
@@ -495,7 +495,7 @@ impl ItemCount {
 }
 
 /// A recipe to turn a set of items into different items.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Recipe {
     /// The inputs needed to craft the recipe.
     inputs: Vec<ItemCount>,

--- a/emergence_lib/src/organisms/sessile/fungi.rs
+++ b/emergence_lib/src/organisms/sessile/fungi.rs
@@ -7,7 +7,6 @@ use emergence_macros::IterableEnum;
 use crate::{
     enum_iter::IterableEnum,
     graphics::{organisms::OrganismSprite, sprites::IntoSprite, Tilemap},
-    items::Recipe,
     organisms::Species,
 };
 
@@ -34,11 +33,9 @@ pub struct LeucoBundle {
 impl LeucoBundle {
     /// Creates new [`Leuco`] fungi at specified tile position.
     pub fn new(tile_pos: TilePos) -> Self {
-        let recipe = Recipe::default();
-
         Self {
             plant: Fungi,
-            sessile_bundle: SessileBundle::new(tile_pos, recipe),
+            sessile_bundle: SessileBundle::new(tile_pos),
         }
     }
 }

--- a/emergence_lib/src/organisms/sessile/mod.rs
+++ b/emergence_lib/src/organisms/sessile/mod.rs
@@ -32,12 +32,22 @@ pub struct SessileBundle<S: Species> {
 }
 
 impl<S: Species> SessileBundle<S> {
-    /// Create a new [`SessileBundle`] at the given `tile_pos`, which will attempt to produce the provided `recipe` automatically.
-    pub fn new(tile_pos: TilePos, recipe: Recipe) -> SessileBundle<S> {
+    /// Create a new [`SessileBundle`] at the given `tile_pos`, without an active crafting recipe.
+    pub fn new(tile_pos: TilePos) -> SessileBundle<S> {
         SessileBundle {
             organism_bundle: OrganismBundle::default(),
             structure_bundle: StructureBundle::default(),
-            crafting_bundle: CraftingBundle::new(recipe),
+            crafting_bundle: CraftingBundle::new(),
+            tile_pos,
+        }
+    }
+
+    /// Create a new [`SessileBundle`] at the given `tile_pos`, which will attempt to produce the provided `recipe` automatically.
+    pub fn new_with_recipe(tile_pos: TilePos, recipe: Recipe) -> SessileBundle<S> {
+        SessileBundle {
+            organism_bundle: OrganismBundle::default(),
+            structure_bundle: StructureBundle::default(),
+            crafting_bundle: CraftingBundle::new_with_recipe(recipe),
             tile_pos,
         }
     }

--- a/emergence_lib/src/organisms/sessile/plants.rs
+++ b/emergence_lib/src/organisms/sessile/plants.rs
@@ -1,6 +1,9 @@
 //! Plants are structures powered by photosynthesis.
 
-use crate as emergence_lib;
+use crate::{
+    self as emergence_lib,
+    items::{ItemCount, ItemId},
+};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TilePos;
 use emergence_macros::IterableEnum;
@@ -12,7 +15,7 @@ use crate::{
     organisms::Species,
 };
 
-use std::default::Default;
+use std::{default::Default, time::Duration};
 
 use super::SessileBundle;
 
@@ -64,11 +67,16 @@ impl IntoSprite for Acacia {
 impl AcaciaBundle {
     /// Creates new Acacia plant.
     pub fn new(tile_pos: TilePos) -> Self {
-        let recipe = Recipe::default();
-
         Self {
             plant: Plant,
-            sessile_bundle: SessileBundle::new(tile_pos, recipe),
+            sessile_bundle: SessileBundle::new_with_recipe(
+                tile_pos,
+                Recipe::new(
+                    Vec::new(),
+                    vec![ItemCount::one(ItemId::acacia_leaf())],
+                    Duration::from_secs(10),
+                ),
+            ),
         }
     }
 }

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -1,5 +1,7 @@
 //! Everything needed to make structures able to craft things.
 
+use std::time::Duration;
+
 use bevy::prelude::*;
 
 use crate::items::{Inventory, Recipe};
@@ -54,8 +56,20 @@ pub struct CraftingBundle {
 }
 
 impl CraftingBundle {
+    /// Create a new crafting bundle without an active recipe set.
+    pub fn new() -> Self {
+        Self {
+            // TODO: Don't hard-code these values
+            input_inventory: InputInventory(Inventory::new(0, 0)),
+            output_inventory: OutputInventory(Inventory::new(1, 10)),
+            craft_timer: CraftTimer(Timer::new(Duration::ZERO, TimerMode::Once)),
+            active_recipe: ActiveRecipe(None),
+            craft_state: CraftingState::WaitingForInput,
+        }
+    }
+
     /// Create a new crafting bundle for the given recipe.
-    pub fn new(recipe: Recipe) -> Self {
+    pub fn new_with_recipe(recipe: Recipe) -> Self {
         Self {
             // TODO: Don't hard-code these values
             input_inventory: InputInventory(Inventory::new(0, 0)),


### PR DESCRIPTION
Fixes #218.

The `Default` implementation for Recipe does not make sense, instead `None` for `ActiveRecipe` should be used.