### PR TITLE
Add middle mouse + drag to tilt camera

### DIFF
--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -98,6 +98,8 @@ pub(crate) enum PlayerAction {
     RotateClipboardRight,
     /// Snaps the camera to the selected object
     SnapToSelection,
+    /// Drag the camera with the cursor
+    DragCamera,
     /// Move the camera from side to side
     Pan,
     /// Move the cursor around the screen
@@ -136,6 +138,7 @@ impl PlayerAction {
             RotateClipboardLeft => UserInput::modified(Modifier::Shift, KeyCode::R),
             RotateClipboardRight => KeyCode::R.into(),
             SnapToSelection => KeyCode::Return.into(),
+            DragCamera => MouseButton::Middle.into(),
             Pan => VirtualDPad::wasd().into(),
             MoveCursor => VirtualDPad::arrow_keys().into(),
             // Plus and Equals are swapped. See: https://github.com/rust-windowing/winit/issues/2682
@@ -172,6 +175,7 @@ impl PlayerAction {
             RotateClipboardLeft => DPadLeft.into(),
             RotateClipboardRight => DPadRight.into(),
             SnapToSelection => GamepadButtonType::LeftThumb.into(),
+            DragCamera => GamepadButtonType::RightThumb.into(),
             Pan => DualAxis::left_stick().into(),
             MoveCursor => DualAxis::right_stick().into(),
             ZoomIn => UserInput::chord([camera_modifier, DPadUp]),


### PR DESCRIPTION
Fixes #427.

Much less convinced on rotation: this is a less common operation and easy to mess up.

Issue was discovered courtesy of a certain lovely playtester :3