### PR TITLE
Revert "Remove dead code for using materials to show selections"

### DIFF
--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -14,6 +14,10 @@ use super::Loadable;
 pub(crate) struct StructureHandles {
     /// The scene for each type of structure
     pub(crate) scenes: HashMap<StructureId, Handle<Scene>>,
+    /// The materials used for tiles when they are selected or otherwise interacted with
+    pub(crate) interaction_materials: HashMap<ObjectInteraction, Handle<StandardMaterial>>,
+    /// The materials used for tiles when they are selected or otherwise interacted with
+    pub(crate) ghost_materials: HashMap<ObjectInteraction, Handle<StandardMaterial>>,
     /// The raycasting mesh used to select structures
     pub(crate) picking_mesh: Handle<Mesh>,
 }
@@ -50,6 +54,8 @@ impl FromWorld for StructureHandles {
 
         let mut handles = StructureHandles {
             scenes: HashMap::default(),
+            interaction_materials,
+            ghost_materials,
             picking_mesh,
         };
 

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -30,6 +30,7 @@ impl Plugin for GraphicsPlugin {
                         structures::populate_structures.before(InteractionSystem::ManagePreviews),
                     ),
             )
+            .add_system_to_stage(CoreStage::PostUpdate, structures::change_structure_material)
             .add_system(selection::display_tile_interactions.after(InteractionSystem::SelectTiles));
     }
 }

--- a/emergence_lib/src/graphics/structures.rs
+++ b/emergence_lib/src/graphics/structures.rs
@@ -4,8 +4,9 @@ use bevy::prelude::*;
 
 use crate::{
     asset_management::structures::StructureHandles,
+    player_interaction::selection::ObjectInteraction,
     simulation::geometry::{MapGeometry, TilePos},
-    structures::StructureId,
+    structures::{ghost::Ghostly, StructureId},
 };
 
 /// Adds rendering components to every spawned structure, real or otherwise
@@ -29,5 +30,31 @@ pub(super) fn populate_structures(
                 ..default()
             })
             .insert(structure_handles.picking_mesh.clone_weak());
+    }
+}
+
+/// Modifies the material of any structures based on their interaction state.
+pub(super) fn change_structure_material(
+    root_structure_query: Query<(Entity, &ObjectInteraction, Option<&Ghostly>), With<StructureId>>,
+    children: Query<&Children>,
+    mut material_query: Query<&mut Handle<StandardMaterial>>,
+    structure_handles: Res<StructureHandles>,
+) {
+    for (root_entity, object_interaction, maybe_ghostly) in root_structure_query.iter() {
+        for child in children.iter_descendants(root_entity) {
+            if let Ok(mut material) = material_query.get_mut(child) {
+                let maybe_material_handle = match maybe_ghostly {
+                    Some(..) => structure_handles.ghost_materials.get(object_interaction),
+                    None => structure_handles
+                        .interaction_materials
+                        .get(object_interaction),
+                };
+
+                // FIXME: how do we restore the materials back to their original form??
+                if let Some(new_handle) = maybe_material_handle {
+                    *material = new_handle.clone_weak();
+                }
+            }
+        }
     }
 }

--- a/emergence_lib/src/structures/ghost.rs
+++ b/emergence_lib/src/structures/ghost.rs
@@ -7,7 +7,7 @@
 use bevy::prelude::*;
 
 use crate::{
-    player_interaction::clipboard::StructureData,
+    player_interaction::{clipboard::StructureData, selection::ObjectInteraction},
     simulation::geometry::{Facing, TilePos},
 };
 
@@ -36,6 +36,8 @@ pub(super) struct GhostBundle {
     facing: Facing,
     /// The items required to actually seed this item
     construction_materials: InputInventory,
+    /// How is this structure being interacted with
+    object_interaction: ObjectInteraction,
 }
 
 impl GhostBundle {
@@ -52,6 +54,7 @@ impl GhostBundle {
             structure_id: data.structure_id,
             facing: data.facing,
             construction_materials,
+            object_interaction: ObjectInteraction::None,
         }
     }
 }
@@ -73,6 +76,8 @@ pub(super) struct PreviewBundle {
     structure_id: StructureId,
     /// The direction the preview is facing
     facing: Facing,
+    /// How is this structure being interacted with
+    object_interaction: ObjectInteraction,
 }
 
 impl PreviewBundle {
@@ -84,6 +89,7 @@ impl PreviewBundle {
             tile_pos,
             structure_id: data.structure_id,
             facing: data.facing,
+            object_interaction: ObjectInteraction::Hovered,
         }
     }
 }

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -9,7 +9,7 @@ use bevy_mod_raycast::RaycastMesh;
 use crate::{
     asset_management::manifest::Manifest,
     items::{inventory::Inventory, recipe::RecipeId, ItemCount, ItemId},
-    player_interaction::clipboard::StructureData,
+    player_interaction::{clipboard::StructureData, selection::ObjectInteraction},
     simulation::geometry::{Facing, TilePos},
 };
 
@@ -95,6 +95,8 @@ struct StructureBundle {
     tile_pos: TilePos,
     /// Makes structures pickable
     raycast_mesh: RaycastMesh<StructureId>,
+    /// How is this structure being interacted with
+    object_interaction: ObjectInteraction,
 }
 
 impl StructureBundle {
@@ -105,6 +107,7 @@ impl StructureBundle {
             facing: data.facing,
             tile_pos,
             raycast_mesh: RaycastMesh::default(),
+            object_interaction: ObjectInteraction::None,
         }
     }
 }


### PR DESCRIPTION
This reverts commit 998ff7989ea81dbb18944e3dde73e1803f266a47.

Partially reverts #394, which broke ghost and hover visualization.