### PR TITLE
Zoning creates ghosts, which are then built by units

### DIFF
--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -14,6 +14,8 @@ pub(crate) struct StructureHandles {
     pub(crate) scenes: HashMap<StructureId, Handle<Scene>>,
     /// The material to be used for all ghosts
     pub(crate) ghost_material: Handle<StandardMaterial>,
+    /// The material to be used for all previews
+    pub(crate) preview_material: Handle<StandardMaterial>,
     /// The raycasting mesh used to select structures
     pub(crate) picking_mesh: Handle<Mesh>,
 }
@@ -37,9 +39,16 @@ impl FromWorld for StructureHandles {
             ..Default::default()
         });
 
+        let preview_material = materials.add(StandardMaterial {
+            base_color: Color::hsla(55., 0.7, 0.9, 0.7),
+            alpha_mode: AlphaMode::Blend,
+            ..Default::default()
+        });
+
         let mut handles = StructureHandles {
             scenes: HashMap::default(),
             ghost_material,
+            preview_material,
             picking_mesh,
         };
 

--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -40,7 +40,7 @@ impl FromWorld for StructureHandles {
         });
 
         let preview_material = materials.add(StandardMaterial {
-            base_color: Color::hsla(55., 0.7, 0.9, 0.7),
+            base_color: Color::hsla(55., 0.9, 0.7, 0.7),
             alpha_mode: AlphaMode::Blend,
             ..Default::default()
         });

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -2,17 +2,13 @@
 
 use bevy::prelude::*;
 
-use crate::{
-    asset_management::{structures::StructureHandles, terrain::TerrainHandles, AssetState},
-    player_interaction::InteractionSystem,
-    simulation::geometry::{MapGeometry, TilePos},
-    structures::{ghost::Ghost, StructureId},
-    terrain::Terrain,
-};
+use crate::{asset_management::AssetState, player_interaction::InteractionSystem};
 
 use self::lighting::LightingPlugin;
 
 mod lighting;
+mod structures;
+mod terrain;
 mod units;
 
 /// Adds all logic required to render the game.
