### PR TITLE
Create CI cache from Cargo.lock file instead of run ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,21 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           override: true
+      - name: Restore registry cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - uses: actions/cache@v3
+      - name: Cache build files
+        uses: actions/cache@v3
         with:
-          # cache the build files! see: https://github.com/actions/cache
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -52,9 +62,20 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Restore registry cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - uses: actions/cache@v3
+      - name: Cache build files
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -85,9 +106,20 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Restore registry cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - uses: actions/cache@v3
+      - name: Cache build files
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -114,9 +146,20 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Restore registry cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - uses: actions/cache@v3
+      - name: Cache build files
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -151,9 +194,20 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
+      - name: Restore registry cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - uses: actions/cache@v3
+      - name: Cache build files
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+      - name: Create Cargo.lock file
+        run: cargo generate-lockfile
       - uses: actions/cache@v3
         with:
           # cache the build files! see: https://github.com/actions/cache
@@ -25,17 +32,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Make sure the cache is updated after every run, in case some dependencies get updated
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
-          # Restore from previous runs of this job
+          # Update the cache every time the lock file changes
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # Restore caches from the same job and toml files
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-${{ github.job }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -46,6 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Create Cargo.lock file
+        run: cargo generate-lockfile
       - uses: actions/cache@v3
         with:
           path: |
@@ -54,16 +62,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Make sure the cache is updated after every run, in case some dependencies get updated
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
-          # Restore from previous runs of this job
+          # Update the cache every time the lock file changes
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # Restore caches from the same job and toml files
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-${{ github.job }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -77,6 +81,12 @@ jobs:
     needs: [check-lints]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Create Cargo.lock file
+        run: cargo generate-lockfile
       - uses: actions/cache@v3
         with:
           path: |
@@ -85,16 +95,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Make sure the cache is updated after every run, in case some dependencies get updated
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
-          # Restore from previous runs of this job
+          # Update the cache every time the lock file changes
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # Restore caches from the same job and toml files
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-${{ github.job }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -105,6 +111,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Create Cargo.lock file
+        run: cargo generate-lockfile
       - uses: actions/cache@v3
         with:
           path: |
@@ -113,15 +124,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Make sure the cache is updated after every run, in case some dependencies get updated
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
-          # Restore from previous runs of this job
+          # Update the cache every time the lock file changes
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # Restore caches from the same job and toml files
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-${{ github.job }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -139,9 +147,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          override: true
+      - name: Create Cargo.lock file
+        run: cargo generate-lockfile
       - uses: actions/cache@v3
-        env:
-          cache-name: cargo-check-unused-dependencies
         with:
           path: |
             ~/.cargo/bin/
@@ -149,16 +161,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Make sure the cache is updated after every run, in case some dependencies get updated
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.run_id }}
-          # Restore from previous runs of this job
+          # Update the cache every time the lock file changes
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # Restore caches from the same job and toml files
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-${{ github.job }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-          override: true
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,11 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           override: true
-      - name: Restore registry cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - name: Cache build files
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
+          # cache the build files! see: https://github.com/actions/cache
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -62,20 +52,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Restore registry cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - name: Cache build files
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -106,20 +85,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Restore registry cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - name: Cache build files
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -146,20 +114,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Restore registry cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - name: Cache build files
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -194,20 +151,9 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
-      - name: Restore registry cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-registry
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
       - name: Create Cargo.lock file
         run: cargo generate-lockfile
-      - name: Cache build files
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Create Cargo.lock file
-        run: cargo generate-lockfile
+        run: cargo update
       - uses: actions/cache@v3
         with:
           # cache the build files! see: https://github.com/actions/cache
@@ -53,7 +53,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Create Cargo.lock file
-        run: cargo generate-lockfile
+        run: cargo update
       - uses: actions/cache@v3
         with:
           path: |
@@ -86,7 +86,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Create Cargo.lock file
-        run: cargo generate-lockfile
+        run: cargo update
       - uses: actions/cache@v3
         with:
           path: |
@@ -115,7 +115,7 @@ jobs:
         with:
           toolchain: stable
       - name: Create Cargo.lock file
-        run: cargo generate-lockfile
+        run: cargo update
       - uses: actions/cache@v3
         with:
           path: |
@@ -152,7 +152,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Create Cargo.lock file
-        run: cargo generate-lockfile
+        run: cargo update
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Follow up to #220.

Instead of renewing the CI cache literally every time (blowing up the maximum cache limit), we now first generate the lock file and _then_ cache things, allowing us to take the lock file hash as key for the cache.

~~The downside is that we can't cache the Rust installation anymore, we'll see how that influences CI times.~~
This only seems to take 13 seconds, so it's not a problem.