### PR TITLE
Zoning prototype

### DIFF
--- a/emergence_lib/src/organisms/mod.rs
+++ b/emergence_lib/src/organisms/mod.rs
@@ -1,28 +1,68 @@
 //! Models organisms, which have two primary types: units (organisms that can move around freely)
 //! and structures (organisms that are fixed in place).
 use bevy::prelude::*;
-
-use crate::enum_iter::IterableEnum;
+use std::fmt::Display;
 
 use self::{
     life_cycles::LifeCycle,
     sessile::{fungi::FungiPlugin, plants::PlantsPlugin},
     units::UnitsPlugin,
 };
+use crate::enum_iter::IterableEnum;
 
 pub mod life_cycles;
 pub mod sessile;
 pub mod units;
 
 /// All of the standard components of an [`Organism`]
-#[derive(Bundle, Default)]
+#[derive(Bundle)]
 pub struct OrganismBundle<S: Species> {
     /// The marker component for orgamisms
     pub organism: Organism,
+    /// The variety of organism
+    pub organism_type: OrganismType,
     /// The marker component for this particular organism
     pub variety: S,
     /// The current life stage for this organism
     pub life_stage: S::LifeStage,
+}
+
+impl<S: Species> Default for OrganismBundle<S> {
+    fn default() -> Self {
+        Self {
+            organism: Organism,
+            organism_type: S::ORGANISM_TYPE,
+            variety: S::default(),
+            life_stage: S::LifeStage::default(),
+        }
+    }
+}
+
+/// The type of the organism, e.g. plant or fungus.
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+pub enum OrganismType {
+    /// A plant.
+    Plant,
+
+    /// A fungus.
+    Fungus,
+
+    /// An ant.
+    Ant,
+}
+
+impl Display for OrganismType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                OrganismType::Plant => "Plant",
+                OrganismType::Fungus => "Fungus",
+                OrganismType::Ant => "Ant",
+            }
+        )
+    }
 }
 
 /// A living part of the game ecosystem.
