### PR TITLE
Camera tweaks

### DIFF
--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -130,9 +130,9 @@ struct CameraSettings {
 impl Default for CameraSettings {
     fn default() -> Self {
         CameraSettings {
-            zoom_speed: Speed::new(100., 100.0, 200.0),
-            pan_speed: Speed::new(100., 100.0, 150.0),
-            rotation_speed: Speed::new(0.3, 3.0, 5.0),
+            zoom_speed: Speed::new(400., 300.0, 1000.0),
+            pan_speed: Speed::new(50., 100.0, 150.0),
+            rotation_speed: Speed::new(1.0, 3.0, 5.0),
             min_zoom: 5.,
             max_zoom: 500.,
             float_radius: 3,

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -136,7 +136,7 @@ impl Default for CameraSettings {
             min_zoom: 0.2,
             max_zoom: 1.,
             float_radius: 3,
-            inclination: 0.7 * PI / 2.,
+            inclination: 0.5 * PI / 2.,
             inclination_speed: 1.,
         }
     }
@@ -260,7 +260,6 @@ fn modify_field_of_view(
     // FIXME: this should probably just be handled by using the `PerspectiveProjection` component directly on our camera
     if let Projection::Perspective(projection) = &mut *projection {
         projection.fov = (projection.fov + delta_zoom).clamp(settings.min_zoom, settings.max_zoom);
-        info!(projection.fov);
     }
 }
 

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -52,10 +52,15 @@ fn setup_camera(mut commands: Commands, map_geometry: Res<MapGeometry>) {
     let planar_angle = facing.direction.angle(&map_geometry.layout.orientation);
 
     let transform = compute_camera_transform(&focus, planar_angle, settings.inclination);
+    let projection = Projection::Perspective(PerspectiveProjection {
+        fov: 0.2,
+        ..Default::default()
+    });
 
     commands
         .spawn(Camera3dBundle {
             transform,
+            projection,
             ..Default::default()
         })
         .insert(settings)
@@ -128,8 +133,8 @@ impl Default for CameraSettings {
             zoom_speed: Speed::new(1., 1.0, 2.0),
             pan_speed: Speed::new(100., 100.0, 150.0),
             rotation_speed: Speed::new(0.3, 3.0, 5.0),
-            min_zoom: 0.,
-            max_zoom: 100.,
+            min_zoom: 0.2,
+            max_zoom: 1.,
             float_radius: 3,
             inclination: 0.7 * PI / 2.,
             inclination_speed: 1.,


### PR DESCRIPTION
Zooming with FOV was a bust: ended up with severe and strange distortions for the amount of zoom we needed.

Setting a low FOV enhanced the miniature effect for me though, so we'll go with that for now!

Adjusted other camera settings for better game feel while I was here too.