### PR TITLE
Add impatience system for units

### DIFF
--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -731,6 +731,7 @@ fn get_details(
                 held_item: unit_query_item.held_item.clone(),
                 goal: unit_query_item.goal.clone(),
                 action: unit_query_item.action.clone(),
+                impatience: unit_query_item.impatience.clone(),
             })
         }
         CurrentSelection::None => SelectionDetails::None,
@@ -964,7 +965,7 @@ mod unit_details {
     use crate::{
         simulation::geometry::TilePos,
         units::{
-            behavior::{CurrentAction, Goal},
+            behavior::{CurrentAction, Goal, Impatience},
             item_interaction::HeldItem,
             UnitId,
         },
@@ -985,6 +986,8 @@ mod unit_details {
         pub(super) goal: &'static Goal,
         /// What is currently being done
         pub(super) action: &'static CurrentAction,
+        /// How frustrated is this unit
+        pub(super) impatience: &'static Impatience,
     }
 
     /// Detailed info about a given unit.
@@ -1002,6 +1005,8 @@ mod unit_details {
         pub(super) goal: Goal,
         /// What is currently being done
         pub(super) action: CurrentAction,
+        /// How frustrated is this unit
+        pub(super) impatience: Impatience,
     }
 
     impl Display for UnitDetails {
@@ -1012,6 +1017,7 @@ mod unit_details {
             let held_item = &self.held_item;
             let goal = &self.goal;
             let action = &self.action;
+            let impatience = &self.impatience;
 
             write!(
                 f,
@@ -1020,7 +1026,8 @@ Unit type: {unit_id}
 Tile: {tile_pos}
 Holding: {held_item}
 Goal: {goal}
-Action: {action}"
+Action: {action}
+Impatience: {impatience}"
             )
         }
     }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -177,7 +177,7 @@ impl Display for LocalSignals {
         for signal_type in self.map.keys().sorted() {
             let signal_strength = self.map.get(signal_type).unwrap().0;
 
-            let substring = format!("{signal_type}: {signal_strength:.2}\n");
+            let substring = format!("{signal_type}: {signal_strength:.3}\n");
 
             string += &substring;
         }
@@ -369,7 +369,12 @@ fn degrade_signals(mut signals: ResMut<Signals>) {
     const DEGRADATION_FRACTION: f32 = 0.1;
 
     /// The value below which decayed signals are eliminated completely
-    const EPSILON_STRENGTH: SignalStrength = SignalStrength(0.0001);
+    ///
+    /// Increasing this value will:
+    ///  - increase computational costs
+    ///  - increase the range at which tasks can be detected
+    ///  - increase the amount of time units will wait around for more production
+    const EPSILON_STRENGTH: SignalStrength = SignalStrength(1e-5);
 
     for signal_map in signals.maps.values_mut() {
         let mut tiles_to_clear: Vec<TilePos> = Vec::with_capacity(signal_map.map.len());

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -17,6 +17,8 @@ use crate::structures::crafting::{InputInventory, OutputInventory};
 use crate::structures::StructureId;
 use crate::units::UnitId;
 
+use super::item_interaction::HeldItem;
+
 /// A unit's current goals.
 ///
 /// Units will be fully concentrated on any task other than [`Goal::Wander`] until it is complete (or overridden).
@@ -351,12 +353,13 @@ impl Impatience {
 }
 
 /// Clears the current goal and drops any held item when impatience has been exceeded
-pub(super) fn clear_goal_when_impatience_full(
-    mut unit_query: Query<(&mut Goal, &mut Impatience), Changed<Impatience>>,
+pub(super) fn handle_full_impatience(
+    mut unit_query: Query<(&mut Goal, &mut Impatience, &mut HeldItem), Changed<Impatience>>,
 ) {
-    for (mut goal, mut impatience) in unit_query.iter_mut() {
+    for (mut goal, mut impatience, mut held_item) in unit_query.iter_mut() {
         if impatience.current > impatience.max {
             impatience.current = 0;
+            *held_item = HeldItem::default();
             *goal = Goal::Wander
         }
     }

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -327,7 +327,9 @@ impl CurrentAction {
 /// When this reaches its max value, the unit will abandon its goal and drop anything its holding.
 #[derive(Component, Clone, Debug)]
 pub(crate) struct Impatience {
+    //// The current impatience for this unit
     current: u8,
+    /// The maximum impatience for this unit
     max: u8,
 }
 

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -313,3 +313,33 @@ impl CurrentAction {
         }
     }
 }
+
+/// How many times this unit has failed to make progress towards its goal.
+///
+/// When this reaches its max value, the unit will abandon its goal and drop anything its holding.
+#[derive(Component, Clone, Debug)]
+pub(crate) struct Impatience {
+    current: u8,
+    max: u8,
+}
+
+impl Display for Impatience {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let current = self.current;
+        let max = self.max;
+        write!(f, "{current}/{max}")
+    }
+}
+
+impl Default for Impatience {
+    fn default() -> Self {
+        Impatience { current: 0, max: 5 }
+    }
+}
+
+impl Impatience {
+    /// Increase this unit's impatience by 1.
+    pub(crate) fn tick_up(&mut self) {
+        self.current += 1;
+    }
+}

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -327,7 +327,7 @@ impl CurrentAction {
 /// When this reaches its max value, the unit will abandon its goal and drop anything its holding.
 #[derive(Component, Clone, Debug)]
 pub(crate) struct Impatience {
-    //// The current impatience for this unit
+    /// The current impatience for this unit
     current: u8,
     /// The maximum impatience for this unit
     max: u8,

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -341,7 +341,10 @@ impl Display for Impatience {
 
 impl Default for Impatience {
     fn default() -> Self {
-        Impatience { current: 0, max: 5 }
+        Impatience {
+            current: 0,
+            max: 10,
+        }
     }
 }
 

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -108,6 +108,9 @@ impl Plugin for UnitsPlugin {
                     .label(UnitSystem::ChooseNewAction)
                     .after(UnitSystem::Act)
                     .after(UnitSystem::ChooseGoal),
+            )
+            .add_system(
+                behavior::clear_goal_when_impatience_full.after(UnitSystem::ChooseNewAction),
             );
     }
 }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -109,8 +109,6 @@ impl Plugin for UnitsPlugin {
                     .after(UnitSystem::Act)
                     .after(UnitSystem::ChooseGoal),
             )
-            .add_system(
-                behavior::clear_goal_when_impatience_full.after(UnitSystem::ChooseNewAction),
-            );
+            .add_system(behavior::handle_full_impatience.after(UnitSystem::ChooseNewAction));
     }
 }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -6,7 +6,7 @@ use bevy_mod_raycast::RaycastMesh;
 use core::fmt::Display;
 
 use self::{
-    behavior::{CurrentAction, Goal},
+    behavior::{CurrentAction, Goal, Impatience},
     item_interaction::HeldItem,
 };
 
@@ -40,6 +40,8 @@ pub(crate) struct UnitBundle {
     current_goal: Goal,
     /// What is the unit currently doing.
     current_action: CurrentAction,
+    /// How frustrated is this unit, causing it to give up its current goal?
+    impatience: Impatience,
     /// What is the unit currently holding, if anything?
     held_item: HeldItem,
     /// Organism data
@@ -56,6 +58,8 @@ impl UnitBundle {
             tile_pos,
             current_goal: Goal::default(),
             current_action: CurrentAction::default(),
+            // TODO: This should be initialized from the unit manifest
+            impatience: Impatience::default(),
             held_item: HeldItem::default(),
             organism_bundle: OrganismBundle::default(),
             raycast_mesh: RaycastMesh::default(),


### PR DESCRIPTION
Fixes #404. 

Impatience increases when no signal gradient can be found, or item transfers fail.

If impatience exceeds the cap, units drop what they're holding and choose a new goal.