@@ -34,6 +74,9 @@ pub struct Organism;
 /// For example, `Acacia` or `Ant` would be a good example of an `Species`,
 /// while `Plant` is too general.
 pub trait Species: Default + Component {
+    /// The [`OrganismType`] associated with this species.
+    const ORGANISM_TYPE: OrganismType;
+
     /// The enum of possible life stages for this organism
     ///
     /// The [`Default`] implementation should correspond to the life stage of the organism when it is spawned

--- a/emergence_lib/src/organisms/sessile/fungi.rs
+++ b/emergence_lib/src/organisms/sessile/fungi.rs
@@ -1,5 +1,8 @@
 //! Fungi are structures powered by decomposition.
-use crate::{self as emergence_lib, organisms::life_cycles::LifeCycle};
+use crate::{
+    self as emergence_lib,
+    organisms::{life_cycles::LifeCycle, OrganismType},
+};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TilePos;
 use emergence_macros::IterableEnum;
@@ -41,6 +44,8 @@ impl LeucoBundle {
 }
 
 impl Species for Leuco {
+    const ORGANISM_TYPE: OrganismType = OrganismType::Fungus;
+
     type LifeStage = LeucoLifeStage;
 
     fn life_cycle() -> LifeCycle<Self> {

--- a/emergence_lib/src/organisms/sessile/plants.rs
+++ b/emergence_lib/src/organisms/sessile/plants.rs
@@ -1,6 +1,10 @@
 //! Plants are structures powered by photosynthesis.
 
-use crate::{self as emergence_lib, items::recipe::RecipeId, organisms::life_cycles::LifeCycle};
+use crate::{
+    self as emergence_lib,
+    items::recipe::RecipeId,
+    organisms::{life_cycles::LifeCycle, OrganismType},
+};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TilePos;
 use emergence_macros::IterableEnum;
@@ -33,6 +37,8 @@ pub struct AcaciaBundle {
 }
 
 impl Species for Acacia {
+    const ORGANISM_TYPE: OrganismType = OrganismType::Plant;
+
     type LifeStage = AcaciaLifeStage;
 
     fn life_cycle() -> LifeCycle<Self> {

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -17,6 +17,8 @@ use leafwing_input_manager::prelude::VirtualDPad;
 use leafwing_input_manager::Actionlike;
 use leafwing_input_manager::InputManagerBundle;
 
+use super::InteractionSystem;
+
 /// Camera logic
 pub struct CameraPlugin;
 
@@ -26,8 +28,8 @@ impl Plugin for CameraPlugin {
 
         app.add_plugin(InputManagerPlugin::<CameraAction>::default())
             .add_startup_system_to_stage(StartupStage::Startup, setup)
-            .add_system(camera_movement.label(PanCamSystemLabel))
-            .add_system(camera_zoom.label(PanCamSystemLabel));
+            .add_system(camera_movement.label(InteractionSystem::MoveCamera))
+            .add_system(camera_zoom.label(InteractionSystem::MoveCamera));
     }
 }
 
@@ -113,23 +115,6 @@ enum CameraAction {
     Pan,
     /// Reveal more or less of the map by pulling the camera away or moving it closer
     Zoom,
-}
-
-/// Plugin that adds the necessary systems for `PanCam` components to work
-#[derive(Default)]
-pub struct PanCamPlugin;
-
-/// Label to allow ordering of `PanCamPlugin`
-#[derive(SystemLabel)]
-pub struct PanCamSystemLabel;
-
-impl Plugin for PanCamPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_system(camera_movement.label(PanCamSystemLabel))
-            .add_system(camera_zoom.label(PanCamSystemLabel));
-
-        app.register_type::<PanCam>();
-    }
 }
 
 /// Handles camera zoom

--- a/emergence_lib/src/player_interaction/cursor.rs
+++ b/emergence_lib/src/player_interaction/cursor.rs
@@ -8,6 +8,8 @@ use bevy_ecs_tilemap::helpers::hex_grid::axial::AxialPos;
 use bevy_ecs_tilemap::map::{TilemapGridSize, TilemapSize};
 use bevy_ecs_tilemap::tiles::TilePos;
 
+use super::InteractionSystem;
+
 /// Initializes the [`CursorWorldPos`] and [`CursorTilePos`] resources, which are kept updated  
 /// updated using [`update_cursor_pos`].
 pub struct CursorTilePosPlugin;
@@ -16,10 +18,11 @@ impl Plugin for CursorTilePosPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CursorWorldPos>()
             .init_resource::<CursorTilePos>()
-            // FIXME: Ideally, this should be executed after the bevy_pancam plugin's
-            // `camera_movement` and `camera_zoom` systems; but for now we don't have the tools to
-            // specify this.
-            .add_system_to_stage(CoreStage::Last, update_cursor_pos);
+            .add_system(
+                update_cursor_pos
+                    .label(InteractionSystem::ComputeCursorPos)
+                    .after(InteractionSystem::MoveCamera),
+            );
     }
 }
 

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -1,6 +1,6 @@
 //! Tools for the player to interact with the world
 
-use bevy::prelude::{App, Plugin};
+use bevy::prelude::{App, Plugin, SystemLabel};
 
 pub mod camera;
 pub mod cursor;
@@ -24,4 +24,17 @@ impl Plugin for InteractionPlugin {
         #[cfg(feature = "debug_tools")]
         app.add_plugin(debug_tools::DebugToolsPlugin);
     }
+}
+
+/// Public system sets for player interaction, used for system ordering and config
+#[derive(SystemLabel, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum InteractionSystem {
+    /// Moves the camera
+    MoveCamera,
+    /// Cursor position is set
+    ComputeCursorPos,
+    /// Tiles are selected
+    SelectTiles,
+    /// Held structure is selected
+    SelectStructure,
 }

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -7,6 +7,7 @@ pub mod cursor;
 pub mod hive_mind;
 pub mod organism_details;
 pub mod tile_selection;
+pub mod zoning;
 
 /// All of the code needed for users to interact with the simulation.
 pub struct InteractionPlugin;
@@ -17,7 +18,8 @@ impl Plugin for InteractionPlugin {
             .add_plugin(cursor::CursorTilePosPlugin)
             .add_plugin(organism_details::DetailsPlugin)
             .add_plugin(hive_mind::HiveMindPlugin)
-            .add_plugin(tile_selection::TileSelectionPlugin);
+            .add_plugin(tile_selection::TileSelectionPlugin)
+            .add_plugin(zoning::ZoningPlugin);
 
         #[cfg(feature = "debug_tools")]
         app.add_plugin(debug_tools::DebugToolsPlugin);

--- a/emergence_lib/src/player_interaction/organism_details.rs
+++ b/emergence_lib/src/player_interaction/organism_details.rs
@@ -3,46 +3,18 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TilePos;
 
-use std::fmt::Display;
-
 use crate::{
     items::{inventory::Inventory, recipe::RecipeId},
     organisms::{
         sessile::{fungi::Fungi, plants::Plant},
         units::Ant,
+        OrganismType,
     },
     player_interaction::cursor::CursorTilePos,
     structures::crafting::{
         ActiveRecipe, CraftTimer, CraftingState, InputInventory, OutputInventory,
     },
 };
-
-/// The type of the organism, e.g. plant or fungus.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum OrganismType {
-    /// A plant.
-    Plant,
-
-    /// A fungus.
-    Fungus,
-
-    /// An ant.
-    Ant,
-}
-
-impl Display for OrganismType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                OrganismType::Plant => "Plant",
-                OrganismType::Fungus => "Fungus",
-                OrganismType::Ant => "Ant",
-            }
-        )
-    }
-}
 
 /// The details about crafting processes.
 #[derive(Debug, Clone)]

