### PR TITLE
Add tests for item transfers

### DIFF
--- a/emergence_lib/src/items/errors.rs
+++ b/emergence_lib/src/items/errors.rs
@@ -31,11 +31,12 @@ pub struct RemoveManyItemsError {
 }
 
 /// Failed to completely transfer items from one inventory to another.
+#[derive(Debug, PartialEq, Eq)]
 pub struct ItemTransferError {
     /// The number and type of items remaining in the input that could not be transferred.
-    pub items_remaining: usize,
-    /// Did this fail because the input inventory was full?
-    pub full_sink: bool,
-    /// Did this fail because the output inventory was empty?
+    pub items_remaining: ItemCount,
+    /// Did this fail because the input inventory of the destination was full?
+    pub full_destination: bool,
+    /// Did this fail because the output inventory of the source was empty?
     pub empty_source: bool,
 }

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -457,16 +457,11 @@ impl Inventory {
         let item_id = item_count.item_id();
 
         let requested = item_count.count();
-        dbg!(requested);
         let available = self.item_count(item_id);
-        dbg!(available);
         let free = other.remaining_space_for_item(item_id, item_manifest);
-        dbg!(free);
 
         let proposed = requested.min(available);
-        dbg!(proposed);
         let actual = proposed.min(free);
-        dbg!(actual);
 
         // Skip the expensive work if there's nothing to move
         if actual > 0 {

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -114,7 +114,7 @@ impl Recipe {
         Recipe::new(
             Vec::new(),
             vec![ItemCount::one(ItemId::acacia_leaf())],
-            Duration::from_secs(10),
+            Duration::from_secs(3),
             Some(Energy(20.)),
         )
     }
@@ -124,7 +124,7 @@ impl Recipe {
         Recipe::new(
             vec![ItemCount::one(ItemId::acacia_leaf())],
             vec![ItemCount::one(ItemId::leuco_chunk())],
-            Duration::from_secs(5),
+            Duration::from_secs(2),
             Some(Energy(40.)),
         )
     }

--- a/emergence_lib/src/units/behavior.rs
+++ b/emergence_lib/src/units/behavior.rs
@@ -245,7 +245,7 @@ impl Display for CurrentAction {
         let action = &self.action;
         let time_remaining = self.timer.remaining_secs();
 
-        write!(f, "{action} for the next {time_remaining:.2} s.")
+        write!(f, "{action}\nRemaining: {time_remaining:.2} s.")
     }
 }
 

--- a/emergence_lib/src/units/item_interaction.rs
+++ b/emergence_lib/src/units/item_interaction.rs
@@ -67,6 +67,7 @@ pub(super) fn pickup_and_drop_items(
             } = current_action.action()
             {
                 if let Ok(mut output_inventory) = output_query.get_mut(*output_entity) {
+                    // Transfer one item at a time
                     let item_count = ItemCount::new(*item_id, 1);
                     let _transfer_result = output_inventory.transfer_item(
                         &item_count,
@@ -91,6 +92,7 @@ pub(super) fn pickup_and_drop_items(
             } = current_action.action()
             {
                 if let Ok(mut input_inventory) = input_query.get_mut(*input_entity) {
+                    // Transfer one item at a time
                     let item_count = ItemCount::new(*item_id, 1);
                     let _transfer_result = held_item.transfer_item(
                         &item_count,


### PR DESCRIPTION
I ran into what looked like a bug with item transfer, with units getting stuck against structures pulling endlessly without filling their inventory.

Could not reproduce reliably.

I added some tests though :upside_down: