### PR TITLE
Generate icons for structures

### DIFF
--- a/emergence_lib/src/asset_management/palette.rs
+++ b/emergence_lib/src/asset_management/palette.rs
@@ -60,3 +60,6 @@ pub(crate) const SELECTION_AND_HOVER_COLOR: Color = Color::hsl(
     (SELECTION_SATURATION + HOVER_SATURATION) / 2.,
     (SELECTION_LIGHTNESS + HOVER_LIGHTNESS) / 2.,
 );
+
+/// The tint used to de-emphasize UI elements that are not selected.
+pub(crate) const UNSELECTED_UI_COLOR: Color = Color::hsl(0., 0., 0.7);

--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -12,11 +12,16 @@ use super::{
     Loadable,
 };
 
+// TODO: discover this from the file directory
+const STRUCTURE_NAMES: [&'static str; 4] = ["acacia", "leuco", "ant_hive", "hatchery"];
+
 /// Stores material handles for the different tile types.
 #[derive(Resource)]
 pub(crate) struct StructureHandles {
     /// The scene for each type of structure
     pub(crate) scenes: HashMap<Id<Structure>, Handle<Scene>>,
+    /// The icon for each type of structure, as displayed in menus
+    pub(crate) icons: HashMap<Id<Structure>, Handle<Image>>,
     /// The materials used for tiles when they are selected or otherwise interacted with
     pub(crate) ghost_materials: HashMap<GhostKind, Handle<StandardMaterial>>,
     /// The raycasting mesh used to select structures
@@ -53,16 +58,15 @@ impl FromWorld for StructureHandles {
 
         let mut handles = StructureHandles {
             scenes: HashMap::default(),
+            icons: HashMap::default(),
             ghost_materials,
             picking_mesh,
         };
 
         let asset_server = world.resource::<AssetServer>();
 
-        // TODO: discover this from the file directory
-        let structure_names = vec!["acacia", "leuco", "ant_hive", "hatchery"];
-
-        for id in structure_names {
+        for id in STRUCTURE_NAMES {
+            // Populate scenes
             let structure_id = Id::new(id);
             let structure_path = format!("structures/{id}.gltf#Scene0");
             let scene = asset_server.load(structure_path);

--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -81,7 +81,7 @@ impl Loadable for StructureHandles {
     fn load_state(&self, asset_server: &AssetServer) -> LoadState {
         for (structure, scene_handle) in &self.scenes {
             let scene_load_state = asset_server.get_load_state(scene_handle);
-            info!("{structure:?}'s scene is {scene_load_state:?}");
+            info!("{structure}'s scene is {scene_load_state:?}");
 
             if scene_load_state != LoadState::Loaded {
                 return scene_load_state;

--- a/emergence_lib/src/asset_management/units.rs
+++ b/emergence_lib/src/asset_management/units.rs
@@ -55,7 +55,7 @@ impl Loadable for UnitHandles {
     fn load_state(&self, asset_server: &AssetServer) -> LoadState {
         for (unit, scene_handle) in &self.scenes {
             let scene_load_state = asset_server.get_load_state(scene_handle);
-            info!("{unit:?}'s scene is {scene_load_state:?}");
+            info!("{unit}'s scene is {scene_load_state:?}");
 
             if scene_load_state != LoadState::Loaded {
                 return scene_load_state;

--- a/emergence_lib/src/graphics/icons.rs
+++ b/emergence_lib/src/graphics/icons.rs
@@ -16,12 +16,9 @@ use crate::asset_management::structures::StructureHandles;
 
 /// The render layer used to draw icons.
 const ICON_LAYER: RenderLayers = RenderLayers::layer(1);
-const ICON_SIZE: Extent3d = Extent3d {
-    width: 512,
-    height: 512,
-    // The default value
-    depth_or_array_layers: 1,
-};
+
+/// The base width of all icons.
+pub(crate) const ICON_SIZE: f32 = 64.0;
 
 pub(super) fn spawn_icon_camera(mut commands: Commands) {
     commands.spawn((
@@ -56,6 +53,14 @@ pub(super) fn generate_icons(
     mut image_assets: ResMut<Assets<Image>>,
     mut commands: Commands,
 ) {
+    /// The extents of the image to render to
+    const ICON_IMAGE_EXTENTS: Extent3d = Extent3d {
+        width: ICON_SIZE as u32,
+        height: ICON_SIZE as u32,
+        // The default value
+        depth_or_array_layers: 1,
+    };
+
     // Despawn any old icon scene
     if let Some(scene_root) = *maybe_scene_root {
         commands.entity(scene_root).despawn_recursive();
@@ -75,7 +80,7 @@ pub(super) fn generate_icons(
             let mut image = Image {
                 texture_descriptor: TextureDescriptor {
                     label: None,
-                    size: ICON_SIZE,
+                    size: ICON_IMAGE_EXTENTS,
                     dimension: TextureDimension::D2,
                     format: TextureFormat::Bgra8UnormSrgb,
                     mip_level_count: 1,
@@ -88,7 +93,7 @@ pub(super) fn generate_icons(
             };
 
             // Fill it with zeros
-            image.resize(ICON_SIZE);
+            image.resize(ICON_IMAGE_EXTENTS);
 
             // Spawn the scene to draw
             let scene_root = commands

--- a/emergence_lib/src/graphics/icons.rs
+++ b/emergence_lib/src/graphics/icons.rs
@@ -12,7 +12,7 @@ use bevy::{
     },
 };
 
-use crate::asset_management::structures::StructureHandles;
+use crate::asset_management::{structures::StructureHandles, AssetState};
 
 /// The render layer used to draw icons.
 const ICON_LAYER: RenderLayers = RenderLayers::layer(1);
@@ -52,7 +52,15 @@ pub(super) fn generate_icons(
     mut maybe_scene_root: Local<Option<Entity>>,
     mut image_assets: ResMut<Assets<Image>>,
     mut commands: Commands,
+    asset_state: Res<State<AssetState>>,
 ) {
+    // TODO: use a real run condition post stageless
+    // It's awful to try and manage this before that because states are bound to a single stage lol
+    if *asset_state.current() != AssetState::Ready {
+        info!("Assets are not yet loaded");
+        return;
+    }
+
     /// The extents of the image to render to
     const ICON_IMAGE_EXTENTS: Extent3d = Extent3d {
         width: ICON_SIZE as u32,

--- a/emergence_lib/src/graphics/icons.rs
+++ b/emergence_lib/src/graphics/icons.rs
@@ -57,6 +57,8 @@ pub(super) fn generate_icons(
 
     for (structure_id, scene) in structure_handles.scenes.iter() {
         if !structure_handles.icons.contains_key(structure_id) {
+            info!("Drawing icon for {structure_id}");
+
             // Spawn the scene to draw
             let scene_root = commands
                 .spawn((

--- a/emergence_lib/src/graphics/icons.rs
+++ b/emergence_lib/src/graphics/icons.rs
@@ -46,7 +46,7 @@ pub(super) fn generate_icons(
 ) {
     // Despawn any old icon scene
     if let Some(scene_root) = *maybe_scene_root {
-        commands.entity(scene_root).despawn();
+        commands.entity(scene_root).despawn_recursive();
         *maybe_scene_root = None;
     }
 

--- a/emergence_lib/src/graphics/icons.rs
+++ b/emergence_lib/src/graphics/icons.rs
@@ -1,0 +1,90 @@
+//! Generates icons from rendered 3D views
+
+use bevy::{
+    core_pipeline::clear_color::ClearColorConfig,
+    prelude::*,
+    render::{camera::RenderTarget, view::RenderLayers},
+};
+
+use crate::asset_management::structures::StructureHandles;
+
+/// The render layer used to draw icons.
+const ICON_LAYER: RenderLayers = RenderLayers::layer(1);
+
+pub(super) fn spawn_icon_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera3dBundle {
+            camera_3d: Camera3d {
+                // Set a white background
+                clear_color: ClearColorConfig::Custom(Color::WHITE),
+                ..default()
+            },
+            camera: Camera {
+                // Don't render to anything unless it's told to
+                target: RenderTarget::Image(Handle::default()),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
+                .looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        IconCamera,
+        ICON_LAYER,
+    ));
+}
+
+#[derive(Component)]
+pub(super) struct IconCamera;
+
+/// Spawn a scene that does not currently have an icon, and set it up to be rendered to the correct texture
+pub(super) fn generate_icons(
+    mut structure_handles: ResMut<StructureHandles>,
+    mut camera_query: Query<&mut Camera, With<IconCamera>>,
+    mut maybe_scene_root: Local<Option<Entity>>,
+    mut image_assets: ResMut<Assets<Image>>,
+    mut commands: Commands,
+) {
+    // Despawn any old icon scene
+    if let Some(scene_root) = *maybe_scene_root {
+        commands.entity(scene_root).despawn();
+        *maybe_scene_root = None;
+    }
+
+    let mut icon_camera = camera_query.single_mut();
+
+    let mut maybe_icon_structure_id = None;
+    let mut maybe_new_icon = None;
+
+    for (structure_id, scene) in structure_handles.scenes.iter() {
+        if !structure_handles.icons.contains_key(structure_id) {
+            // Spawn the scene to draw
+            let scene_root = commands
+                .spawn((
+                    ICON_LAYER,
+                    SceneBundle {
+                        scene: scene.clone_weak(),
+                        ..default()
+                    },
+                ))
+                .id();
+
+            *maybe_scene_root = Some(scene_root);
+
+            // Set the camera to draw to the correct image
+            let image_handle = image_assets.add(Image::default());
+            icon_camera.target = RenderTarget::Image(image_handle.clone_weak());
+            maybe_icon_structure_id = Some(*structure_id);
+            maybe_new_icon = Some(image_handle);
+
+            // Only try and draw one icon per frame
+            break;
+        }
+    }
+
+    if let (Some(icon_structure_id), Some(new_icon)) = (maybe_icon_structure_id, maybe_new_icon) {
+        structure_handles.icons.insert(icon_structure_id, new_icon);
+    } else {
+        // If all of the icons are rendered, draw to nothing
+        icon_camera.target = RenderTarget::Image(Handle::default());
+    }
+}

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -22,11 +22,10 @@ impl Plugin for GraphicsPlugin {
         app.add_plugin(LightingPlugin)
             .add_startup_system(spawn_icon_camera)
             .add_system_set(
-                SystemSet::on_update(AssetState::Ready)
-                    .with_system(units::display_held_item)
-                    .with_system(icons::generate_icons),
+                SystemSet::on_update(AssetState::Ready).with_system(units::display_held_item),
             )
             .add_system_to_stage(CoreStage::PostUpdate, inherit_materials)
+            .add_system_to_stage(CoreStage::Last, icons::generate_icons)
             .add_system(selection::display_tile_interactions.after(InteractionSystem::SelectTiles));
     }
 }

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -6,7 +6,7 @@ use crate::{asset_management::AssetState, player_interaction::InteractionSystem}
 
 use self::{icons::spawn_icon_camera, lighting::LightingPlugin};
 
-mod icons;
+pub(crate) mod icons;
 mod lighting;
 mod selection;
 mod structures;

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -4,8 +4,9 @@ use bevy::prelude::*;
 
 use crate::{asset_management::AssetState, player_interaction::InteractionSystem};
 
-use self::lighting::LightingPlugin;
+use self::{icons::spawn_icon_camera, lighting::LightingPlugin};
 
+mod icons;
 mod lighting;
 mod selection;
 mod structures;
@@ -19,8 +20,11 @@ pub struct GraphicsPlugin;
 impl Plugin for GraphicsPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(LightingPlugin)
+            .add_startup_system(spawn_icon_camera)
             .add_system_set(
-                SystemSet::on_update(AssetState::Ready).with_system(units::display_held_item),
+                SystemSet::on_update(AssetState::Ready)
+                    .with_system(units::display_held_item)
+                    .with_system(icons::generate_icons),
             )
             .add_system_to_stage(CoreStage::PostUpdate, inherit_materials)
             .add_system(selection::display_tile_interactions.after(InteractionSystem::SelectTiles));

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -44,8 +44,6 @@ pub(crate) struct StructureData {
     construction_materials: InputInventory,
     /// The set of terrain types that this structure can be built on
     pub(crate) allowed_terrain_types: HashSet<Terrain>,
-    /// The color associated with this structure
-    pub(crate) color: Color,
 }
 
 impl StructureData {
@@ -79,7 +77,6 @@ impl Default for StructureManifest {
                 starting_recipe: ActiveRecipe::new(Id::leuco_chunk_production()),
                 construction_materials: leuco_construction_materials,
                 allowed_terrain_types: HashSet::from_iter([Terrain::Plain, Terrain::Muddy]),
-                color: Color::ORANGE_RED,
             },
         );
 
@@ -97,7 +94,6 @@ impl Default for StructureManifest {
                 starting_recipe: ActiveRecipe::new(Id::acacia_leaf_production()),
                 construction_materials: acacia_construction_materials,
                 allowed_terrain_types: HashSet::from_iter([Terrain::Plain, Terrain::Muddy]),
-                color: Color::GREEN,
             },
         );
 
@@ -113,7 +109,6 @@ impl Default for StructureManifest {
                     Terrain::Muddy,
                     Terrain::Rocky,
                 ]),
-                color: Color::BEIGE,
             },
         );
 
@@ -125,7 +120,6 @@ impl Default for StructureManifest {
                 starting_recipe: ActiveRecipe::new(Id::hatch_ants()),
                 construction_materials: InputInventory::default(),
                 allowed_terrain_types: HashSet::from_iter([Terrain::Plain, Terrain::Rocky]),
-                color: Color::BLUE,
             },
         );
 

--- a/emergence_lib/src/ui/select_structure.rs
+++ b/emergence_lib/src/ui/select_structure.rs
@@ -7,6 +7,7 @@ use leafwing_input_manager::prelude::ActionState;
 use crate::{
     asset_management::{
         manifest::{Id, Structure, StructureManifest},
+        palette::UNSELECTED_UI_COLOR,
         structures::StructureHandles,
     },
     graphics::icons::ICON_SIZE,
@@ -265,9 +266,9 @@ fn handle_selection(
             } else {
                 for (icon_entity, _structure_id, mut background_color) in icon_query.iter_mut() {
                     if icon_entity == data.icon_entity {
-                        *background_color = BackgroundColor(Color::ANTIQUE_WHITE);
+                        *background_color = BackgroundColor(Color::WHITE);
                     } else {
-                        *background_color = BackgroundColor(Color::NONE);
+                        *background_color = BackgroundColor(UNSELECTED_UI_COLOR);
                     }
                 }
             }
@@ -279,7 +280,7 @@ fn handle_selection(
                 cleanup(commands, menu_query);
             } else {
                 for (.., mut background_color) in icon_query.iter_mut() {
-                    *background_color = BackgroundColor(Color::NONE);
+                    *background_color = BackgroundColor(UNSELECTED_UI_COLOR);
                 }
             }
         }

--- a/emergence_lib/src/ui/select_structure.rs
+++ b/emergence_lib/src/ui/select_structure.rs
@@ -9,6 +9,7 @@ use crate::{
         manifest::{Id, Structure, StructureManifest},
         structures::StructureHandles,
     },
+    graphics::icons::ICON_SIZE,
     player_interaction::{
         clipboard::{Clipboard, ClipboardData},
         cursor::CursorPos,
@@ -16,6 +17,9 @@ use crate::{
     },
     simulation::geometry::Facing,
 };
+
+/// The diameter of hexes used in this menu.
+const HEX_SIZE: f32 = ICON_SIZE;
 
 /// Hex menu and selection modifying logic.
 pub(super) struct SelectStructurePlugin;
@@ -94,9 +98,6 @@ fn spawn_hex_menu(
     structure_manifest: Res<StructureManifest>,
     structure_handles: Res<StructureHandles>,
 ) {
-    /// The size of the hexes used in this menu.
-    const HEX_SIZE: f32 = 64.0;
-
     if actions.just_pressed(PlayerAction::SelectStructure) {
         if let Some(cursor_pos) = cursor_pos.maybe_screen_pos() {
             let mut arrangement = HexMenuArrangement {


### PR DESCRIPTION
Fixes #322.

Trying to get the render-to-texture approach going, but it's currently not working.

Debugging steps:

- [x] systems are running. Yes!
- [x] camera can render anything. Yes, because I can set it to just render to the window and see the clear color.
- [ ] camera can see objects spawned. No: nothing is seen when rendering to the window.
  - [x] camera position is correct (I mean, they're a bit small...)
  - [ ] render layers don't appear to be inherited
  - [ ] objects are not spawned by the time the screenshot is taken
- [x] setting the textures in `StructureHandles` changes the icons in the menu. ~~No, at least not with `Image::default`.~~ Fixed by setting the `background_color` of the ImageNode to white.
- [x] the textures are being set correctly from the camera. Probably not, as the camera seems to be rendering something.


To do:e
- [ ] actually display the structure...
- [ ] figure out why this is broken randomly (hi ambiguities...)
- [x] re-add the nice "change colors on highlight" effect