### PR TITLE
Fix item dropoff

### DIFF
--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -4,7 +4,7 @@ use std::{fmt::Display, time::Duration};
 
 use crate::asset_management::manifest::Manifest;
 
-use super::{ItemCount, ItemId};
+use super::{inventory::Inventory, ItemCount, ItemId, ItemManifest};
 
 /// The unique identifier of a recipe.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -55,26 +55,6 @@ impl Recipe {
         }
     }
 
-    // TODO: Remove this once we load recipes from asset files
-    /// An acacia plant producing leaves.
-    pub(crate) fn acacia_leaf_production() -> Self {
-        Recipe::new(
-            Vec::new(),
-            vec![ItemCount::one(ItemId::acacia_leaf())],
-            Duration::from_secs(10),
-        )
-    }
-
-    // TODO: Remove this once we load recipes from asset files
-    /// A leuco mushroom processing acacia leaves
-    pub(crate) fn leuco_chunk_production() -> Self {
-        Recipe::new(
-            vec![ItemCount::one(ItemId::acacia_leaf())],
-            vec![ItemCount::one(ItemId::leuco_chunk())],
-            Duration::from_secs(5),
-        )
-    }
-
     /// The inputs needed to craft the recipe.
     pub(crate) fn inputs(&self) -> &Vec<ItemCount> {
         &self.inputs
@@ -88,6 +68,45 @@ impl Recipe {
     /// The time needed to craft the recipe.
     pub(crate) fn craft_time(&self) -> &Duration {
         &self.craft_time
+    }
+
+    /// An inventory with empty slots for all of the inputs of this recipe.
+    pub(crate) fn input_inventory(&self, item_manifest: &ItemManifest) -> Inventory {
+        let mut inventory = Inventory::new(self.inputs.len());
+        for item_count in &self.inputs {
+            inventory.add_empty_slot(item_count.item_id.clone(), item_manifest);
+        }
+        inventory
+    }
+
+    /// An inventory with empty slots for all of the outputs of this recipe.
+    pub(crate) fn output_inventory(&self, item_manifest: &ItemManifest) -> Inventory {
+        let mut inventory = Inventory::new(self.outputs.len());
+        for item_count in &self.outputs {
+            inventory.add_empty_slot(item_count.item_id.clone(), item_manifest);
+        }
+        inventory
+    }
+}
+
+// TODO: Remove this once we load recipes from asset files
+impl Recipe {
+    /// An acacia plant producing leaves.
+    pub(crate) fn acacia_leaf_production() -> Self {
+        Recipe::new(
+            Vec::new(),
+            vec![ItemCount::one(ItemId::acacia_leaf())],
+            Duration::from_secs(10),
+        )
+    }
+
+    /// A leuco mushroom processing acacia leaves
+    pub(crate) fn leuco_chunk_production() -> Self {
+        Recipe::new(
+            vec![ItemCount::one(ItemId::acacia_leaf())],
+            vec![ItemCount::one(ItemId::leuco_chunk())],
+            Duration::from_secs(5),
+        )
     }
 }
 

--- a/emergence_lib/src/organisms/units/behavior.rs
+++ b/emergence_lib/src/organisms/units/behavior.rs
@@ -105,7 +105,7 @@ impl Goal {
                 for tile_pos in neighboring_tiles {
                     if let Some(&structure_entity) = map_geometry.structure_index.get(&tile_pos) {
                         if let Ok(input_inventory) = input_inventory_query.get(structure_entity) {
-                            if input_inventory.item_count(item_id) > 0 {
+                            if input_inventory.remaining_reserved_space_for_item(item_id) > 0 {
                                 entities_with_desired_item.push(structure_entity);
                             }
                         }

--- a/emergence_lib/src/organisms/units/item_interaction.rs
+++ b/emergence_lib/src/organisms/units/item_interaction.rs
@@ -110,7 +110,7 @@ pub(super) fn pickup_and_drop_items(
                     );
 
                     // If our unit's unloaded, swap to wandering to find something else to do
-                    if held_item.is_full() {
+                    if held_item.is_empty() {
                         Goal::Wander
                     // If we still have items, keep unloading
                     } else {

--- a/emergence_lib/src/organisms/units/item_interaction.rs
+++ b/emergence_lib/src/organisms/units/item_interaction.rs
@@ -109,7 +109,7 @@ pub(super) fn pickup_and_drop_items(
                         item_manifest,
                     );
 
-                    // If our unit's unloaded, swap to wandering to find something else to do
+                    // If our unit is unloaded, swap to wandering to find something else to do
                     if held_item.is_empty() {
                         Goal::Wander
                     // If we still have items, keep unloading

--- a/emergence_lib/src/organisms/units/item_interaction.rs
+++ b/emergence_lib/src/organisms/units/item_interaction.rs
@@ -129,3 +129,10 @@ pub(super) fn pickup_and_drop_items(
         }
     }
 }
+
+/// Clears out any slots that no longer have items in them.
+pub(super) fn clear_empty_slots(mut query: Query<&mut HeldItem>) {
+    for mut held_item in query.iter_mut() {
+        held_item.clear_empty_slots()
+    }
+}

--- a/emergence_lib/src/organisms/units/mod.rs
+++ b/emergence_lib/src/organisms/units/mod.rs
@@ -70,6 +70,8 @@ pub(crate) enum UnitSystem {
     AdvanceTimers,
     /// Carry out the chosen action
     Act,
+    /// Perform any necessary cleanup
+    Cleanup,
     /// Pick a higher level goal to pursue
     ChooseGoal,
     /// Pick an action that will get the agent closer to the goal being pursued
@@ -90,6 +92,11 @@ impl Plugin for UnitsPlugin {
                 item_interaction::pickup_and_drop_items
                     .label(UnitSystem::Act)
                     .after(UnitSystem::AdvanceTimers),
+            )
+            .add_system(
+                item_interaction::clear_empty_slots
+                    .label(UnitSystem::Cleanup)
+                    .after(UnitSystem::Act),
             )
             .add_system(behavior::choose_goal.label(UnitSystem::ChooseGoal))
             .add_system(

--- a/emergence_lib/src/player_interaction/details.rs
+++ b/emergence_lib/src/player_interaction/details.rs
@@ -231,10 +231,10 @@ Tile: {tile_pos}"
 
             write!(
                 f,
-                "Input: {input_inventory}
-Output: {output_inventory}
-Recipe: {recipe_string}
-{crafting_state}: {time_remaining:.2} s / {total_duration:.2} s"
+                "Recipe: {recipe_string}
+Input: {input_inventory}
+{crafting_state}: {time_remaining:.1} s / {total_duration:.1} s
+Output: {output_inventory}"
             )
         }
     }

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -99,8 +99,8 @@ impl Command for SpawnStructureCommand {
                                 .entity_mut(structure_entity)
                                 .insert(CraftingBundle::new(
                                     structure_details.starting_recipe.clone(),
-                                    &*recipe_manifest,
-                                    &*item_manifest,
+                                    &recipe_manifest,
+                                    &item_manifest,
                                 ));
                         })
                     })

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -6,6 +6,7 @@ use bevy::{
 };
 
 use crate::{
+    items::{recipe::RecipeManifest, ItemManifest},
     organisms::OrganismBundle,
     player_interaction::clipboard::StructureData,
     simulation::geometry::{MapGeometry, TilePos},
@@ -92,11 +93,17 @@ impl Command for SpawnStructureCommand {
                 };
 
                 if structure_details.crafts {
-                    world
-                        .entity_mut(structure_entity)
-                        .insert(CraftingBundle::new(
-                            structure_details.starting_recipe.clone(),
-                        ));
+                    world.resource_scope(|world, recipe_manifest: Mut<RecipeManifest>| {
+                        world.resource_scope(|world, item_manifest: Mut<ItemManifest>| {
+                            world
+                                .entity_mut(structure_entity)
+                                .insert(CraftingBundle::new(
+                                    structure_details.starting_recipe.clone(),
+                                    &*recipe_manifest,
+                                    &*item_manifest,
+                                ));
+                        })
+                    })
                 };
 
                 structure_entity

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -93,15 +93,20 @@ pub(crate) struct CraftingBundle {
 
 impl CraftingBundle {
     /// Create a new crafting bundle without an active recipe set.
-    pub(crate) fn new(starting_recipe: Option<RecipeId>) -> Self {
+    pub(crate) fn new(
+        starting_recipe: Option<RecipeId>,
+        recipe_manifest: &RecipeManifest,
+        item_manifest: &ItemManifest,
+    ) -> Self {
         if let Some(recipe_id) = starting_recipe {
+            let recipe = recipe_manifest.get(&recipe_id);
+
             Self {
-                // TODO: Don't hard-code these values
                 input_inventory: InputInventory {
-                    inventory: Inventory::new(0),
+                    inventory: recipe.input_inventory(item_manifest),
                 },
                 output_inventory: OutputInventory {
-                    inventory: Inventory::new(1),
+                    inventory: recipe.output_inventory(item_manifest),
                 },
                 craft_timer: CraftTimer(Timer::new(Duration::default(), TimerMode::Once)),
                 active_recipe: ActiveRecipe(Some(recipe_id)),
@@ -109,7 +114,6 @@ impl CraftingBundle {
             }
         } else {
             Self {
-                // TODO: Don't hard-code these values
                 input_inventory: InputInventory {
                     inventory: Inventory::new(0),
                 },


### PR DESCRIPTION
Fix #363.

To do so, I had to make inventories able to store 0 count slots, and manually clear out 0 count slots when needed (like for storage chests or units).