@@ -25,100 +21,13 @@ impl Plugin for GraphicsPlugin {
         app.add_plugin(LightingPlugin)
             .add_system_set(
                 SystemSet::on_update(AssetState::Ready)
-                    .with_system(populate_terrain)
+                    .with_system(terrain::populate_terrain)
                     .with_system(units::populate_units)
                     .with_system(units::display_held_item)
-                    .with_system(populate_structures)
+                    .with_system(structures::populate_structures)
                     // We need to avoid attempting to insert bundles into entities that no longer exist
-                    .with_system(mesh_ghosts.before(InteractionSystem::ManageGhosts)),
+                    .with_system(structures::mesh_ghosts.before(InteractionSystem::ManageGhosts)),
             )
-            .add_system_to_stage(CoreStage::PostUpdate, change_ghost_material);
-    }
-}
-
-/// Adds rendering components to every spawned terrain tile
-fn populate_terrain(
-    new_terrain: Query<(Entity, &TilePos, &Terrain), Added<Terrain>>,
-    mut commands: Commands,
-    handles: Res<TerrainHandles>,
-    map_geometry: Res<MapGeometry>,
-) {
-    for (terrain_entity, tile_pos, terrain) in new_terrain.iter() {
-        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
-        let hex_height = *map_geometry.height_index.get(tile_pos).unwrap();
-
-        commands.entity(terrain_entity).insert(PbrBundle {
-            mesh: handles.mesh.clone_weak(),
-            material: handles.terrain_materials.get(terrain).unwrap().clone_weak(),
-            transform: Transform::from_xyz(pos.x, 0.0, pos.y).with_scale(Vec3 {
-                x: 1.,
-                y: hex_height,
-                z: 1.,
-            }),
-            ..default()
-        });
-    }
-}
-
-/// Adds rendering components to every spawned structure
-fn populate_structures(
-    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, Without<Ghost>)>,
-    mut commands: Commands,
-    structure_handles: Res<StructureHandles>,
-    map_geometry: Res<MapGeometry>,
-) {
-    for (entity, tile_pos, structure_id) in new_structures.iter() {
-        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
-        let terrain_height = map_geometry.height_index.get(tile_pos).unwrap();
-
-        let scene_handle = structure_handles.scenes.get(structure_id).unwrap();
-
-        commands
-            .entity(entity)
-            .insert(SceneBundle {
-                scene: scene_handle.clone_weak(),
-                transform: Transform::from_xyz(pos.x, *terrain_height, pos.y),
-                ..default()
-            })
-            .insert(structure_handles.picking_mesh.clone_weak());
-    }
-}
-
-/// Adds rendering components to every spawned ghost
-fn mesh_ghosts(
-    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, With<Ghost>)>,
-    mut commands: Commands,
-    map_geometry: Res<MapGeometry>,
-    structure_handles: Res<StructureHandles>,
-) {
-    // TODO: vary ghost mesh based on structure_id
-    for (entity, tile_pos, structure_id) in new_structures.iter() {
-        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
-        let terrain_height = map_geometry.height_index.get(tile_pos).unwrap();
-
-        let scene_handle = structure_handles.scenes.get(structure_id).unwrap();
-
-        // Spawn scene as a child of the root ghost
-        commands.entity(entity).insert(SceneBundle {
-            scene: scene_handle.clone_weak(),
-            transform: Transform::from_xyz(pos.x, *terrain_height, pos.y),
-            ..default()
-        });
-    }
-}
-
-/// Modifies the material of any entities spawned due to a ghost structure.
-fn change_ghost_material(
-    ghost_query: Query<Entity, With<Ghost>>,
-    children: Query<&Children>,
-    mut material_query: Query<&mut Handle<StandardMaterial>>,
-    structure_handles: Res<StructureHandles>,
-) {
-    for ghost_entity in ghost_query.iter() {
-        for child in children.iter_descendants(ghost_entity) {
-            if let Ok(mut material) = material_query.get_mut(child) {
-                *material = structure_handles.ghost_material.clone_weak();
-            }
-        }
+            .add_system_to_stage(CoreStage::PostUpdate, structures::change_ghost_material);
     }
 }

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -24,10 +24,12 @@ impl Plugin for GraphicsPlugin {
                     .with_system(terrain::populate_terrain)
                     .with_system(units::populate_units)
                     .with_system(units::display_held_item)
-                    .with_system(structures::populate_structures)
                     // We need to avoid attempting to insert bundles into entities that no longer exist
-                    .with_system(structures::mesh_ghosts.before(InteractionSystem::ManageGhosts)),
+                    .with_system(
+                        structures::populate_structures.before(InteractionSystem::ManagePreviews),
+                    ),
             )
-            .add_system_to_stage(CoreStage::PostUpdate, structures::change_ghost_material);
+            .add_system_to_stage(CoreStage::PostUpdate, structures::change_ghost_material)
+            .add_system_to_stage(CoreStage::PostUpdate, structures::change_preview_material);
     }
 }

