### PR TITLE
Fix typo in cron job

### DIFF
--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -3,7 +3,7 @@ name: cargo udeps
 on:
   schedule:
     # Every week at 12 p.m. on Sundays
-    - "0 12 * * 0"
+    - cron: "0 12 * * 0"
 
 jobs:
   check-unused-dependencies:


### PR DESCRIPTION
I missed the `cron` part of the definition