### PR TITLE
Item and recipe manifests

### DIFF
--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -21,6 +21,7 @@ bevy-trait-query = { git = "https://github.com/Leafwing-Studios/bevy-trait-query
 indexmap = "1.9"
 debug_tools = { path = "../tools/debug_tools", optional = true }
 petitset = "0.2"
+serde = "1.0.152"
 
 [dev-dependencies]
 # We need headless operation in tests

--- a/emergence_lib/src/graphics/ui/hover_panel.rs
+++ b/emergence_lib/src/graphics/ui/hover_panel.rs
@@ -2,8 +2,8 @@
 use bevy::prelude::*;
 
 use crate::{
-    cursor::CursorTilePos, organisms::organism_details::HoverDetails,
-    structures::crafting::CraftingState,
+    cursor::CursorTilePos, items::recipe::RecipeManifest,
+    organisms::organism_details::HoverDetails, structures::crafting::CraftingState,
 };
 
 use super::{FiraSansFontFamily, RightPanel, UiStage};
@@ -109,6 +109,7 @@ fn setup_hover_panel(
 fn update_hover_panel(
     cursor_tile_pos: Res<CursorTilePos>,
     hover_details: Res<HoverDetails>,
+    recipe_manifest: Res<RecipeManifest>,
     mut panel_query: Query<&mut Visibility, With<HoverPanel>>,
     mut position_query: Query<&mut Text, With<PositionText>>,
     mut organism_query: Query<
@@ -154,7 +155,8 @@ fn update_hover_panel(
                 // Update all text entries for crafting
                 text.sections[1].value = format!("{}", crafting_details.input_inventory);
                 text.sections[3].value = format!("{}", crafting_details.output_inventory);
-                text.sections[5].value = if let Some(recipe) = &crafting_details.active_recipe {
+                text.sections[5].value = if let Some(recipe_id) = &crafting_details.active_recipe {
+                    let recipe = recipe_manifest.get(recipe_id).unwrap();
                     format!("{}", recipe)
                 } else {
                     "None".to_string()

--- a/emergence_lib/src/graphics/ui/hover_panel.rs
+++ b/emergence_lib/src/graphics/ui/hover_panel.rs
@@ -156,7 +156,7 @@ fn update_hover_panel(
                 text.sections[1].value = format!("{}", crafting_details.input_inventory);
                 text.sections[3].value = format!("{}", crafting_details.output_inventory);
                 text.sections[5].value = if let Some(recipe_id) = &crafting_details.active_recipe {
-                    let recipe = recipe_manifest.get(recipe_id).unwrap();
+                    let recipe = recipe_manifest.get(recipe_id);
                     format!("{}", recipe)
                 } else {
                     "None".to_string()

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -355,6 +355,7 @@ mod tests {
     fn item_manifest() -> ItemManifest {
         let mut item_manifest = HashMap::new();
         item_manifest.insert(ItemId::acacia_leaf(), ItemData::acacia_leaf());
+        item_manifest.insert(ItemId::test(), ItemData { stack_size: 10 });
 
         ItemManifest::new(item_manifest)
     }

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -8,6 +8,7 @@ use super::{
     slot::ItemSlot,
     ItemId,
 };
+
 /// An inventory to store multiple types of items.
 #[derive(Debug, Default, Clone)]
 pub struct Inventory {

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -47,6 +47,12 @@ impl ItemData {
     pub fn stack_size(&self) -> usize {
         self.stack_size
     }
+
+    // TODO: Remove this once we can load item data from asset files
+    /// A leaf from an acacia plant.
+    pub fn acacia_leaf() -> Self {
+        Self { stack_size: 10 }
+    }
 }
 
 /// The data definitions for all items.

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Display;
 
+use crate::manifest::Manifest;
+
 pub mod count;
 pub mod errors;
 pub mod inventory;
@@ -9,7 +11,7 @@ pub mod recipe;
 pub mod slot;
 
 /// The unique identifier of an item.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ItemId(&'static str);
 
 impl ItemId {
@@ -30,3 +32,20 @@ impl Display for ItemId {
         write!(f, "{}", self.0)
     }
 }
+
+/// The data associated with each item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemData {
+    /// The number of items that can fit in a single item slot.
+    stack_size: usize,
+}
+
+impl ItemData {
+    /// The number of items that can fit in a single item slot.
+    pub fn stack_size(&self) -> usize {
+        self.stack_size
+    }
+}
+
+/// The data definitions for all items.
+pub type ItemManifest = Manifest<ItemId, ItemData>;

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Display;
 
+use serde::{Deserialize, Serialize};
+
 use crate::manifest::Manifest;
 
 pub mod count;
@@ -34,7 +36,7 @@ impl Display for ItemId {
 }
 
 /// The data associated with each item.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ItemData {
     /// The number of items that can fit in a single item slot.
     stack_size: usize,

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -2,7 +2,20 @@
 
 use std::{fmt::Display, time::Duration};
 
+use crate::manifest::Manifest;
+
 use super::count::ItemCount;
+
+/// The unique identifier of a recipe.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct RecipeId(&'static str);
+
+impl RecipeId {
+    /// The ID of the recipe for the leaf production of acacia plants.
+    pub fn acacia_leaf_production() -> Self {
+        Self("acacia_leaf_production")
+    }
+}
 
 /// A recipe to turn a set of items into different items.
 #[derive(Debug, Clone)]
@@ -61,6 +74,9 @@ impl Display for Recipe {
         write!(f, "[{input_str}] -> [{output_str}] | {duration_str}s")
     }
 }
+
+/// The definitions for all recipes.
+pub type RecipeManifest = Manifest<RecipeId, Recipe>;
 
 #[cfg(test)]
 mod tests {

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -4,7 +4,7 @@ use std::{fmt::Display, time::Duration};
 
 use crate::manifest::Manifest;
 
-use super::count::ItemCount;
+use super::{count::ItemCount, ItemId};
 
 /// The unique identifier of a recipe.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -38,6 +38,16 @@ impl Recipe {
             outputs,
             craft_time,
         }
+    }
+
+    // TODO: Remove this once we load recipes from asset files
+    /// An acacia plant producing leaves.
+    pub fn acacia_leaf_production() -> Self {
+        Recipe::new(
+            Vec::new(),
+            vec![ItemCount::one(ItemId::acacia_leaf())],
+            Duration::from_secs(10),
+        )
     }
 
     /// The inputs needed to craft the recipe.

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -17,6 +17,12 @@ impl RecipeId {
     }
 }
 
+impl Display for RecipeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A recipe to turn a set of items into different items.
 #[derive(Debug, Clone)]
 pub struct Recipe {

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -16,6 +16,7 @@ pub mod graphics;
 pub mod hive_mind;
 pub mod interactable;
 pub mod items;
+pub mod manifest;
 pub mod organisms;
 pub mod signals;
 pub mod simulation;

--- a/emergence_lib/src/manifest.rs
+++ b/emergence_lib/src/manifest.rs
@@ -1,0 +1,26 @@
+//! Read-only definitions for entities.
+use bevy::{prelude::*, utils::HashMap};
+use std::{fmt::Debug, hash::Hash};
+
+/// Read-only data definitions.
+#[derive(Debug, Resource)]
+pub struct Manifest<Id, Data>(HashMap<Id, Data>)
+where
+    Id: Debug + PartialEq + Eq + Hash,
+    Data: Debug;
+
+impl<Id, Data> Manifest<Id, Data>
+where
+    Id: Debug + PartialEq + Eq + Hash,
+    Data: Debug,
+{
+    /// Create a new manifest with the given definitions.
+    pub fn new(map: HashMap<Id, Data>) -> Self {
+        Self(map)
+    }
+
+    /// Get the data entry for the given ID.
+    pub fn get(&self, id: &Id) -> Option<&Data> {
+        self.0.get(id)
+    }
+}

--- a/emergence_lib/src/manifest.rs
+++ b/emergence_lib/src/manifest.rs
@@ -1,7 +1,10 @@
 //! Read-only definitions for entities.
 use bevy::{prelude::*, utils::HashMap};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, hash::Hash};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
 
 /// Read-only data definitions.
 #[derive(Debug, Resource, Serialize, Deserialize)]
@@ -12,7 +15,7 @@ where
 
 impl<Id, Data> Manifest<Id, Data>
 where
-    Id: Debug + PartialEq + Eq + Hash,
+    Id: Debug + Display + PartialEq + Eq + Hash,
     Data: Debug,
 {
     /// Create a new manifest with the given definitions.
@@ -21,7 +24,14 @@ where
     }
 
     /// Get the data entry for the given ID.
-    pub fn get(&self, id: &Id) -> Option<&Data> {
-        self.0.get(id)
+    ///
+    /// # Panics
+    ///
+    /// This function panics when the given ID does not exist in the manifest.
+    /// We assume that all IDs are valid and the manifests are complete.
+    pub fn get(&self, id: &Id) -> &Data {
+        self.0
+            .get(id)
+            .unwrap_or_else(|| panic!("ID {id} not found in manifest"))
     }
 }

--- a/emergence_lib/src/manifest.rs
+++ b/emergence_lib/src/manifest.rs
@@ -1,9 +1,10 @@
 //! Read-only definitions for entities.
 use bevy::{prelude::*, utils::HashMap};
+use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, hash::Hash};
 
 /// Read-only data definitions.
-#[derive(Debug, Resource)]
+#[derive(Debug, Resource, Serialize, Deserialize)]
 pub struct Manifest<Id, Data>(HashMap<Id, Data>)
 where
     Id: Debug + PartialEq + Eq + Hash,

--- a/emergence_lib/src/organisms/organism_details.rs
+++ b/emergence_lib/src/organisms/organism_details.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 
 use crate::{
     cursor::CursorTilePos,
-    items::{inventory::Inventory, recipe::Recipe},
+    items::{inventory::Inventory, recipe::RecipeId},
     structures::crafting::{
         ActiveRecipe, CraftTimer, CraftingState, InputInventory, OutputInventory,
     },
@@ -55,7 +55,7 @@ pub struct CraftingDetails {
     pub output_inventory: Inventory,
 
     /// The recipe that's currently being crafted, if any.
-    pub active_recipe: Option<Recipe>,
+    pub active_recipe: Option<RecipeId>,
 
     /// The state of the ongoing crafting process.
     pub state: CraftingState,
@@ -134,7 +134,7 @@ fn hover_details(
                         Some(CraftingDetails {
                             input_inventory: input.inventory().clone(),
                             output_inventory: output.inventory().clone(),
-                            active_recipe: recipe.maybe_recipe().clone(),
+                            active_recipe: recipe.recipe_id().clone(),
                             state: state.clone(),
                             timer: timer.timer().clone(),
                         })

--- a/emergence_lib/src/organisms/sessile/mod.rs
+++ b/emergence_lib/src/organisms/sessile/mod.rs
@@ -6,7 +6,7 @@ use bevy::prelude::Bundle;
 use bevy_ecs_tilemap::tiles::TilePos;
 
 use crate::{
-    items::recipe::Recipe,
+    items::recipe::RecipeId,
     structures::{crafting::CraftingBundle, StructureBundle},
 };
 
@@ -43,11 +43,11 @@ impl<S: Species> SessileBundle<S> {
     }
 
     /// Create a new [`SessileBundle`] at the given `tile_pos`, which will attempt to produce the provided `recipe` automatically.
-    pub fn new_with_recipe(tile_pos: TilePos, recipe: Recipe) -> SessileBundle<S> {
+    pub fn new_with_recipe(tile_pos: TilePos, recipe_id: RecipeId) -> SessileBundle<S> {
         SessileBundle {
             organism_bundle: OrganismBundle::default(),
             structure_bundle: StructureBundle::default(),
-            crafting_bundle: CraftingBundle::new_with_recipe(recipe),
+            crafting_bundle: CraftingBundle::new_with_recipe(recipe_id),
             tile_pos,
         }
     }

--- a/emergence_lib/src/organisms/sessile/plants.rs
+++ b/emergence_lib/src/organisms/sessile/plants.rs
@@ -1,10 +1,6 @@
 //! Plants are structures powered by photosynthesis.
 
-use crate::{
-    self as emergence_lib,
-    items::{count::ItemCount, ItemId},
-    organisms::life_cycles::LifeCycle,
-};
+use crate::{self as emergence_lib, items::recipe::RecipeId, organisms::life_cycles::LifeCycle};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TilePos;
 use emergence_macros::IterableEnum;
@@ -12,11 +8,10 @@ use emergence_macros::IterableEnum;
 use crate::{
     enum_iter::IterableEnum,
     graphics::{organisms::OrganismSprite, sprites::IntoSprite, Tilemap},
-    items::recipe::Recipe,
     organisms::Species,
 };
 
-use std::{default::Default, time::Duration};
+use std::default::Default;
 
 use super::SessileBundle;
 
@@ -79,11 +74,7 @@ impl AcaciaBundle {
             plant: Plant,
             sessile_bundle: SessileBundle::new_with_recipe(
                 tile_pos,
-                Recipe::new(
-                    Vec::new(),
-                    vec![ItemCount::one(ItemId::acacia_leaf())],
-                    Duration::from_secs(10),
-                ),
+                RecipeId::acacia_leaf_production(),
             ),
         }
     }

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -147,7 +147,7 @@ fn start_and_finish_crafting(
             if *craft_state == CraftingState::Finished
                 && output
                     .0
-                    .add_all_or_nothing_many_items(recipe.outputs(), &*item_manifest)
+                    .add_all_or_nothing_many_items(recipe.outputs(), &item_manifest)
                     .is_ok()
             {
                 info!("Crafted items: {:?}", recipe.outputs());

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -5,10 +5,9 @@ use std::time::Duration;
 use bevy::{prelude::*, utils::HashMap};
 
 use crate::items::{
-    count::ItemCount,
     inventory::Inventory,
     recipe::{Recipe, RecipeId, RecipeManifest},
-    ItemId,
+    ItemData, ItemId, ItemManifest,
 };
 
 /// The current state in the crafting progress.
@@ -185,18 +184,19 @@ pub struct CraftingPlugin;
 
 impl Plugin for CraftingPlugin {
     fn build(&self, app: &mut App) {
+        // TODO: LOad this from an asset file
+        let mut item_manifest = HashMap::new();
+        item_manifest.insert(ItemId::acacia_leaf(), ItemData::acacia_leaf());
+
         // TODO: Load this from an asset file
         let mut recipe_manifest = HashMap::new();
         recipe_manifest.insert(
             RecipeId::acacia_leaf_production(),
-            Recipe::new(
-                Vec::new(),
-                vec![ItemCount::one(ItemId::acacia_leaf())],
-                Duration::from_secs(10),
-            ),
+            Recipe::acacia_leaf_production(),
         );
 
-        app.insert_resource(RecipeManifest::new(recipe_manifest))
+        app.insert_resource(ItemManifest::new(item_manifest))
+            .insert_resource(RecipeManifest::new(recipe_manifest))
             .add_system(progress_crafting)
             .add_system(start_and_finish_crafting.after(progress_crafting));
     }

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -2,11 +2,13 @@
 
 use std::time::Duration;
 
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 
 use crate::items::{
+    count::ItemCount,
     inventory::Inventory,
-    recipe::{RecipeId, RecipeManifest},
+    recipe::{Recipe, RecipeId, RecipeManifest},
+    ItemId,
 };
 
 /// The current state in the crafting progress.
@@ -183,7 +185,19 @@ pub struct CraftingPlugin;
 
 impl Plugin for CraftingPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(progress_crafting)
+        // TODO: Load this from an asset file
+        let mut recipe_manifest = HashMap::new();
+        recipe_manifest.insert(
+            RecipeId::acacia_leaf_production(),
+            Recipe::new(
+                Vec::new(),
+                vec![ItemCount::one(ItemId::acacia_leaf())],
+                Duration::from_secs(10),
+            ),
+        );
+
+        app.insert_resource(RecipeManifest::new(recipe_manifest))
+            .add_system(progress_crafting)
             .add_system(start_and_finish_crafting.after(progress_crafting));
     }
 }

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -140,19 +140,16 @@ fn start_and_finish_crafting(
     for (active_recipe, mut craft_timer, mut input, mut output, mut craft_state) in query.iter_mut()
     {
         if let Some(recipe_id) = &active_recipe.0 {
+            let recipe = recipe_manifest.get(recipe_id).unwrap();
+
             // Try to finish the crafting by putting the output in the inventory
             if *craft_state == CraftingState::Finished
                 && output
                     .0
-                    .add_all_or_nothing_many_items(
-                        recipe_manifest.get(recipe_id).unwrap().outputs(),
-                    )
+                    .add_all_or_nothing_many_items(recipe.outputs())
                     .is_ok()
             {
-                info!(
-                    "Crafted items: {:?}",
-                    recipe_manifest.get(recipe_id).unwrap().outputs()
-                );
+                info!("Crafted items: {:?}", recipe.outputs());
                 // The next item can be crafted
                 *craft_state = CraftingState::WaitingForInput;
             }
@@ -161,15 +158,11 @@ fn start_and_finish_crafting(
             if *craft_state == CraftingState::WaitingForInput
                 && input
                     .0
-                    .remove_all_or_nothing_many_items(
-                        recipe_manifest.get(recipe_id).unwrap().inputs(),
-                    )
+                    .remove_all_or_nothing_many_items(recipe.inputs())
                     .is_ok()
             {
                 // Set the timer to the recipe time
-                craft_timer
-                    .0
-                    .set_duration(*recipe_manifest.get(recipe_id).unwrap().craft_time());
+                craft_timer.0.set_duration(*recipe.craft_time());
                 craft_timer.0.reset();
 
                 // Start crafting


### PR DESCRIPTION
Closes #231 (the rest will be done in separate issues).

This PR introduces the concept of "manifests", which are read-only definitions of properties.
Later on, they will be read from asset files and serve as an easy configuration for our entities.

To begin, I have added a manifest for items, which currently just stores their stack size, and a manifest for recipes, which stores the inputs, outputs and crafting time.
The manifests are inserted in the crafting plugin. I also changed the inventory code a bit to use the stack size from the manifest instead of a hard-coded value.

## Future Work

- Load the manifests as assets from config files
  - Since the assets are only available in `emergence_game`, where do we handle the loading and resource insertion?
- Implement some kind of data validation for manifests. In the game we assume that all IDs are valid and all manifests are complete. This should be validated after loading the manifest files.
- Figure out a better way to handle this in the inventory code. Currently the slots still store the maximum item count to simplify the code a bit. We might also split the manifests into multiple hash maps to pass around less data. E.g. have one manifest that only stores the stack sizes. This should be done in a pre-processing step as keeping track of everything in the asset files like this would be tedious.