### PR TITLE
Add impatience mechanic again

### DIFF
--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -728,6 +728,7 @@ fn get_details(
                 held_item: unit_query_item.held_item.clone(),
                 goal: unit_query_item.goal.clone(),
                 action: unit_query_item.action.clone(),
+                impatience_pool: unit_query_item.impatience_pool.clone(),
                 organism_details,
             })
         }
@@ -999,7 +1000,7 @@ mod terrain_details {
         pub(super) terrain_type: &'static Terrain,
     }
 
-    /// Detailed info about a given unit.
+    /// Detailed info about a given piece of terrain.
     #[derive(Debug)]
     pub(crate) struct TerrainDetails {
         /// The root entity
@@ -1039,7 +1040,10 @@ mod unit_details {
     use crate::{
         asset_management::manifest::{Id, Unit},
         simulation::geometry::TilePos,
-        units::{actions::CurrentAction, goals::Goal, item_interaction::UnitInventory},
+        units::{
+            actions::CurrentAction, goals::Goal, impatience::ImpatiencePool,
+            item_interaction::UnitInventory,
+        },
     };
 
     use super::organism_details::OrganismDetails;
@@ -1059,6 +1063,8 @@ mod unit_details {
         pub(super) goal: &'static Goal,
         /// What is currently being done
         pub(super) action: &'static CurrentAction,
+        /// How frustrated the unit is
+        pub(super) impatience_pool: &'static ImpatiencePool,
     }
 
     /// Detailed info about a given unit.
@@ -1078,6 +1084,8 @@ mod unit_details {
         pub(super) action: CurrentAction,
         /// Details about this organism, if it is one.
         pub(crate) organism_details: OrganismDetails,
+        /// How frustrated the unit is
+        pub(super) impatience_pool: ImpatiencePool,
     }
 
     impl Display for UnitDetails {
@@ -1088,6 +1096,7 @@ mod unit_details {
             let held_item = &self.held_item;
             let goal = &self.goal;
             let action = &self.action;
+            let impatience_pool = &self.impatience_pool;
             let organism_details = &self.organism_details;
 
             write!(
@@ -1098,6 +1107,7 @@ Tile: {tile_pos}
 Holding: {held_item}
 Goal: {goal}
 Action: {action}
+Impatience: {impatience_pool}
 {organism_details}"
             )
         }

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -15,7 +15,9 @@ use crate::{
     terrain::Terrain,
 };
 
-use super::{goals::Goal, hunger::Diet, item_interaction::UnitInventory};
+use super::{
+    goals::Goal, hunger::Diet, impatience::ImpatiencePool, item_interaction::UnitInventory,
+};
 
 /// Ticks the timer for each [`CurrentAction`].
 pub(super) fn advance_action_timer(mut units_query: Query<&mut CurrentAction>, time: Res<Time>) {
@@ -139,7 +141,9 @@ pub(super) fn handle_actions(
     for mut unit in unit_query.iter_mut() {
         if unit.action.finished() {
             match unit.action.action() {
-                UnitAction::Idle => (),
+                UnitAction::Idle => {
+                    unit.impatience.increment();
+                }
                 UnitAction::PickUp {
                     item_id,
                     output_entity,
@@ -262,6 +266,8 @@ pub(super) struct ActionDataQuery {
     diet: &'static Diet,
     /// How much energy the unit has
     energy_pool: &'static mut EnergyPool,
+    /// How frustrated this unit is about not being able to progress towards its goal
+    impatience: &'static mut ImpatiencePool,
     /// The direction this unit is facing
     facing: &'static mut Facing,
 }

--- a/emergence_lib/src/units/impatience.rs
+++ b/emergence_lib/src/units/impatience.rs
@@ -1,3 +1,6 @@
+//! Tracks impatience (frustration) of units,
+//! causing them to give up impossible tasks.
+
 use bevy::prelude::*;
 use core::fmt::Display;
 

--- a/emergence_lib/src/units/impatience.rs
+++ b/emergence_lib/src/units/impatience.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+use core::fmt::Display;
+
+/// The patience of a unit.
+///
+/// If current >= max, they will abandon their current goal.
+#[derive(Debug, Clone, PartialEq, Component, Resource)]
+pub(crate) struct ImpatiencePool {
+    /// The current impatience of this unit.
+    current: u8,
+    /// The maximum impatience of this unit.
+    max: u8,
+}
+
+impl ImpatiencePool {
+    /// Creates a new impatience pool with the provided `max` value.
+    pub(super) fn new(max: u8) -> Self {
+        ImpatiencePool { current: 0, max }
+    }
+
+    /// Is this unit out of patience?
+    pub(super) fn is_full(&self) -> bool {
+        self.current >= self.max
+    }
+
+    /// Increase the current impatience by 1
+    pub(super) fn increment(&mut self) {
+        self.current += 1;
+    }
+
+    /// Resets the current impatience to 0
+    pub(super) fn reset(&mut self) {
+        self.current = 0;
+    }
+}
+
+impl Display for ImpatiencePool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.current, self.max)
+    }
+}


### PR DESCRIPTION
Apparently essential for preventing subtle dead locks. Fixes #458 and dramatically improves gameplay.