### PR TITLE
Track and store intent

### DIFF
--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -22,6 +22,8 @@ indexmap = "1.9"
 debug_tools = { path = "../tools/debug_tools", optional = true }
 petitset = "0.2"
 serde = "1.0.152"
+leafwing_abilities = "0.3.0"
+derive_more = "0.99.17"
 
 [dev-dependencies]
 # We need headless operation in tests

--- a/emergence_lib/src/organisms/units/act.rs
+++ b/emergence_lib/src/organisms/units/act.rs
@@ -1,9 +1,12 @@
 //! Unit behaviour simulation
 
-use crate::organisms::units::pathfinding::get_weighted_position;
+use crate::{
+    organisms::units::pathfinding::get_weighted_position,
+    player_interaction::abilities::IntentAbility,
+};
 
 use crate::curves::BottomClampedLine;
-use crate::signals::emitters::{Emitter, StockEmitter};
+use crate::signals::emitters::Emitter;
 use crate::signals::tile_signals::TileSignals;
 use crate::simulation::map::index::MapIndex;
 use crate::simulation::map::MapPositions;
@@ -23,8 +26,8 @@ fn wander(
 ) -> TilePos {
     let signals_to_weight = |tile_signals: &TileSignals| {
         sensor.signal_to_weight(
-            tile_signals.get(&Emitter::Stock(StockEmitter::Lure)),
-            tile_signals.get(&Emitter::Stock(StockEmitter::Warning)),
+            tile_signals.get(&Emitter::Ability(IntentAbility::Lure)),
+            tile_signals.get(&Emitter::Ability(IntentAbility::Warning)),
         )
     };
 

--- a/emergence_lib/src/player_interaction/abilities.rs
+++ b/emergence_lib/src/player_interaction/abilities.rs
@@ -63,6 +63,8 @@ fn use_ability(
     if let Some(pos) = cursor_tile_pos.maybe_tile_pos() {
         for variant in IntentAbility::variants() {
             if ability_state.pressed(variant) {
+                #[allow(clippy::collapsible_if)]
+                // The expend method has side effects, and needs to be guarded
                 if intent_pool.expend(variant.cost()).is_ok() {
                     event_writer.send(SignalModificationEvent::SignalIncrement {
                         emitter: Emitter::Ability(variant),

--- a/emergence_lib/src/player_interaction/abilities.rs
+++ b/emergence_lib/src/player_interaction/abilities.rs
@@ -1,6 +1,8 @@
 //! Abilities spend intent, modifying the behavior of allied organisms in an area.
 
 use super::cursor::CursorTilePos;
+use super::intent::Intent;
+use super::InteractionSystem;
 use crate::signals::emitters::Emitter;
 use crate::signals::emitters::StockEmitter::{Lure, Warning};
 use crate::signals::SignalModificationEvent;
@@ -15,7 +17,12 @@ impl Plugin for AbilitiesPlugin {
         app.add_plugin(InputManagerPlugin::<IntentAbility>::default())
             .init_resource::<ActionState<IntentAbility>>()
             .insert_resource(IntentAbility::default_input_map())
-            .add_system(use_ability);
+            .add_system(
+                use_ability
+                    .label(InteractionSystem::UseAbilities)
+                    // If we don't have enough intent, zoning should be applied first to reduce the risk of an error message.
+                    .after(InteractionSystem::ApplyZoning),
+            );
     }
 }
 
@@ -35,6 +42,14 @@ impl IntentAbility {
             (KeyCode::F, IntentAbility::Lure),
             (KeyCode::G, IntentAbility::Warning),
         ])
+    }
+
+    /// The cost of each ability
+    fn cost(&self) -> Intent {
+        match self {
+            IntentAbility::Lure => Intent(10.),
+            IntentAbility::Warning => Intent(20.),
+        }
     }
 }
 

--- a/emergence_lib/src/player_interaction/intent.rs
+++ b/emergence_lib/src/player_interaction/intent.rs
@@ -1,0 +1,92 @@
+//! Intent represents the hive mind's ability to act.
+//!
+//! It slowly recovers over time, with a generous cap,
+//! and can be spent on [abilities](super::abilities), [zoning](super::zoning)
+//! and in other minor ways to influence the world.
+
+use std::ops::{Div, Mul};
+
+use bevy::prelude::Resource;
+use derive_more::{Add, AddAssign, Sub, SubAssign};
+use leafwing_abilities::{pool::MaxPoolLessThanZero, prelude::Pool};
+
+/// The amount of Intent available to the player.
+/// If they spend it all, they can no longer act.
+///
+/// This is stored as a single global resource.
+#[derive(Debug, Clone, PartialEq, Resource)]
+pub struct IntentPool {
+    /// The current amount of available intent.
+    current: Intent,
+    /// The maximum intent that can be stored.
+    max: Intent,
+    /// The amount of intent regenerated per second.
+    pub regen_per_second: Intent,
+}
+
+/// A quantity of Intent, used to modify an [`IntentPool`].
+///
+/// This is used to measure the amount of Intent that must be spent to perform various actions.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default, Add, Sub, AddAssign, SubAssign)]
+pub struct Intent(pub f32);
+
+impl Mul<f32> for Intent {
+    type Output = Intent;
+
+    fn mul(self, rhs: f32) -> Intent {
+        Intent(self.0 * rhs)
+    }
+}
+
+impl Div<f32> for Intent {
+    type Output = Intent;
+
+    fn div(self, rhs: f32) -> Intent {
+        Intent(self.0 / rhs)
+    }
+}
+
+impl Pool for IntentPool {
+    type Quantity = Intent;
+    const ZERO: Intent = Intent(0.);
+
+    fn new(current: Self::Quantity, max: Self::Quantity, regen_per_second: Self::Quantity) -> Self {
+        IntentPool {
+            current,
+            max,
+            regen_per_second,
+        }
+    }
+
+    fn current(&self) -> Self::Quantity {
+        self.current
+    }
+
+    fn set_current(&mut self, new_quantity: Self::Quantity) -> Self::Quantity {
+        let actual_value = Intent(new_quantity.0.clamp(0., self.max.0));
+        self.current = actual_value;
+        self.current
+    }
+
+    fn max(&self) -> Self::Quantity {
+        self.max
+    }
+
+    fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanZero> {
+        if new_max < Self::ZERO {
+            Err(MaxPoolLessThanZero)
+        } else {
+            self.max = new_max;
+            self.set_current(self.current);
+            Ok(())
+        }
+    }
+
+    fn regen_per_second(&self) -> Self::Quantity {
+        self.regen_per_second
+    }
+
+    fn set_regen_per_second(&mut self, new_regen_per_second: Self::Quantity) {
+        self.regen_per_second = new_regen_per_second;
+    }
+}

--- a/emergence_lib/src/player_interaction/intent.rs
+++ b/emergence_lib/src/player_interaction/intent.rs
@@ -15,6 +15,7 @@ use leafwing_abilities::{pool::MaxPoolLessThanZero, prelude::Pool};
 
 use super::InteractionSystem;
 
+/// Tracks, regenerates and displays [`IntentPool`].
 pub(super) struct IntentPlugin;
 
 impl Plugin for IntentPlugin {
@@ -49,7 +50,9 @@ pub struct IntentPool {
     pub regen_per_second: Intent,
 }
 
+/// The maximum amount of intent that can be stored at once
 const MAX_INTENT: Intent = Intent(100.);
+/// Amount of intent that is regenerated each second
 const INTENT_REGEN: Intent = Intent(10.);
 
 impl Default for IntentPool {

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -5,6 +5,7 @@ use bevy::prelude::{App, Plugin, SystemLabel};
 pub mod abilities;
 pub mod camera;
 pub mod cursor;
+pub mod intent;
 pub mod organism_details;
 pub mod tile_selection;
 pub mod zoning;

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -16,9 +16,10 @@ pub struct InteractionPlugin;
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(camera::CameraPlugin)
-            .add_plugin(cursor::CursorTilePosPlugin)
-            .add_plugin(organism_details::DetailsPlugin)
             .add_plugin(abilities::AbilitiesPlugin)
+            .add_plugin(cursor::CursorTilePosPlugin)
+            .add_plugin(intent::IntentPlugin)
+            .add_plugin(organism_details::DetailsPlugin)
             .add_plugin(tile_selection::TileSelectionPlugin)
             .add_plugin(zoning::ZoningPlugin);
 
@@ -38,4 +39,10 @@ pub enum InteractionSystem {
     SelectTiles,
     /// Held structure is selected
     SelectStructure,
+    /// Replenishes the [`IntentPool`](intent::IntentPool) of the hive mind
+    ReplenishIntent,
+    /// Apply zoning to tiles
+    ApplyZoning,
+    /// Use intent-spending abilities
+    UseAbilities,
 }

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -22,7 +22,11 @@ impl Plugin for ZoningPlugin {
                     .label(InteractionSystem::SelectStructure)
                     .after(InteractionSystem::ComputeCursorPos),
             )
-            .add_system(zone_selected_tiles.after(InteractionSystem::SelectTiles))
+            .add_system(
+                zone_selected_tiles
+                    .label(InteractionSystem::ApplyZoning)
+                    .after(InteractionSystem::SelectTiles),
+            )
             .add_system(display_selected_structure.after(InteractionSystem::SelectStructure));
     }
 }

--- a/emergence_lib/src/signals/configs.rs
+++ b/emergence_lib/src/signals/configs.rs
@@ -1,7 +1,6 @@
 //! Utilities to manage configuration of signals (colour, decay rate, etc.).
 
-use crate::enum_iter::IterableEnum;
-use crate::signals::emitters::{Emitter, StockEmitter};
+use crate::signals::emitters::Emitter;
 use bevy::ecs::system::Resource;
 use indexmap::IndexMap;
 
@@ -18,39 +17,10 @@ pub struct SignalConfigs {
 
 impl Default for SignalConfigs {
     fn default() -> Self {
-        let variants = StockEmitter::variants();
-        let mut configs = IndexMap::with_capacity(variants.len());
-        for variant in variants {
-            let config = match variant {
-                StockEmitter::Ant => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-4,
-                },
-                StockEmitter::Plant => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-4,
-                },
-                StockEmitter::Fungus => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-4,
-                },
-                StockEmitter::Unspecified => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-4,
-                },
-                StockEmitter::Lure => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-2,
-                },
-                StockEmitter::Warning => SignalConfig {
-                    diffusion_factor: 1e-4,
-                    decay_probability: 1e-4,
-                },
-            };
-            configs.insert(Emitter::Stock(variant), config);
+        // TODO: revise and set this up.
+        SignalConfigs {
+            configs: IndexMap::default(),
         }
-
-        SignalConfigs { configs }
     }
 }
 

--- a/emergence_lib/src/signals/configs.rs
+++ b/emergence_lib/src/signals/configs.rs
@@ -9,19 +9,10 @@ use indexmap::IndexMap;
 /// Internally, this uses an [`IndexMap`], so that there is also a notion of order: the order
 /// in which elements are inserted into the dictionary. Some notion of order is necessary in order
 /// to color tiles consistently.
-#[derive(Resource, Clone, Debug)]
+#[derive(Resource, Default, Clone, Debug)]
 pub struct SignalConfigs {
     /// Stores the configuration associated with each emitter.
     configs: IndexMap<Emitter, SignalConfig>,
-}
-
-impl Default for SignalConfigs {
-    fn default() -> Self {
-        // TODO: revise and set this up.
-        SignalConfigs {
-            configs: IndexMap::default(),
-        }
-    }
 }
 
 impl SignalConfigs {

--- a/emergence_lib/src/signals/emitters.rs
+++ b/emergence_lib/src/signals/emitters.rs
@@ -1,38 +1,15 @@
 //! Data for entities which can emit a signal.
 
-use bevy::prelude::*;
-use emergence_macros::IterableEnum;
-
-/// All signal emitters have an `EmitterId`, which is essentially a `u16`.
-#[derive(Component, Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
+use crate::player_interaction::abilities::IntentAbility;
+/// Varieties of signals
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Emitter {
-    /// A custom signal, designed by the player.
-    Custom(u16),
-    /// A stock signal, which comes pre-defined by the game.
-    Stock(StockEmitter),
-}
-
-impl Default for Emitter {
-    fn default() -> Self {
-        Self::Stock(StockEmitter::Unspecified)
-    }
-}
-
-use crate as emergence_lib;
-/// Enumerates stock signal emitters.
-#[derive(Debug, Default, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, IterableEnum)]
-pub enum StockEmitter {
-    /// Emitter is unspecified.
-    #[default]
-    Unspecified,
-    /// Emitter is stock ant.
+    /// An ant
     Ant,
-    /// Emitter is stock fungus.
+    /// A fungus
     Fungus,
-    /// Draws nearby allied units.
-    Lure,
-    /// Repels nearby allied units.
-    Warning,
-    /// Emitter is a plant.
+    /// A plant
     Plant,
+    /// Ability-driven effects.
+    Ability(IntentAbility),
 }

--- a/emergence_lib/src/signals/mod.rs
+++ b/emergence_lib/src/signals/mod.rs
@@ -126,30 +126,32 @@ fn compute_deltas(
         let signals_patch = map_signals.get_patch_mut(tile_pos).unwrap();
 
         for (emitter_id, current_value) in current_values {
-            let signal_config = signal_configs.get(&emitter_id).unwrap();
+            if let Some(signal_config) = signal_configs.get(&emitter_id) {
+                // TODO: this should also be cached in a MapIndex?
+                // normalize the diffusion factors into a probability
+                let neighbor_diffusion_probability = if signal_config.diffusion_factor > 0.0 {
+                    let count = map_positions.get_patch_count(tile_pos).unwrap();
+                    signal_config.diffusion_factor / (signal_config.diffusion_factor * count as f32)
+                } else {
+                    0.0
+                };
 
-            // TODO: this should also be cached in a MapIndex?
-            // normalize the diffusion factors into a probability
-            let neighbor_diffusion_probability = if signal_config.diffusion_factor > 0.0 {
-                let count = map_positions.get_patch_count(tile_pos).unwrap();
-                signal_config.diffusion_factor / (signal_config.diffusion_factor * count as f32)
-            } else {
-                0.0
-            };
-
-            let mut total_outgoing = 0.0;
-            for location in HexPatchLocation::variants() {
-                if let Some(s) = signals_patch.get_inner_mut(location) {
-                    let delta = neighbor_diffusion_probability * current_value;
-                    s.get_mut().increment_incoming(&emitter_id, delta);
-                    total_outgoing += delta;
+                let mut total_outgoing = 0.0;
+                for location in HexPatchLocation::variants() {
+                    if let Some(s) = signals_patch.get_inner_mut(location) {
+                        let delta = neighbor_diffusion_probability * current_value;
+                        s.get_mut().increment_incoming(&emitter_id, delta);
+                        total_outgoing += delta;
+                    }
                 }
+                signals_patch
+                    .get_inner_mut(HexPatchLocation::Center)
+                    .unwrap()
+                    .get_mut()
+                    .increment_outgoing(&emitter_id, total_outgoing);
+            } else {
+                error!("No config found for {emitter_id:?}!");
             }
-            signals_patch
-                .get_inner_mut(HexPatchLocation::Center)
-                .unwrap()
-                .get_mut()
-                .increment_outgoing(&emitter_id, total_outgoing);
         }
     }
 }

--- a/emergence_lib/src/signals/mod.rs
+++ b/emergence_lib/src/signals/mod.rs
@@ -211,9 +211,3 @@ pub enum SignalInfo {
     /// Signal that requests work be carried out.
     Work,
 }
-
-impl Default for SignalInfo {
-    fn default() -> Self {
-        Self::Passive(Emitter::default())
-    }
-}

--- a/emergence_lib/src/signals/tile_signals.rs
+++ b/emergence_lib/src/signals/tile_signals.rs
@@ -3,6 +3,7 @@
 use crate::signals::configs::SignalConfigs;
 use crate::signals::emitters::Emitter;
 use crate::signals::Signal;
+use bevy::prelude::error;
 use bevy::utils::HashMap;
 
 /// Keeps track of the different signals present at a tile.
@@ -78,12 +79,13 @@ impl TileSignals {
     }
 
     /// Decay signal at the tile.
-    ///
-    /// Panics if there is no signal from the specified `Emitter`.
     pub fn decay(&mut self, signal_configs: &SignalConfigs) {
         for (emitter, signal) in self.map.iter_mut() {
-            let config = signal_configs.get(emitter).unwrap();
-            signal.current_value *= 1.0 - config.decay_probability;
+            if let Some(config) = signal_configs.get(emitter) {
+                signal.current_value *= 1.0 - config.decay_probability;
+            } else {
+                error!("No config found for {signal:?}!");
+            };
         }
     }
 


### PR DESCRIPTION
This PR creates a simple `IntentPool` resource, which is spent when using abilities.

Along the way, I had to simplify the signals code a bit. It's still a bit of a disaster (the ID problem is really essential), and needs to be reconfigured, but it wasn't working before this either 🤷🏽‍♀️ 

Fixes #51.