### PR TITLE
Remove dependency of check-compiles on check-lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
 
   check-compiles:
     runs-on: ubuntu-latest
-    needs: [check-lints]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The `check-compiles` CI job depended on the `check-lints` CI job, so they couldn't run in parallel.
I think there is no strong reason to have this dependency, so I'd rather squeeze out another minute for our total CI time.