--- a/emergence_lib/src/player_interaction/tile_selection.rs
+++ b/emergence_lib/src/player_interaction/tile_selection.rs
@@ -8,7 +8,7 @@ use leafwing_input_manager::{
     Actionlike,
 };
 
-use super::cursor::CursorTilePos;
+use super::{cursor::CursorTilePos, InteractionSystem};
 
 /// Actions that can be used to select tiles.
 ///
@@ -184,10 +184,15 @@ impl Plugin for TileSelectionPlugin {
             .init_resource::<ActionState<TileSelectionAction>>()
             .insert_resource(TileSelectionAction::default_input_map())
             .add_plugin(InputManagerPlugin::<TileSelectionAction>::default())
-            .add_system(select_tiles)
-            .add_system(highlight_selected_tiles.after(select_tiles));
+            .add_system(
+                select_tiles
+                    .label(InteractionSystem::SelectTiles)
+                    .after(InteractionSystem::ComputeCursorPos),
+            )
+            .add_system(highlight_selected_tiles.after(InteractionSystem::SelectTiles));
     }
 }
+
 /// Integrates user input into tile selection actions to let other systems handle what happens to a selected tile
 fn select_tiles(
     cursor_tile_pos: Res<CursorTilePos>,

--- a/emergence_lib/src/player_interaction/tile_selection.rs
+++ b/emergence_lib/src/player_interaction/tile_selection.rs
@@ -28,6 +28,8 @@ pub enum TileSelectionAction {
     ///
     /// This action will track whether you are selecting or deselecting tiles based on the state of the first tile modified with this action.
     Multiple,
+    /// Clears the entire tile selection.
+    Clear,
 }
 
 /// Determines how the player input impacts a chosen tile.
@@ -135,6 +137,7 @@ impl SelectedTiles {
 
     /// Clears the set of selected tiles.
     pub fn clear_selection(&mut self) {
+        self.cache_selection();
         self.selection.clear();
     }
 
@@ -193,7 +196,9 @@ fn select_tiles(
     mut selection_mode: Local<SelectMode>,
 ) {
     if let Some(cursor_tile) = cursor_tile_pos.maybe_tile_pos() {
-        if actions.pressed(TileSelectionAction::Multiple) {
+        if actions.pressed(TileSelectionAction::Clear) {
+            selected_tiles.clear_selection();
+        } else if actions.pressed(TileSelectionAction::Multiple) {
             if *selection_mode == SelectMode::None {
                 *selection_mode = match selected_tiles.contains_pos(&cursor_tile) {
                     // If you start with a selected tile, subtract from the selection

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -1,0 +1,110 @@
+//! Selecting structures to place, and then setting tiles as those structures.
+
+use bevy::prelude::*;
+use bevy_ecs_tilemap::tiles::TilePos;
+use leafwing_input_manager::prelude::*;
+
+use crate::organisms::OrganismType;
+
+use super::{cursor::CursorTilePos, tile_selection::SelectedTiles, InteractionSystem};
+
+/// Logic and resources for structure selection and placement.
+pub struct ZoningPlugin;
+
+impl Plugin for ZoningPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SelectedStructure>()
+            .init_resource::<ActionState<ZoningAction>>()
+            .insert_resource(ZoningAction::default_input_map())
+            .add_plugin(InputManagerPlugin::<ZoningAction>::default())
+            .add_system(
+                set_selected_structure
+                    .label(InteractionSystem::SelectStructure)
+                    .after(InteractionSystem::ComputeCursorPos),
+            )
+            .add_system(zone_selected_tiles.after(InteractionSystem::SelectTiles))
+            .add_system(display_selected_structure.after(InteractionSystem::SelectStructure));
+    }
+}
+
+/// Tracks which structure the player has selected, if any
+#[derive(Resource, Default)]
+pub struct SelectedStructure {
+    /// Which structure is selected
+    // FIXME: should only be able to store structures. Units should be excluded.
+    pub maybe_structure: Option<OrganismType>,
+}
+
+/// Actions that the player can take to select and place structures
+#[derive(Actionlike, Clone, PartialEq, Debug)]
+pub enum ZoningAction {
+    /// Selects the structure on the tile under the player's cursor.
+    ///
+    /// If there is no structure there, the player's selection is cleared.
+    Pipette,
+    /// Clears the current structure selection.
+    ClearSelection,
+    /// Sets the zoning of all currently selected tiles to the currently selected structure.
+    ///
+    /// If no structure is selected, any zoning will be removed.
+    Zone,
+}
+
+impl ZoningAction {
+    /// The default keybindings
+    fn default_input_map() -> InputMap<ZoningAction> {
+        InputMap::new([
+            (KeyCode::Q, ZoningAction::Pipette),
+            (KeyCode::Space, ZoningAction::Zone),
+            (KeyCode::Back, ZoningAction::ClearSelection),
+            (KeyCode::Delete, ZoningAction::ClearSelection),
+        ])
+    }
+}
+
+/// Sets which structure the player has selected.
+fn set_selected_structure(
+    zoning_actions: Res<ActionState<ZoningAction>>,
+    mut selected_structure: ResMut<SelectedStructure>,
+    cursor_pos: Res<CursorTilePos>,
+    structure_query: Query<(&TilePos, &OrganismType)>,
+) {
+    // Clearing should take priority over selecting a new item (on the same frame)
+    if zoning_actions.just_pressed(ZoningAction::ClearSelection) {
+        selected_structure.maybe_structure = None;
+    } else if zoning_actions.just_pressed(ZoningAction::Pipette) {
+        // PERF: this needs to use an index, rather than a linear time search
+        let mut structure_under_cursor = None;
+        for (&tile_pos, organism_type) in structure_query.iter() {
+            if Some(tile_pos) == cursor_pos.maybe_tile_pos() {
+                structure_under_cursor = Some(organism_type.clone());
+                break;
+            }
+        }
+
+        selected_structure.maybe_structure = structure_under_cursor;
+    }
+}
+
+/// Shows which structure the player has selected.
+fn display_selected_structure(selected_structure: Res<SelectedStructure>) {
+    if selected_structure.is_changed() {
+        let selected_structure = &selected_structure.maybe_structure;
+        info!("Currently selected: {selected_structure:?}");
+    }
+}
+
+/// Applies zoning to an area
+fn zone_selected_tiles(
+    zoning_actions: Res<ActionState<ZoningAction>>,
+    selected_structure: Res<SelectedStructure>,
+    selected_tiles: Res<SelectedTiles>,
+) {
+    if zoning_actions.pressed(ZoningAction::Zone) {
+        // TODO: actually zone tiles
+        for &tile in selected_tiles.selection() {
+            let selected_structure = &selected_structure.maybe_structure;
+            info!("Zoning: {tile:?} to {selected_structure:?}.");
+        }
+    }
+}


### PR DESCRIPTION
Simple but effective controls and logic for zoning.

No organism selection yet, instead, grab them with a pipette!

```rust
/// Actions that the player can take to select and place structures
#[derive(Actionlike, Clone, PartialEq, Debug)]
pub enum ZoningAction {
    /// Selects the structure on the tile under the player's cursor.
    ///
    /// If there is no structure there, the player's selection is cleared.
    Pipette,
    /// Clears the current structure selection.
    ClearSelection,
    /// Sets the zoning of all currently selected tiles to the currently selected structure.
    ///
    /// If no structure is selected, any zoning will be removed.
    Zone,
}

impl ZoningAction {
    /// The default keybindings
    fn default_input_map() -> InputMap<ZoningAction> {
        InputMap::new([
            (KeyCode::Q, ZoningAction::Pipette),
            (KeyCode::Space, ZoningAction::Zone),
            (KeyCode::Back, ZoningAction::ClearSelection),
            (KeyCode::Delete, ZoningAction::ClearSelection),
        ])
    }
}
```

## Additional items

1. Storing `OrganismType` on the `OrganismBundle` for simplicity. We really need a better data structure here so it's extensible.
2. Added some real system ordering for the player interaction systems.
3. `Esc` now clears the set of selected tiles (`Backspace` clears the selected item).