### PR TITLE
Add basic copy-paste functionality

### DIFF
--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -7,7 +7,7 @@ pub mod camera;
 pub mod cursor;
 pub mod intent;
 pub mod organism_details;
-pub mod tile_selection;
+pub mod selection;
 pub mod zoning;
 
 /// All of the code needed for users to interact with the simulation.
@@ -20,7 +20,7 @@ impl Plugin for InteractionPlugin {
             .add_plugin(cursor::CursorPlugin)
             .add_plugin(intent::IntentPlugin)
             .add_plugin(organism_details::DetailsPlugin)
-            .add_plugin(tile_selection::TileSelectionPlugin)
+            .add_plugin(selection::SelectionPlugin)
             .add_plugin(zoning::ZoningPlugin);
 
         #[cfg(feature = "debug_tools")]

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -318,6 +318,10 @@ struct Clipboard {
 
 impl Clipboard {
     fn normalize_positions(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
         // FIXME: this naive center calculation will overflow
         let mut sum_x = 0;
         let mut sum_y = 0;

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -400,10 +400,17 @@ fn apply_zoning(
             } else if clipboard.len() == 1 {
                 let structure_id = clipboard.values().next().unwrap();
 
-                for (_terrain_entity, tile_pos) in selected_tiles.selection().iter() {
-                    if map_geometry.height_index.contains_key(tile_pos) {
+                if selected_tiles.is_empty() {
+                    if map_geometry.height_index.contains_key(&cursor_tile_pos) {
                         // FIXME: this should use a dedicated command to get all the details right
-                        commands.spawn(StructureBundle::new(structure_id.clone(), *tile_pos));
+                        commands.spawn(StructureBundle::new(structure_id.clone(), cursor_tile_pos));
+                    }
+                } else {
+                    for (_terrain_entity, tile_pos) in selected_tiles.selection().iter() {
+                        if map_geometry.height_index.contains_key(tile_pos) {
+                            // FIXME: this should use a dedicated command to get all the details right
+                            commands.spawn(StructureBundle::new(structure_id.clone(), *tile_pos));
+                        }
                     }
                 }
             // Paste the selection

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -317,6 +317,9 @@ struct Clipboard {
 }
 
 impl Clipboard {
+    /// Normalizes the positions of the items on the clipboard.
+    ///
+    /// Centers relative to the mean selected tile position.
     fn normalize_positions(&mut self) {
         if self.is_empty() {
             return;
@@ -349,14 +352,20 @@ impl Clipboard {
         self.contents = new_map;
     }
 
+    /// Apply a tile-position shift to the items on the clipboard.
+    ///
+    /// Used to place items in the correct location relative to the cursor.
     fn offset_positions(&self, origin: TilePos) -> Vec<(TilePos, StructureId)> {
         self.iter()
-            .map(|(k, v)| ((*k + origin).clone(), v.clone()))
+            .map(|(k, v)| ((*k + origin), v.clone()))
             .collect()
     }
 }
 
 // PERF: this pair of copy-paste systems should use an index of where the structures are
+/// Copies the selected structure(s) to the clipboard, to be placed later.
+///
+/// This system also handles the "pipette" functionality.
 fn copy_selection(
     cursor: Res<CursorPos>,
     actions: Res<ActionState<SelectionAction>>,
@@ -394,6 +403,9 @@ fn copy_selection(
 }
 
 // PERF: this pair of copy-paste systems should use an index of where the structures are
+/// Applies zoning to an area, causing structures to be created (or removed) there.
+///
+/// This system also handles the "paste" functionality.
 fn apply_zoning(
     cursor: Res<CursorPos>,
     actions: Res<ActionState<SelectionAction>>,

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -349,11 +349,21 @@ fn copy_selection(
             // We want to replace our selection, rather than add to it
             clipboard.clear();
 
-            for (_terrain_entity, terrain_tile_pos) in selected_tiles.selection().iter() {
-                // PERF: lol quadratic...
+            // If there is no selection, just grab whatever's under the cursor
+            if selected_tiles.is_empty() {
                 for (structure_id, structure_tile_pos) in structure_query.iter() {
-                    if terrain_tile_pos == structure_tile_pos {
-                        clipboard.insert(*structure_tile_pos, structure_id.clone());
+                    if cursor_tile_pos == *structure_tile_pos {
+                        clipboard.insert(TilePos::default(), structure_id.clone());
+                        return;
+                    }
+                }
+            } else {
+                for (_terrain_entity, terrain_tile_pos) in selected_tiles.selection().iter() {
+                    // PERF: lol quadratic...
+                    for (structure_id, structure_tile_pos) in structure_query.iter() {
+                        if terrain_tile_pos == structure_tile_pos {
+                            clipboard.insert(*structure_tile_pos, structure_id.clone());
+                        }
                     }
                 }
             }

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -391,14 +391,18 @@ fn apply_zoning(
                 let structure_id = clipboard.values().next().unwrap();
 
                 for (_terrain_entity, tile_pos) in selected_tiles.selection().iter() {
-                    // FIXME: this should use a dedicated command to get all the details right
-                    commands.spawn(StructureBundle::new(structure_id.clone(), *tile_pos));
+                    if map_geometry.height_index.contains_key(tile_pos) {
+                        // FIXME: this should use a dedicated command to get all the details right
+                        commands.spawn(StructureBundle::new(structure_id.clone(), *tile_pos));
+                    }
                 }
             // Paste the selection
             } else {
                 for (tile_pos, structure_id) in clipboard.offset_positions(cursor_tile_pos) {
-                    // FIXME: this should use a dedicated command to get all the details right
-                    commands.spawn(StructureBundle::new(structure_id, tile_pos));
+                    if map_geometry.height_index.contains_key(&tile_pos) {
+                        // FIXME: this should use a dedicated command to get all the details right
+                        commands.spawn(StructureBundle::new(structure_id.clone(), tile_pos));
+                    }
                 }
             }
         }

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -8,7 +8,7 @@ use crate::{
     structures::{StructureBundle, StructureId},
 };
 
-use super::{cursor::CursorPos, tile_selection::SelectedTiles, InteractionSystem};
+use super::{cursor::CursorPos, selection::SelectedTiles, InteractionSystem};
 
 /// Logic and resources for structure selection and placement.
 pub struct ZoningPlugin;

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -1,14 +1,10 @@
 //! Selecting structures to place, and then setting tiles as those structures.
 
 use bevy::prelude::*;
-use leafwing_input_manager::prelude::*;
 
-use crate::{
-    simulation::geometry::{MapGeometry, TilePos},
-    structures::{StructureBundle, StructureId},
-};
+use crate::structures::StructureId;
 
-use super::{cursor::CursorPos, selection::SelectedTiles, InteractionSystem};
+use super::InteractionSystem;
 
 /// Logic and resources for structure selection and placement.
 pub struct ZoningPlugin;
@@ -16,19 +12,6 @@ pub struct ZoningPlugin;
 impl Plugin for ZoningPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SelectedStructure>()
-            .init_resource::<ActionState<ZoningAction>>()
-            .insert_resource(ZoningAction::default_input_map())
-            .add_plugin(InputManagerPlugin::<ZoningAction>::default())
-            .add_system(
-                set_selected_structure
-                    .label(InteractionSystem::SelectStructure)
-                    .after(InteractionSystem::ComputeCursorPos),
-            )
-            .add_system(
-                zone_selected_tiles
-                    .label(InteractionSystem::ApplyZoning)
-                    .after(InteractionSystem::SelectTiles),
-            )
             .add_system(display_selected_structure.after(InteractionSystem::SelectStructure));
     }
 }
@@ -40,89 +23,10 @@ pub struct SelectedStructure {
     pub maybe_structure: Option<StructureId>,
 }
 
-/// Actions that the player can take to select and place structures
-#[derive(Actionlike, Clone, PartialEq, Debug)]
-pub enum ZoningAction {
-    /// Selects the structure on the tile under the player's cursor.
-    ///
-    /// If there is no structure there, the player's selection is cleared.
-    Pipette,
-    /// Clears the current structure selection.
-    ClearSelection,
-    /// Sets the zoning of all currently selected tiles to the currently selected structure.
-    ///
-    /// If no structure is selected, any zoning will be removed.
-    Zone,
-}
-
-impl ZoningAction {
-    /// The default keybindings
-    fn default_input_map() -> InputMap<ZoningAction> {
-        InputMap::new([
-            (KeyCode::Q, ZoningAction::Pipette),
-            (KeyCode::Space, ZoningAction::Zone),
-            (KeyCode::Escape, ZoningAction::ClearSelection),
-        ])
-    }
-}
-
-/// Sets which structure the player has selected.
-fn set_selected_structure(
-    zoning_actions: Res<ActionState<ZoningAction>>,
-    mut selected_structure: ResMut<SelectedStructure>,
-    cursor_pos: Res<CursorPos>,
-    structure_query: Query<(&TilePos, &StructureId)>,
-) {
-    // Clearing should take priority over selecting a new item (on the same frame)
-    if zoning_actions.just_pressed(ZoningAction::ClearSelection) {
-        selected_structure.maybe_structure = None;
-    } else if zoning_actions.just_pressed(ZoningAction::Pipette) {
-        // PERF: this needs to use an index, rather than a linear time search
-        let mut structure_under_cursor = None;
-        for (&tile_pos, organism_type) in structure_query.iter() {
-            if Some(tile_pos) == cursor_pos.maybe_tile_pos() {
-                structure_under_cursor = Some(organism_type.clone());
-                break;
-            }
-        }
-
-        selected_structure.maybe_structure = structure_under_cursor;
-    }
-}
-
 /// Shows which structure the player has selected.
 fn display_selected_structure(selected_structure: Res<SelectedStructure>) {
     if selected_structure.is_changed() {
         let selected_structure = &selected_structure.maybe_structure;
         info!("Currently selected: {selected_structure:?}");
-    }
-}
-
-/// Applies zoning to an area
-fn zone_selected_tiles(
-    zoning_actions: Res<ActionState<ZoningAction>>,
-    selected_structure: Res<SelectedStructure>,
-    selected_tiles: Res<SelectedTiles>,
-    structure_query: Query<(Entity, &TilePos), With<StructureId>>,
-    map_geometry: Res<MapGeometry>,
-    mut commands: Commands,
-) {
-    if zoning_actions.just_pressed(ZoningAction::Zone) {
-        if let Some(selected_structure) = &selected_structure.maybe_structure {
-            for (_entity, tile_pos) in selected_tiles.selection() {
-                let structure = StructureBundle::new(selected_structure.clone(), *tile_pos);
-
-                commands.spawn(structure);
-            }
-        } else {
-            for (structure_entity, tile_pos) in structure_query.iter() {
-                // PERF: this is kind of a mess; we can probably improve this through a smarter SelectedStructre type
-                let terrain_entity = map_geometry.terrain_index.get(tile_pos).unwrap();
-
-                if selected_tiles.contains_tile(*terrain_entity, *tile_pos) {
-                    commands.entity(structure_entity).despawn();
-                }
-            }
-        }
     }
 }

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -3,10 +3,26 @@
 use std::f32::consts::PI;
 
 use bevy::{prelude::*, utils::HashMap};
+use derive_more::{Add, AddAssign, Sub, SubAssign};
 use hexx::{Direction, Hex, HexLayout};
 
 /// A hex-based coordinate, that represents exactly one tile.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash, Deref, DerefMut, Default)]
+#[derive(
+    Component,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Deref,
+    DerefMut,
+    Default,
+    Add,
+    Sub,
+    AddAssign,
+    SubAssign,
+)]
 pub struct TilePos {
     /// The underlying hex coordinate
     pub hex: Hex,


### PR DESCRIPTION
We're doing something a bit clever here: the pipette-zoning tool pair is the same as the copy-paste tool pair.

I'd like to see if we can get the UX to work out to reduce the required number of keybindings (and for elegant design), but we'll have to test it.