### PR TITLE
Remove broken doc link

### DIFF
--- a/emergence_lib/src/player_interaction/intent.rs
+++ b/emergence_lib/src/player_interaction/intent.rs
@@ -1,7 +1,7 @@
 //! Intent represents the hive mind's ability to act.
 //!
 //! It slowly recovers over time, with a generous cap,
-//! and can be spent on [abilities](super::abilities), [zoning](super::zoning)
+//! and can be spent on [abilities](super::abilities), zoning
 //! and in other minor ways to influence the world.
 
 use std::ops::{Div, Mul};


### PR DESCRIPTION
`check-doc` is now mandatory in CI so this stuff doesn't stay broken.