### PR TITLE
Fix error with wrong commit hash for bevy-trait-query

### DIFF
--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -17,7 +17,7 @@ bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap", rev 
 rand = "0.8"
 leafwing-input-manager = "0.7"
 emergence_macros = { path = "../emergence_macros", version = "0.6" }
-bevy-trait-query = { git = "https://github.com/Leafwing-Studios/bevy-trait-query", rev = "65533bf8680753a3f998056e1719b826652f3b69" }
+bevy-trait-query = { git = "https://github.com/Leafwing-Studios/bevy-trait-query", rev = "5089dde94b3d91bb44230ceee9a4afe4222ae773" }
 indexmap = "1.9"
 debug_tools = { path = "../tools/debug_tools", optional = true }
 petitset = "0.2"


### PR DESCRIPTION
Closes #226 (hopefully).

This changes the commit rev for `bevy-trait-query` to the latest one on the `added-changed` branch.
The previously specified commit hash doesn't seem to exist anymore, it might have gotten lost while squashing commits or deleting branches.

Let's see if this fixes the flakiness of the `cargo update` command in CI.