--- a/emergence_lib/src/graphics/structures.rs
+++ b/emergence_lib/src/graphics/structures.rs
@@ -1,0 +1,70 @@
+use bevy::prelude::*;
+
+use crate::{
+    asset_management::structures::StructureHandles,
+    simulation::geometry::{MapGeometry, TilePos},
+    structures::{ghost::Ghost, StructureId},
+};
+
+/// Adds rendering components to every spawned structure
+pub(super) fn populate_structures(
+    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, Without<Ghost>)>,
+    mut commands: Commands,
+    structure_handles: Res<StructureHandles>,
+    map_geometry: Res<MapGeometry>,
+) {
+    for (entity, tile_pos, structure_id) in new_structures.iter() {
+        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
+        let terrain_height = map_geometry.height_index.get(tile_pos).unwrap();
+
+        let scene_handle = structure_handles.scenes.get(structure_id).unwrap();
+
+        commands
+            .entity(entity)
+            .insert(SceneBundle {
+                scene: scene_handle.clone_weak(),
+                transform: Transform::from_xyz(pos.x, *terrain_height, pos.y),
+                ..default()
+            })
+            .insert(structure_handles.picking_mesh.clone_weak());
+    }
+}
+
+/// Adds rendering components to every spawned ghost
+pub(super) fn mesh_ghosts(
+    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, With<Ghost>)>,
+    mut commands: Commands,
+    map_geometry: Res<MapGeometry>,
+    structure_handles: Res<StructureHandles>,
+) {
+    // TODO: vary ghost mesh based on structure_id
+    for (entity, tile_pos, structure_id) in new_structures.iter() {
+        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
+        let terrain_height = map_geometry.height_index.get(tile_pos).unwrap();
+
+        let scene_handle = structure_handles.scenes.get(structure_id).unwrap();
+
+        // Spawn scene as a child of the root ghost
+        commands.entity(entity).insert(SceneBundle {
+            scene: scene_handle.clone_weak(),
+            transform: Transform::from_xyz(pos.x, *terrain_height, pos.y),
+            ..default()
+        });
+    }
+}
+
+/// Modifies the material of any entities spawned due to a ghost structure.
+pub(super) fn change_ghost_material(
+    ghost_query: Query<Entity, With<Ghost>>,
+    children: Query<&Children>,
+    mut material_query: Query<&mut Handle<StandardMaterial>>,
+    structure_handles: Res<StructureHandles>,
+) {
+    for ghost_entity in ghost_query.iter() {
+        for child in children.iter_descendants(ghost_entity) {
+            if let Ok(mut material) = material_query.get_mut(child) {
+                *material = structure_handles.ghost_material.clone_weak();
+            }
+        }
+    }
+}

--- a/emergence_lib/src/graphics/structures.rs
+++ b/emergence_lib/src/graphics/structures.rs
@@ -3,12 +3,15 @@ use bevy::prelude::*;
 use crate::{
     asset_management::structures::StructureHandles,
     simulation::geometry::{MapGeometry, TilePos},
-    structures::{ghost::Ghost, StructureId},
+    structures::{
+        ghost::{Ghost, Preview},
+        StructureId,
+    },
 };
 
-/// Adds rendering components to every spawned structure
+/// Adds rendering components to every spawned structure, real or otherwise
 pub(super) fn populate_structures(
-    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, Without<Ghost>)>,
+    new_structures: Query<(Entity, &TilePos, &StructureId), Added<StructureId>>,
     mut commands: Commands,
     structure_handles: Res<StructureHandles>,
     map_geometry: Res<MapGeometry>,
@@ -30,29 +33,6 @@ pub(super) fn populate_structures(
     }
 }
 
