### PR TITLE
Fix missing toolchain definition for udeps job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   check-lints:

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -5,6 +5,9 @@ on:
     # Every week at 12 p.m. on Sundays
     - cron: "0 12 * * 0"
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   check-unused-dependencies:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Nightly is needed for udeps
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          toolchain: nightly
           override: true
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0


### PR DESCRIPTION
I didn't copy over an env variable, so the toolchain definition was missing in the `udeps` scheduled job.

We don't really need an environment variable for this, so I just hard-coded it now.