### PR TITLE
Units only carry one item at a time

### DIFF
--- a/emergence_lib/src/graphics/units.rs
+++ b/emergence_lib/src/graphics/units.rs
@@ -4,11 +4,13 @@ use bevy::prelude::*;
 
 use crate::{
     asset_management::manifest::{Id, Unit},
-    units::item_interaction::HeldItem,
+    units::item_interaction::UnitInventory,
 };
 
 /// Shows the item that each unit is holding
-pub(super) fn display_held_item(unit_query: Query<&HeldItem, (With<Id<Unit>>, Changed<HeldItem>)>) {
+pub(super) fn display_held_item(
+    unit_query: Query<&UnitInventory, (With<Id<Unit>>, Changed<UnitInventory>)>,
+) {
     for _held_item in unit_query.iter() {
         // TODO: actually display this
     }

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -1052,7 +1052,7 @@ mod unit_details {
     use crate::{
         asset_management::manifest::{Id, Unit},
         simulation::geometry::TilePos,
-        units::{actions::CurrentAction, goals::Goal, item_interaction::HeldItem},
+        units::{actions::CurrentAction, goals::Goal, item_interaction::UnitInventory},
     };
 
     use super::organism_details::OrganismDetails;
@@ -1067,7 +1067,7 @@ mod unit_details {
         /// The current location
         pub(super) tile_pos: &'static TilePos,
         /// What's being carried
-        pub(super) held_item: &'static HeldItem,
+        pub(super) held_item: &'static UnitInventory,
         /// What this unit is trying to acheive
         pub(super) goal: &'static Goal,
         /// What is currently being done
@@ -1084,7 +1084,7 @@ mod unit_details {
         /// The current location
         pub(super) tile_pos: TilePos,
         /// What's being carried
-        pub(super) held_item: HeldItem,
+        pub(super) held_item: UnitInventory,
         /// What this unit is trying to acheive
         pub(super) goal: Goal,
         /// What is currently being done

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -14,7 +14,7 @@ use crate::{
     structures::crafting::{InputInventory, OutputInventory},
 };
 
-use super::{goals::Goal, hunger::Diet, item_interaction::HeldItem};
+use super::{goals::Goal, hunger::Diet, item_interaction::UnitInventory};
 
 /// Ticks the timer for each [`CurrentAction`].
 pub(super) fn advance_action_timer(mut units_query: Query<&mut CurrentAction>, time: Res<Time>) {
@@ -28,7 +28,7 @@ pub(super) fn advance_action_timer(mut units_query: Query<&mut CurrentAction>, t
 /// Choose the unit's action for this turn
 pub(super) fn choose_actions(
     mut units_query: Query<
-        (&TilePos, &Facing, &Goal, &mut CurrentAction, &HeldItem),
+        (&TilePos, &Facing, &Goal, &mut CurrentAction, &UnitInventory),
         With<Id<Unit>>,
     >,
     input_inventory_query: Query<&InputInventory>,
@@ -191,7 +191,7 @@ pub(super) fn handle_actions(
                 }
                 UnitAction::Abandon => {
                     // TODO: actually put these dropped items somewhere
-                    *unit.held_item = HeldItem::default();
+                    *unit.held_item = UnitInventory::default();
                 }
             }
         }
@@ -207,7 +207,7 @@ pub(super) struct ActionDataQuery {
     /// The unit's action
     action: &'static CurrentAction,
     /// What the unit is holding
-    held_item: &'static mut HeldItem,
+    held_item: &'static mut UnitInventory,
     /// The unit's spatial position for rendering
     transform: &'static mut Transform,
     /// The tile that the unit is on

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -39,7 +39,7 @@ pub(super) fn choose_actions(
     let rng = &mut thread_rng();
     let map_geometry = map_geometry.into_inner();
 
-    for (&unit_tile_pos, facing, goal, mut action, held_item) in units_query.iter_mut() {
+    for (&unit_tile_pos, facing, goal, mut action, unit_inventory) in units_query.iter_mut() {
         if action.finished() {
             *action = match goal {
                 // Alternate between spinning and moving forward.
@@ -50,8 +50,7 @@ pub(super) fn choose_actions(
                     _ => CurrentAction::random_spin(rng),
                 },
                 Goal::Pickup(item_id) => {
-                    let maybe_item = held_item.item_id();
-                    if maybe_item.is_some() && maybe_item.unwrap() != *item_id {
+                    if unit_inventory.is_some() && unit_inventory.unwrap() != *item_id {
                         CurrentAction::abandon()
                     } else {
                         CurrentAction::find_item(
@@ -67,8 +66,7 @@ pub(super) fn choose_actions(
                     }
                 }
                 Goal::DropOff(item_id) => {
-                    let maybe_item = held_item.item_id();
-                    if maybe_item.is_some() && maybe_item.unwrap() != *item_id {
+                    if unit_inventory.is_some() && unit_inventory.unwrap() != *item_id {
                         CurrentAction::abandon()
                     } else {
                         CurrentAction::find_receptacle(
@@ -84,7 +82,7 @@ pub(super) fn choose_actions(
                     }
                 }
                 Goal::Eat(item_id) => {
-                    if let Some(held_item) = held_item.item_id() {
+                    if let Some(held_item) = unit_inventory.held_item {
                         if held_item == *item_id {
                             CurrentAction::eat()
                         } else {
@@ -128,20 +126,23 @@ pub(super) fn handle_actions(
                     output_entity,
                 } => {
                     if let Ok(mut output_inventory) = output_query.get_mut(*output_entity) {
-                        // Transfer one item at a time
-                        let item_count = ItemCount::new(*item_id, 1);
-                        let _transfer_result = output_inventory.transfer_item(
-                            &item_count,
-                            &mut unit.held_item.inventory,
-                            item_manifest,
-                        );
+                        *unit.goal = match unit.unit_inventory.held_item {
+                            // We shouldn't be holding anything yet, but if we are get rid of it
+                            Some(held_item_id) => Goal::DropOff(held_item_id),
+                            None => {
+                                let item_count = ItemCount::new(*item_id, 1);
+                                let transfer_result =
+                                    output_inventory.remove_item_all_or_nothing(&item_count);
 
-                        // If our unit's all loaded, swap to delivering it
-                        *unit.goal = if unit.held_item.is_full() {
-                            Goal::DropOff(*item_id)
-                        // If we can carry more, try and grab more items
-                        } else {
-                            Goal::Pickup(*item_id)
+                                // If our unit's all loaded, swap to delivering it
+                                match transfer_result {
+                                    Ok(()) => {
+                                        unit.unit_inventory.held_item = Some(*item_id);
+                                        Goal::DropOff(*item_id)
+                                    }
+                                    Err(..) => Goal::Pickup(*item_id),
+                                }
+                            }
                         }
                     }
                 }
@@ -150,20 +151,28 @@ pub(super) fn handle_actions(
                     input_entity,
                 } => {
                     if let Ok(mut input_inventory) = input_query.get_mut(*input_entity) {
-                        // Transfer one item at a time
-                        let item_count = ItemCount::new(*item_id, 1);
-                        let _transfer_result = unit.held_item.transfer_item(
-                            &item_count,
-                            &mut input_inventory.inventory,
-                            item_manifest,
-                        );
+                        *unit.goal = match unit.unit_inventory.held_item {
+                            // We should be holding something, if we're not find something else to do
+                            None => Goal::Wander,
+                            Some(held_item_id) => {
+                                if held_item_id == *item_id {
+                                    let item_count = ItemCount::new(held_item_id, 1);
+                                    let transfer_result = input_inventory
+                                        .add_item_all_or_nothing(&item_count, item_manifest);
 
-                        // If our unit is unloaded, swap to wandering to find something else to do
-                        *unit.goal = if unit.held_item.is_empty() {
-                            Goal::Wander
-                        // If we still have items, keep unloading
-                        } else {
-                            Goal::DropOff(*item_id)
+                                    // If our unit is unloaded, swap to wandering to find something else to do
+                                    match transfer_result {
+                                        Ok(()) => {
+                                            unit.unit_inventory.held_item = None;
+                                            Goal::Wander
+                                        }
+                                        Err(..) => Goal::DropOff(held_item_id),
+                                    }
+                                } else {
+                                    // Somehow we're holding the wrong thing
+                                    Goal::DropOff(held_item_id)
+                                }
+                            }
                         }
                     }
                 }
@@ -179,19 +188,18 @@ pub(super) fn handle_actions(
                     unit.transform.translation = target_tile.into_world_pos(&map_geometry);
                 }
                 UnitAction::Eat => {
-                    let item_count = ItemCount::new(unit.diet.item(), 1);
-                    if unit
-                        .held_item
-                        .remove_item_all_or_nothing(&item_count)
-                        .is_ok()
-                    {
-                        let proposed = unit.energy_pool.current() + unit.diet.energy();
-                        unit.energy_pool.set_current(proposed);
+                    if let Some(held_item) = unit.unit_inventory.held_item {
+                        if held_item == unit.diet.item() {
+                            let proposed = unit.energy_pool.current() + unit.diet.energy();
+                            unit.energy_pool.set_current(proposed);
+                        }
                     }
+
+                    unit.unit_inventory.held_item = None;
                 }
                 UnitAction::Abandon => {
                     // TODO: actually put these dropped items somewhere
-                    *unit.held_item = UnitInventory::default();
+                    unit.unit_inventory.held_item = None;
                 }
             }
         }
@@ -207,7 +215,7 @@ pub(super) struct ActionDataQuery {
     /// The unit's action
     action: &'static CurrentAction,
     /// What the unit is holding
-    held_item: &'static mut UnitInventory,
+    unit_inventory: &'static mut UnitInventory,
     /// The unit's spatial position for rendering
     transform: &'static mut Transform,
     /// The tile that the unit is on

--- a/emergence_lib/src/units/item_interaction.rs
+++ b/emergence_lib/src/units/item_interaction.rs
@@ -10,20 +10,20 @@ use core::fmt::Display;
 
 /// The item(s) that a unit is carrying.
 #[derive(Component, Clone, Debug, Deref, DerefMut)]
-pub(crate) struct HeldItem {
+pub(crate) struct UnitInventory {
     /// The internal representation.
     pub(crate) inventory: Inventory,
 }
 
-impl Default for HeldItem {
+impl Default for UnitInventory {
     fn default() -> Self {
-        HeldItem {
+        UnitInventory {
             inventory: Inventory::new(1),
         }
     }
 }
 
-impl Display for HeldItem {
+impl Display for UnitInventory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(slot) = self.item_slot() {
             let item = slot.item_id();
@@ -35,7 +35,7 @@ impl Display for HeldItem {
     }
 }
 
-impl HeldItem {
+impl UnitInventory {
     /// The item and quantity held, if any.
     pub(crate) fn item_slot(&self) -> Option<&ItemSlot> {
         self.inventory.iter().next()
@@ -49,7 +49,7 @@ impl HeldItem {
 }
 
 /// Clears out any slots that no longer have items in them.
-pub(super) fn clear_empty_slots(mut query: Query<&mut HeldItem>) {
+pub(super) fn clear_empty_slots(mut query: Query<&mut UnitInventory>) {
     for mut held_item in query.iter_mut() {
         held_item.clear_empty_slots()
     }

--- a/emergence_lib/src/units/item_interaction.rs
+++ b/emergence_lib/src/units/item_interaction.rs
@@ -2,55 +2,22 @@
 
 use bevy::prelude::*;
 
-use crate::{
-    asset_management::manifest::{Id, Item},
-    items::{inventory::Inventory, slot::ItemSlot},
-};
+use crate::asset_management::manifest::{Id, Item};
 use core::fmt::Display;
 
 /// The item(s) that a unit is carrying.
-#[derive(Component, Clone, Debug, Deref, DerefMut)]
+#[derive(Component, Default, Clone, Debug, Deref, DerefMut)]
 pub(crate) struct UnitInventory {
-    /// The internal representation.
-    pub(crate) inventory: Inventory,
-}
-
-impl Default for UnitInventory {
-    fn default() -> Self {
-        UnitInventory {
-            inventory: Inventory::new(1),
-        }
-    }
+    /// The single item the unit is currently holding
+    pub(crate) held_item: Option<Id<Item>>,
 }
 
 impl Display for UnitInventory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(slot) = self.item_slot() {
-            let item = slot.item_id();
-            let count = slot.count();
-            write!(f, "{count} {item}")
+        if let Some(item) = self.held_item {
+            write!(f, "{item}")
         } else {
-            write!(f, "Empty")
+            write!(f, "Nothing")
         }
-    }
-}
-
-impl UnitInventory {
-    /// The item and quantity held, if any.
-    pub(crate) fn item_slot(&self) -> Option<&ItemSlot> {
-        self.inventory.iter().next()
-    }
-
-    /// The type of item held.
-    pub(crate) fn item_id(&self) -> Option<Id<Item>> {
-        let item_slot = self.item_slot()?;
-        Some(item_slot.item_id())
-    }
-}
-
-/// Clears out any slots that no longer have items in them.
-pub(super) fn clear_empty_slots(mut query: Query<&mut UnitInventory>) {
-    for mut held_item in query.iter_mut() {
-        held_item.clear_empty_slots()
     }
 }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -122,8 +122,6 @@ pub(crate) enum UnitSystem {
     AdvanceTimers,
     /// Carry out the chosen action
     Act,
-    /// Perform any necessary cleanup
-    Cleanup,
     /// Pick a higher level goal to pursue
     ChooseGoal,
     /// Pick an action that will get the agent closer to the goal being pursued
@@ -140,11 +138,6 @@ impl Plugin for UnitsPlugin {
                 actions::handle_actions
                     .label(UnitSystem::Act)
                     .after(UnitSystem::AdvanceTimers),
-            )
-            .add_system(
-                item_interaction::clear_empty_slots
-                    .label(UnitSystem::Cleanup)
-                    .after(UnitSystem::Act),
             )
             .add_system(goals::choose_goal.label(UnitSystem::ChooseGoal))
             .add_system(

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -12,7 +12,7 @@ use bevy::{prelude::*, utils::HashMap};
 use bevy_mod_raycast::RaycastMesh;
 use leafwing_abilities::prelude::Pool;
 
-use self::{actions::CurrentAction, goals::Goal, hunger::Diet, item_interaction::HeldItem};
+use self::{actions::CurrentAction, goals::Goal, hunger::Diet, item_interaction::UnitInventory};
 
 use crate::organisms::OrganismBundle;
 
@@ -70,7 +70,7 @@ pub(crate) struct UnitBundle {
     /// What is the unit currently doing.
     current_action: CurrentAction,
     /// What is the unit currently holding, if anything?
-    held_item: HeldItem,
+    held_item: UnitInventory,
     /// What does this unit need to eat?
     diet: Diet,
     /// Organism data
@@ -101,7 +101,7 @@ impl UnitBundle {
             facing: Facing::default(),
             current_goal: Goal::default(),
             current_action: CurrentAction::default(),
-            held_item: HeldItem::default(),
+            held_item: UnitInventory::default(),
             diet: unit_data.diet,
             organism_bundle: OrganismBundle::new(unit_data.energy_pool),
             raycast_mesh: RaycastMesh::default(),


### PR DESCRIPTION
This ends up making the behavior feel much more intuitive and clear, and reduces the amount of deadlocking.

I think there's a good argument to be made for allowing some units to carry more items at once later, but it shouldn't be the default behavior.