-/// Adds rendering components to every spawned ghost
-pub(super) fn mesh_ghosts(
-    new_structures: Query<(Entity, &TilePos, &StructureId), (Added<StructureId>, With<Ghost>)>,
-    mut commands: Commands,
-    map_geometry: Res<MapGeometry>,
-    structure_handles: Res<StructureHandles>,
-) {
-    // TODO: vary ghost mesh based on structure_id
-    for (entity, tile_pos, structure_id) in new_structures.iter() {
-        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
-        let terrain_height = map_geometry.height_index.get(tile_pos).unwrap();
-
-        let scene_handle = structure_handles.scenes.get(structure_id).unwrap();
-
-        // Spawn scene as a child of the root ghost
-        commands.entity(entity).insert(SceneBundle {
-            scene: scene_handle.clone_weak(),
-            transform: Transform::from_xyz(pos.x, *terrain_height, pos.y),
-            ..default()
-        });
-    }
-}
-
 /// Modifies the material of any entities spawned due to a ghost structure.
 pub(super) fn change_ghost_material(
     ghost_query: Query<Entity, With<Ghost>>,
@@ -64,6 +44,22 @@ pub(super) fn change_ghost_material(
         for child in children.iter_descendants(ghost_entity) {
             if let Ok(mut material) = material_query.get_mut(child) {
                 *material = structure_handles.ghost_material.clone_weak();
+            }
+        }
+    }
+}
+
+/// Modifies the material of any entities spawned due to a ghost structure.
+pub(super) fn change_preview_material(
+    ghost_query: Query<Entity, With<Preview>>,
+    children: Query<&Children>,
+    mut material_query: Query<&mut Handle<StandardMaterial>>,
+    structure_handles: Res<StructureHandles>,
+) {
+    for ghost_entity in ghost_query.iter() {
+        for child in children.iter_descendants(ghost_entity) {
+            if let Ok(mut material) = material_query.get_mut(child) {
+                *material = structure_handles.preview_material.clone_weak();
             }
         }
     }

--- a/emergence_lib/src/graphics/structures.rs
+++ b/emergence_lib/src/graphics/structures.rs
@@ -1,3 +1,5 @@
+//! Graphics and animation code for structures.
+
 use bevy::prelude::*;
 
 use crate::{

--- a/emergence_lib/src/graphics/terrain.rs
+++ b/emergence_lib/src/graphics/terrain.rs
@@ -1,3 +1,5 @@
+//! Graphics code for terrain.
+
 use bevy::prelude::*;
 
 use crate::{

--- a/emergence_lib/src/graphics/terrain.rs
+++ b/emergence_lib/src/graphics/terrain.rs
@@ -1,0 +1,31 @@
+use bevy::prelude::*;
+
+use crate::{
+    asset_management::terrain::TerrainHandles,
+    simulation::geometry::{MapGeometry, TilePos},
+    terrain::Terrain,
+};
+
+/// Adds rendering components to every spawned terrain tile
+pub(super) fn populate_terrain(
+    new_terrain: Query<(Entity, &TilePos, &Terrain), Added<Terrain>>,
+    mut commands: Commands,
+    handles: Res<TerrainHandles>,
+    map_geometry: Res<MapGeometry>,
+) {
+    for (terrain_entity, tile_pos, terrain) in new_terrain.iter() {
+        let pos = map_geometry.layout.hex_to_world_pos(tile_pos.hex);
+        let hex_height = *map_geometry.height_index.get(tile_pos).unwrap();
+
+        commands.entity(terrain_entity).insert(PbrBundle {
+            mesh: handles.mesh.clone_weak(),
+            material: handles.terrain_materials.get(terrain).unwrap().clone_weak(),
+            transform: Transform::from_xyz(pos.x, 0.0, pos.y).with_scale(Vec3 {
+                x: 1.,
+                y: hex_height,
+                z: 1.,
+            }),
+            ..default()
+        });
+    }
+}

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -33,6 +33,15 @@ impl Inventory {
         }
     }
 
+    // FIXME: this doesn't properly respect max stack size
+    /// Creates an inventory from the provided [`ItemCount`].
+    pub(crate) fn new_from_item(item_count: ItemCount) -> Self {
+        Self {
+            slots: vec![ItemSlot::new(item_count.item_id, item_count.count)],
+            max_slot_count: 1,
+        }
+    }
+
     /// Returns an iterator over the items in the inventory and their count.
     pub(crate) fn iter(&self) -> impl Iterator<Item = &ItemSlot> {
         self.slots.iter()

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -30,7 +30,7 @@ impl Plugin for ClipboardPlugin {
             )
             .add_system(
                 display_selection
-                    .label(InteractionSystem::ManageGhosts)
+                    .label(InteractionSystem::ManagePreviews)
                     .after(InteractionSystem::SetClipboard),
             );
     }

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -55,7 +55,7 @@ impl Clipboard {
 }
 
 /// The data copied via the clipboard for a single structure.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct StructureData {
     /// The identity of the structure.
     pub(crate) id: StructureId,

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -58,7 +58,7 @@ impl Clipboard {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct StructureData {
     /// The identity of the structure.
-    pub(crate) id: StructureId,
+    pub(crate) structure_id: StructureId,
     /// The orientation of the structure.
     pub(crate) facing: Facing,
 }
@@ -156,7 +156,7 @@ fn copy_selection(
                 if let Some(structure_entity) = map_geometry.structure_index.get(&cursor_tile_pos) {
                     let (id, facing) = structure_query.get(*structure_entity).unwrap();
                     let clipboard_item = StructureData {
-                        id: *id,
+                        structure_id: *id,
                         facing: *facing,
                     };
 
@@ -169,7 +169,7 @@ fn copy_selection(
                     {
                         let (id, facing) = structure_query.get(*structure_entity).unwrap();
                         let clipboard_item = StructureData {
-                            id: *id,
+                            structure_id: *id,
                             facing: *facing,
                         };
 
@@ -219,7 +219,7 @@ fn display_selection(
             // Preview should exist
             if let Some(desired_clipboard_item) = desired_previews.get(tile_pos) {
                 // Preview's identity changed
-                if *existing_structure_id != desired_clipboard_item.id
+                if *existing_structure_id != desired_clipboard_item.structure_id
                     || *existing_facing != desired_clipboard_item.facing
                 {
                     commands.despawn_preview(*tile_pos);

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -56,7 +56,7 @@ pub(crate) enum InteractionSystem {
     /// Use intent-spending abilities
     UseAbilities,
     /// Spawn and despawn ghosts
-    ManageGhosts,
+    ManagePreviews,
     /// Updates information about the hovered entities
     HoverDetails,
 }

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -115,8 +115,9 @@ fn act_on_zoning(
 ) {
     for (zoning, &tile_pos) in terrain_query.iter() {
         match zoning {
-            Zoning::Structure(item) => commands.spawn_structure(tile_pos, item.clone()),
-            Zoning::None => (), // Do nothing
+            Zoning::Structure(item) => commands.spawn_ghost(tile_pos, item.clone()),
+            Zoning::None => commands.despawn_ghost(tile_pos),
+            // TODO: this should also take delayed effect
             Zoning::Clear => commands.despawn_structure(tile_pos),
         };
     }

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -4,8 +4,10 @@ use bevy::prelude::*;
 use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
-    simulation::geometry::{MapGeometry, TilePos},
-    structures::commands::StructureCommandsExt,
+    simulation::geometry::{Facing, MapGeometry, TilePos},
+    structures::{
+        commands::StructureCommandsExt, crafting::InputInventory, ghost::Ghost, StructureId,
+    },
     terrain::Terrain,
 };
 
@@ -31,7 +33,8 @@ impl Plugin for ZoningPlugin {
             act_on_zoning
                 .label(InteractionSystem::ManagePreviews)
                 .after(InteractionSystem::ApplyZoning),
-        );
+        )
+        .add_system(turn_ghosts_into_structures);
     }
 }
 
@@ -120,5 +123,24 @@ fn act_on_zoning(
             // TODO: this should also take delayed effect
             Zoning::Clear => commands.despawn_structure(tile_pos),
         };
+    }
+}
+
+/// Transforms ghosts into structures once all of their construction materials have been supplied.
+fn turn_ghosts_into_structures(
+    ghost_query: Query<(&InputInventory, &TilePos, &StructureId, &Facing), With<Ghost>>,
+    mut commands: Commands,
+) {
+    for (input_inventory, &tile_pos, &structure_id, &facing) in ghost_query.iter() {
+        if input_inventory.is_full() {
+            commands.despawn_ghost(tile_pos);
+            commands.spawn_structure(
+                tile_pos,
+                StructureData {
+                    structure_id,
+                    facing,
+                },
+            );
+        }
     }
 }

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -29,7 +29,7 @@ impl Plugin for ZoningPlugin {
         )
         .add_system(
             act_on_zoning
-                .label(InteractionSystem::ManageGhosts)
+                .label(InteractionSystem::ManagePreviews)
                 .after(InteractionSystem::ApplyZoning),
         );
     }

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -206,7 +206,7 @@ fn generate_organisms(
     let plant_positions = entity_positions.split_off(entity_positions.len() - n_plant);
     for position in plant_positions {
         let item = StructureData {
-            id: StructureId { id: "acacia" },
+            structure_id: StructureId { id: "acacia" },
             facing: Facing::default(),
         };
 
@@ -217,7 +217,7 @@ fn generate_organisms(
     let fungus_positions = entity_positions.split_off(entity_positions.len() - n_fungi);
     for position in fungus_positions {
         let item = StructureData {
-            id: StructureId { id: "leuco" },
+            structure_id: StructureId { id: "leuco" },
             facing: Facing::default(),
         };
 

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -111,6 +111,8 @@ pub(crate) struct MapGeometry {
     pub(crate) structure_index: HashMap<TilePos, Entity>,
     /// Which [`Ghost`](crate::structures::ghost::Ghost) entity is stored at each tile position
     pub(crate) ghost_index: HashMap<TilePos, Entity>,
+    /// Which [`Preview`](crate::structures::ghost::Preview) entity is stored at each tile position
+    pub(crate) preview_index: HashMap<TilePos, Entity>,
     /// The height of the terrain at each tile position
     pub(crate) height_index: HashMap<TilePos, f32>,
 }
@@ -132,6 +134,7 @@ impl MapGeometry {
             terrain_index: HashMap::default(),
             structure_index: HashMap::default(),
             ghost_index: HashMap::default(),
+            preview_index: HashMap::default(),
             height_index: HashMap::default(),
         }
     }

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -101,7 +101,7 @@ impl Command for SpawnStructureCommand {
 
         let structure_entity =
             world.resource_scope(|world, structure_manifest: Mut<StructureManifest>| {
-                let structure_details = structure_manifest.get(self.data.id);
+                let structure_details = structure_manifest.get(self.data.structure_id);
 
                 let structure_entity = world
                     .spawn(StructureBundle::new(self.tile_pos, self.data))
@@ -185,7 +185,7 @@ impl Command for SpawnGhostCommand {
         }
 
         let structure_manifest = world.resource::<StructureManifest>();
-        let variety_data = structure_manifest.get(self.data.id);
+        let variety_data = structure_manifest.get(self.data.structure_id);
         let construction_materials = variety_data.construction_materials.clone();
 
         // Spawn a ghost

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -162,8 +162,18 @@ impl Command for SpawnGhostCommand {
             world.entity_mut(existing_ghost).despawn_recursive();
         }
 
+        let structure_manifest = world.resource::<StructureManifest>();
+        let variety_data = structure_manifest.get(self.data.id);
+        let construction_materials = variety_data.construction_materials.clone();
+
         // Spawn a ghost
-        let ghost_entity = world.spawn(GhostBundle::new(self.tile_pos, self.data)).id();
+        let ghost_entity = world
+            .spawn(GhostBundle::new(
+                self.tile_pos,
+                self.data,
+                construction_materials,
+            ))
+            .id();
 
         let mut geometry = world.resource_mut::<MapGeometry>();
         geometry.ghost_index.insert(self.tile_pos, ghost_entity);

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -37,7 +37,7 @@ impl Display for CraftingState {
 }
 
 /// The input inventory for a structure.
-#[derive(Component, Debug, Default, Deref, DerefMut)]
+#[derive(Component, Clone, Debug, Default, Deref, DerefMut)]
 pub(crate) struct InputInventory {
     /// Inner storage
     pub(crate) inventory: Inventory,

--- a/emergence_lib/src/structures/ghost.rs
+++ b/emergence_lib/src/structures/ghost.rs
@@ -1,4 +1,8 @@
 //! Ghosts are translucent phantom structures, used to show structures that could be or are planned to be built.
+//!
+//! There is an important distinction between "ghosts" and "previews", even though they appear similarly to players.
+//! Ghosts are buildings that are genuinely planned to be built.
+//! Previews are simply hovered, and used as a visual aid to show placement.
 
 use bevy::prelude::*;
 
@@ -7,7 +11,7 @@ use crate::{
     simulation::geometry::{Facing, TilePos},
 };
 
-use super::StructureId;
+use super::{crafting::InputInventory, StructureId};
 
 /// A marker component that indicates that this structure is planned to be built, rather than actually existing.
 #[derive(Component, Clone, Copy, Debug)]
@@ -24,13 +28,49 @@ pub(super) struct GhostBundle {
     structure_id: StructureId,
     /// The direction the ghost is facing
     facing: Facing,
+    /// The items required to actually seed this item
+    construction_materials: InputInventory,
 }
 
 impl GhostBundle {
     /// Creates a new [`GhostBundle`].
-    pub(super) fn new(tile_pos: TilePos, data: StructureData) -> Self {
+    pub(super) fn new(
+        tile_pos: TilePos,
+        data: StructureData,
+        construction_materials: InputInventory,
+    ) -> Self {
         GhostBundle {
             ghost: Ghost,
+            tile_pos,
+            structure_id: data.id,
+            facing: data.facing,
+            construction_materials,
+        }
+    }
+}
+
+/// A marker component that indicates that this structure is planned to be built, rather than actually existing.
+#[derive(Component, Clone, Copy, Debug)]
+pub(crate) struct Preview;
+
+/// The set of components needed to spawn a structure preview.
+#[derive(Bundle)]
+pub(super) struct PreviewBundle {
+    /// Marker component
+    preview: Preview,
+    /// The location of the ghost
+    tile_pos: TilePos,
+    /// The variety of structure
+    structure_id: StructureId,
+    /// The direction the ghost is facing
+    facing: Facing,
+}
+
+impl PreviewBundle {
+    /// Creates a new [`PreviewBundle`].
+    pub(super) fn new(tile_pos: TilePos, data: StructureData) -> Self {
+        PreviewBundle {
+            preview: Preview,
             tile_pos,
             structure_id: data.id,
             facing: data.facing,

--- a/emergence_lib/src/structures/ghost.rs
+++ b/emergence_lib/src/structures/ghost.rs
@@ -42,7 +42,7 @@ impl GhostBundle {
         GhostBundle {
             ghost: Ghost,
             tile_pos,
-            structure_id: data.id,
+            structure_id: data.structure_id,
             facing: data.facing,
             construction_materials,
         }
@@ -72,7 +72,7 @@ impl PreviewBundle {
         PreviewBundle {
             preview: Preview,
             tile_pos,
-            structure_id: data.id,
+            structure_id: data.structure_id,
             facing: data.facing,
         }
     }

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -8,12 +8,12 @@ use bevy_mod_raycast::RaycastMesh;
 
 use crate::{
     asset_management::manifest::Manifest,
-    items::recipe::RecipeId,
+    items::{inventory::Inventory, recipe::RecipeId, ItemCount, ItemId},
     player_interaction::clipboard::StructureData,
     simulation::geometry::{Facing, TilePos},
 };
 
-use self::crafting::CraftingPlugin;
+use self::crafting::{CraftingPlugin, InputInventory};
 use std::fmt::Display;
 
 pub(crate) mod commands;
@@ -39,6 +39,8 @@ pub(crate) struct StructureVariety {
     crafts: bool,
     /// Does this structure start with a recipe pre-selected?
     starting_recipe: Option<RecipeId>,
+    /// The set of items needed to create a new copy of this structure
+    construction_materials: InputInventory,
     /// The color associated with this structure
     color: Color,
 }
@@ -47,6 +49,10 @@ impl Default for StructureManifest {
     fn default() -> Self {
         let mut map = HashMap::default();
 
+        let leuco_construction_materials = InputInventory {
+            inventory: Inventory::new_from_item(ItemCount::new(ItemId::leuco_chunk(), 1)),
+        };
+
         // TODO: read these from files
         map.insert(
             StructureId { id: "leuco" },
@@ -54,9 +60,14 @@ impl Default for StructureManifest {
                 organism: true,
                 crafts: true,
                 starting_recipe: Some(RecipeId::leuco_chunk_production()),
+                construction_materials: leuco_construction_materials,
                 color: Color::ORANGE_RED,
             },
         );
+
+        let acacia_construction_materials = InputInventory {
+            inventory: Inventory::new_from_item(ItemCount::new(ItemId::acacia_leaf(), 2)),
+        };
 
         map.insert(
             StructureId { id: "acacia" },
@@ -64,6 +75,7 @@ impl Default for StructureManifest {
                 organism: true,
                 crafts: true,
                 starting_recipe: Some(RecipeId::acacia_leaf_production()),
+                construction_materials: acacia_construction_materials,
                 color: Color::GREEN,
             },
         );

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -101,7 +101,7 @@ impl StructureBundle {
     /// Creates a new structure
     fn new(tile_pos: TilePos, data: StructureData) -> Self {
         StructureBundle {
-            structure: data.id,
+            structure: data.structure_id,
             facing: data.facing,
             tile_pos,
             raycast_mesh: RaycastMesh::default(),

--- a/emergence_lib/src/ui/select_structure.rs
+++ b/emergence_lib/src/ui/select_structure.rs
@@ -243,7 +243,7 @@ fn handle_selection(
         Ok(data) => {
             if data.complete {
                 let structure_data = StructureData {
-                    id: data.structure_id,
+                    structure_id: data.structure_id,
                     facing: Facing::default(),
                 };
 

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -103,6 +103,16 @@ impl Goal {
                 let mut entities_with_desired_item: Vec<Entity> = Vec::new();
 
                 for tile_pos in neighboring_tiles {
+                    // Ghosts
+                    if let Some(&ghost_entity) = map_geometry.ghost_index.get(&tile_pos) {
+                        if let Ok(input_inventory) = input_inventory_query.get(ghost_entity) {
+                            if input_inventory.remaining_reserved_space_for_item(*item_id) > 0 {
+                                entities_with_desired_item.push(ghost_entity);
+                            }
+                        }
+                    }
+
+                    // Structures
                     if let Some(&structure_entity) = map_geometry.structure_index.get(&tile_pos) {
                         if let Ok(input_inventory) = input_inventory_query.get(structure_entity) {
                             if input_inventory.remaining_reserved_space_for_item(*item_id) > 0 {

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -133,7 +133,11 @@ impl Goal {
 /// Choose this unit's new goal if needed
 pub(super) fn choose_goal(mut units_query: Query<&mut Goal>) {
     // TODO: pick goal intelligently based on local environment
-    let possible_goals = vec![Goal::Wander, Goal::Pickup(ItemId::acacia_leaf())];
+    let possible_goals = vec![
+        Goal::Wander,
+        Goal::Pickup(ItemId::acacia_leaf()),
+        Goal::Pickup(ItemId::leuco_chunk()),
+    ];
     let rng = &mut thread_rng();
 
     for mut goal in units_query.iter_mut() {


### PR DESCRIPTION
Fixes #243 🎉 

Ghosts and "previews" are now distinct, to avoid units trying to build things that you're trying out in your clipboard.

Still pretty jank with such poor info viz and random walks, but it genuinely *works*.