### PR TITLE
Discretize height of terrain

### DIFF
--- a/emergence_lib/src/asset_management.rs
+++ b/emergence_lib/src/asset_management.rs
@@ -7,7 +7,10 @@ use bevy::{
 };
 use hexx::{Hex, HexLayout, MeshInfo};
 
-use crate::{simulation::geometry::MapGeometry, structures::StructureId, terrain::Terrain};
+use crate::{
+    enum_iter::IterableEnum, simulation::geometry::MapGeometry, structures::StructureId,
+    terrain::Terrain,
+};
 
 /// Collects asset management systems and resources.
 pub struct AssetManagementPlugin;
@@ -34,9 +37,11 @@ impl FromWorld for TileHandles {
     fn from_world(world: &mut World) -> Self {
         let mut material_assets = world.resource_mut::<Assets<StandardMaterial>>();
         let mut materials = HashMap::new();
-        materials.insert(Terrain::Plain, material_assets.add(Color::BEIGE.into()));
-        materials.insert(Terrain::Rocky, material_assets.add(Color::GRAY.into()));
-        materials.insert(Terrain::High, material_assets.add(Color::RED.into()));
+
+        for variant in Terrain::variants() {
+            let material_handle = material_assets.add(variant.material());
+            materials.insert(variant, material_handle);
+        }
 
         let selected_tile_handle = material_assets.add(Color::SEA_GREEN.into());
 

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -8,7 +8,7 @@ pub(super) struct LightingPlugin;
 impl Plugin for LightingPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(AmbientLight {
-            brightness: 1.,
+            brightness: 0.5,
             color: Color::WHITE,
         })
         .add_startup_system(spawn_sun);
@@ -18,6 +18,11 @@ impl Plugin for LightingPlugin {
 /// Spawns a directional light source to illuminate the scene
 fn spawn_sun(mut commands: Commands) {
     commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            color: Color::WHITE,
+            illuminance: 50000.,
+            ..Default::default()
+        },
         transform: Transform::from_xyz(30., 100., 30.).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -56,7 +56,7 @@ impl Default for GenerationConfig {
     fn default() -> GenerationConfig {
         let mut terrain_weights: HashMap<Terrain, f32> = HashMap::new();
         terrain_weights.insert(Terrain::Plain, GenerationConfig::TERRAIN_WEIGHT_PLAIN);
-        terrain_weights.insert(Terrain::High, GenerationConfig::TERRAIN_WEIGHT_HIGH);
+        terrain_weights.insert(Terrain::Muddy, GenerationConfig::TERRAIN_WEIGHT_HIGH);
         terrain_weights.insert(Terrain::Rocky, GenerationConfig::TERRAIN_WEIGHT_ROCKY);
 
         GenerationConfig {

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -111,6 +111,10 @@ impl Plugin for GenerationPlugin {
     }
 }
 
+/// The minimum height of any tile.
+///
+/// This should always be a multiple of 1.0;
+const MIN_HEIGHT: f32 = 1.0;
 /// Scale the pos to make it work better with the noise function
 const FREQUENCY_SCALE: f32 = 0.07;
 /// Scale the output of the noise function so you can more easily use the number for a height
@@ -145,10 +149,13 @@ pub fn generate_terrain(
 
         let tile_pos = TilePos { hex };
         let pos = vec2(tile_pos.x as f32, tile_pos.y as f32);
-        let hex_height =
-            (fbm_simplex_2d_seeded(pos * FREQUENCY_SCALE, OCTAVES, LACUNARITY, GAIN, SEED)
+
+        let hex_height = MIN_HEIGHT
+            + (fbm_simplex_2d_seeded(pos * FREQUENCY_SCALE, OCTAVES, LACUNARITY, GAIN, SEED)
                 * AMPLITUDE_SCALE)
-                .abs();
+                .abs()
+                // Height is stepped, and should always be a multiple of 1.0
+                .round();
 
         // Spawn the terrain entity
         let terrain_entity = commands

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -17,8 +17,24 @@ pub enum Terrain {
     Plain,
     /// Terrain that is rocky, and thus difficult to traverse.
     Rocky,
-    /// Terrain that has higher altitude compared to others.
-    High,
+    /// Terrain that is unusually muddy.
+    Muddy,
+}
+
+impl Terrain {
+    /// The rendering material associated with this terrain type.
+    pub fn material(&self) -> StandardMaterial {
+        let base_color = match self {
+            Terrain::Plain => Color::BEIGE,
+            Terrain::Rocky => Color::GRAY,
+            Terrain::Muddy => Color::BISQUE,
+        };
+
+        StandardMaterial {
+            base_color,
+            ..Default::default()
+        }
+    }
 }
 
 /// All of the components needed to define a piece of terrain.

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -32,6 +32,8 @@ impl Terrain {
 
         StandardMaterial {
             base_color,
+            perceptual_roughness: 0.6,
+            metallic: 0.01,
             ..Default::default()
         }
     }


### PR DESCRIPTION
This is essential for clear and repeatable factory-builder gameplay.

I also tweaked some of the rendering settings to try in vain to improve readability.