### PR TITLE
Migrate to noisy_bevy

### DIFF
--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -14,6 +14,7 @@ debug_tools = ['dep:debug_tools']
 [dependencies]
 bevy = "0.9"
 rand = "0.8"
+noisy_bevy = "0.2"
 leafwing-input-manager = "0.7"
 emergence_macros = { path = "../emergence_macros", version = "0.6" }
 indexmap = "1.9"

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -8,9 +8,12 @@ use crate::terrain::{Terrain, TerrainBundle};
 use bevy::app::{App, Plugin, StartupStage};
 use bevy::ecs::prelude::*;
 use bevy::log::info;
+use bevy::math::vec2;
+use bevy::prelude::Vec2;
 use bevy::utils::HashMap;
 use hexx::shapes::hexagon;
 use hexx::Hex;
+use noisy_bevy::fbm_simplex_2d_seeded;
 use rand::distributions::Uniform;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -110,6 +113,19 @@ impl Plugin for GenerationPlugin {
     }
 }
 
+/// Scale the pos to make it work better with the noise function
+const FREQUENCY_SCALE: f32 = 0.07;
+/// Scale the output of the noise function so you can more easily use the number for a height
+const AMPLITUDE_SCALE: f32 = 2.0;
+/// How many times will the fbm be sampled?
+const OCTAVES: usize = 4;
+/// Smoothing factor
+const LACUNARITY: f32 = 2.3;
+/// Scale the output of the fbm function
+const GAIN: f32 = 0.5;
+/// Seed that determines the noise function output
+const SEED: f32 = 2378.0;
+
 /// Creates the world according to [`GenerationConfig`].
 pub fn generate_terrain(
     mut commands: Commands,
@@ -130,7 +146,11 @@ pub fn generate_terrain(
             .unwrap();
 
         let tile_pos = TilePos { hex };
-        let hex_height = rng.sample(Uniform::new(1., 3.));
+        let pos = vec2(tile_pos.x as f32, tile_pos.y as f32);
+        let hex_height =
+            (fbm_simplex_2d_seeded(pos * FREQUENCY_SCALE, OCTAVES, LACUNARITY, GAIN, SEED)
+                * AMPLITUDE_SCALE)
+                .abs();
 
         // Spawn the terrain entity
         let terrain_entity = commands

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -9,14 +9,12 @@ use bevy::app::{App, Plugin, StartupStage};
 use bevy::ecs::prelude::*;
 use bevy::log::info;
 use bevy::math::vec2;
-use bevy::prelude::Vec2;
 use bevy::utils::HashMap;
 use hexx::shapes::hexagon;
 use hexx::Hex;
 use noisy_bevy::fbm_simplex_2d_seeded;
-use rand::distributions::Uniform;
 use rand::seq::SliceRandom;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 
 use super::geometry::MapGeometry;
 


### PR DESCRIPTION
This switches from using the `rand ` crate to `noisy_bevy` for noise in terrain generation. This replaces `bevy_turborand` in #264   