### PR TITLE
Improve CI times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-check-lints-${{ hashFiles('**/Cargo.toml') }}
+          # Make sure the cache is updated after every run, in case some dependencies get updated
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
+          # Restore from previous runs of this job
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -49,7 +54,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+          # Make sure the cache is updated after every run, in case some dependencies get updated
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
+          # Restore from previous runs of this job
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -75,7 +85,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-check-compiles-${{ hashFiles('**/Cargo.toml') }}
+          # Make sure the cache is updated after every run, in case some dependencies get updated
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
+          # Restore from previous runs of this job
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -98,7 +113,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-check-doc-${{ hashFiles('**/Cargo.toml') }}
+          # Make sure the cache is updated after every run, in case some dependencies get updated
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
+          # Restore from previous runs of this job
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -120,6 +140,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
+        env:
+          cache-name: cargo-check-unused-dependencies
         with:
           path: |
             ~/.cargo/bin/
@@ -127,7 +149,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
+          # Make sure the cache is updated after every run, in case some dependencies get updated
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
+          # Restore from previous runs of this job
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-check-lints-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -99,7 +99,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-check-doc-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -112,10 +112,10 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
-#      - name: Installs cargo-deadlinks
-#        run: cargo install --force cargo-deadlinks
-#      - name: Checks dead links
-#        run: cargo deadlinks
+  #      - name: Installs cargo-deadlinks
+  #        run: cargo install --force cargo-deadlinks
+  #      - name: Checks dead links
+  #        run: cargo deadlinks
 
   check-unused-dependencies:
     runs-on: ubuntu-latest
@@ -140,17 +140,3 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo udeps
         run: cargo udeps
-
-  mdbook:
-    runs-on: ubuntu-20.04
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
-
-      - run: mdbook build design

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,13 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
+      # We don't --force install to reduce CI times (drastically)
+      # We fix the version so that it overwrites when we specify a new one
+      # We need to remember to update the version from time to time
       - name: Installs cargo-udeps
-        run: cargo install cargo-udeps
+        run: cargo install cargo-udeps@0.1.35
+        # Cargo gives an error if it's already installed
+        continue-on-error: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo udeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- test
         env:
-          CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   check-compiles:
@@ -110,7 +109,6 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- doc
         env:
-          CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
   #      - name: Installs cargo-deadlinks
   #        run: cargo install --force cargo-deadlinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Installs cargo-udeps
-        run: cargo install --force cargo-udeps
+        run: cargo install cargo-udeps
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo udeps

--- a/.github/workflows/design-book.yml
+++ b/.github/workflows/design-book.yml
@@ -7,6 +7,20 @@ on:
   pull_request:
 
 jobs:
+  mdbook:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: "latest"
+
+      - run: mdbook build design
+
   deploy:
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
Closes #220.

This is an attempt to improve the long CI times.

- Enable incremental compilation for CI.
- Bump version of cache action in `check-doc` workflow
- Fix CI caches by always updating them to the latest version
- Don't use `--force` on `cargo-udeps` installation so it doesn't have to be rebuilt every time

Some other cleanups:

- Make the cache keys consistent.
- Move mdbook build workflow to the design book workflow file.

## How the new caching works

We don't commit the `Cargo.lock` into our repository, because [it's not recommended for libraries](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries). (Not sure what the recommendation is for workspaces with both libraries and binaries, but we'll ignore that for now)

This means that CI, after cloning, only has access to the `Cargo.toml` file, but that doesn't indicate the actual versions of dependencies that will be installed on a fresh compile.

The problem is now that the `Cargo.toml` hash specifies the key for or cache. That means that only if the `Cargo.toml` changes, the cache is updated.
So once a new patch version of a crate is released, this won't be cached anymore so it has to be rebuilt and potentially redownloaded every time, increasing CI times by a lot.

The fix: We append the `github.run_id` to the cache key, which means that we will update the cache after every CI run.
Of course, we still want to reuse older CI runs. We can do this by specifying key _prefixes_ in the `restore-keys` attribute. They will then be used as a basis for the cache when the exact key could not be found.

The problem: We now create a new cache for every time CI runs. I _think_ this shouldn't be a problem as GitHub automatically cleans up unused caches after 7 days or if the maximum cache size has been reached.
If it ends up being a problem we can [delete caches manually when we don't need them anymore](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries), for example only keeping the last cache for each `Cargo.toml` hash.