### PR TITLE
Use cargo-cache action to cache Cargo build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -95,7 +95,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -95,7 +95,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,23 +21,8 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           override: true
-      - name: Create Cargo.lock file
-        run: cargo update
-      - uses: actions/cache@v3
-        with:
-          # cache the build files! see: https://github.com/actions/cache
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Update the cache every time the lock file changes
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          # Restore caches from the same job and toml files
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -52,22 +37,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Create Cargo.lock file
-        run: cargo update
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Update the cache every time the lock file changes
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          # Restore caches from the same job and toml files
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -85,22 +56,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Create Cargo.lock file
-        run: cargo update
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Update the cache every time the lock file changes
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          # Restore caches from the same job and toml files
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -114,22 +71,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Create Cargo.lock file
-        run: cargo update
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Update the cache every time the lock file changes
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          # Restore caches from the same job and toml files
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -151,22 +94,8 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
-      - name: Create Cargo.lock file
-        run: cargo update
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Update the cache every time the lock file changes
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          # Restore caches from the same job and toml files
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ github.job }}-
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -95,7 +95,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
+        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -95,7 +95,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Build & run tests
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
@@ -95,7 +95,7 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@c9547bfffccc362f0bab274ce02a4a2e7d23a191
+        uses: Leafwing-Studios/cargo-cache@6dc28e2602e677d85fa9d7cad58f725b659213be
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time


### PR DESCRIPTION
This simplifies our CI process by using the new [`Leafwing-Studios/cargo-cache`](https://github.com/Leafwing-Studios/cargo-cache) action.

This also lets us know if it actually works...