### PR TITLE
Remove neglect mechanic

### DIFF
--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -661,14 +661,13 @@ fn get_details(
                 structure_id: *ghost_query_item.structure_id,
                 input_inventory: ghost_query_item.input_inventory.clone(),
                 crafting_state: ghost_query_item.crafting_state.clone(),
-                neglect: ghost_query_item.emitter.neglect_multiplier,
                 active_recipe: ghost_query_item.active_recipe.clone(),
             })
         }
         CurrentSelection::Structure(structure_entity) => {
             let structure_query_item = structure_query.get(*structure_entity)?;
 
-            let crafting_details = if let Some((input, output, active_recipe, state, emitter)) =
+            let crafting_details = if let Some((input, output, active_recipe, state)) =
                 structure_query_item.crafting
             {
                 let maybe_recipe_id = *active_recipe.recipe_id();
@@ -680,7 +679,6 @@ fn get_details(
                     output_inventory: output.inventory.clone(),
                     recipe,
                     state: state.clone(),
-                    neglect: emitter.neglect_multiplier,
                 })
             } else {
                 None
@@ -795,8 +793,6 @@ mod ghost_details {
         pub(super) input_inventory: InputInventory,
         /// The ghost's progress through construction
         pub(super) crafting_state: CraftingState,
-        /// The neglect multiplier of this ghost
-        pub(super) neglect: f32,
         /// The recipe that will be crafted when the structure is first built
         pub(super) active_recipe: ActiveRecipe,
     }
@@ -808,7 +804,6 @@ mod ghost_details {
             let tile_pos = &self.tile_pos;
             let input_inventory = &*self.input_inventory;
             let crafting_state = &self.crafting_state;
-            let neglect = self.neglect;
             let recipe = &self.active_recipe;
 
             let string = format!(
@@ -817,8 +812,7 @@ mod ghost_details {
 Ghost structure type: {structure_id}
 Recipe: {recipe}
 Construction materials: {input_inventory}
-{crafting_state}
-Neglect: {neglect:.2}"
+{crafting_state}"
             );
 
             write!(f, "{string}")
@@ -876,7 +870,6 @@ mod structure_details {
     use crate::{
         asset_management::manifest::{Id, Structure},
         items::{inventory::Inventory, recipe::RecipeData},
-        signals::Emitter,
         simulation::geometry::TilePos,
         structures::crafting::{ActiveRecipe, CraftingState, InputInventory, OutputInventory},
     };
@@ -896,7 +889,6 @@ mod structure_details {
             &'static OutputInventory,
             &'static ActiveRecipe,
             &'static CraftingState,
-            &'static Emitter,
         )>,
     }
 
@@ -955,9 +947,6 @@ Tile: {tile_pos}"
 
         /// The state of the ongoing crafting process.
         pub(crate) state: CraftingState,
-
-        /// The neglect multiplier of the structure
-        pub(crate) neglect: f32,
     }
 
     impl Display for CraftingDetails {
@@ -965,7 +954,6 @@ Tile: {tile_pos}"
             let input_inventory = &self.input_inventory;
             let output_inventory = &self.output_inventory;
             let crafting_state = &self.state;
-            let neglect = self.neglect;
 
             let recipe_string = match &self.recipe {
                 Some(recipe) => format!("{recipe}"),
@@ -977,8 +965,7 @@ Tile: {tile_pos}"
                 "Recipe: {recipe_string}
 Input: {input_inventory}
 {crafting_state}
-Output: {output_inventory}
-Neglect: {neglect:.2}"
+Output: {output_inventory}"
             )
         }
     }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -288,18 +288,10 @@ impl Mul<f32> for SignalStrength {
 /// The component that causes a game object to emit a signal.
 ///
 /// This can change over time, and multiple signals may be emitted at once.
-#[derive(Component, Debug, Clone)]
+#[derive(Default, Component, Debug, Clone)]
 pub(crate) struct Emitter {
     /// The list of signals to emit at a provided
     pub(crate) signals: Vec<(SignalType, SignalStrength)>,
-}
-
-impl Default for Emitter {
-    fn default() -> Self {
-        Emitter {
-            signals: Vec::new(),
-        }
-    }
 }
 
 /// Emits signals from [`Emitter`] sources.

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -292,17 +292,12 @@ impl Mul<f32> for SignalStrength {
 pub(crate) struct Emitter {
     /// The list of signals to emit at a provided
     pub(crate) signals: Vec<(SignalType, SignalStrength)>,
-    /// A multiplier on any signals emitted.
-    ///
-    /// Increases over time as needs are ignored.
-    pub(crate) neglect_multiplier: f32,
 }
 
 impl Default for Emitter {
     fn default() -> Self {
         Emitter {
             signals: Vec::new(),
-            neglect_multiplier: 1.,
         }
     }
 }
@@ -311,11 +306,7 @@ impl Default for Emitter {
 fn emit_signals(mut signals: ResMut<Signals>, emitter_query: Query<(&TilePos, &Emitter)>) {
     for (&tile_pos, emitter) in emitter_query.iter() {
         for (signal_type, signal_strength) in &emitter.signals {
-            signals.add_signal(
-                *signal_type,
-                tile_pos,
-                *signal_strength * emitter.neglect_multiplier,
-            );
+            signals.add_signal(*signal_type, tile_pos, *signal_strength);
         }
     }
 }

--- a/emergence_lib/src/structures/ghost.rs
+++ b/emergence_lib/src/structures/ghost.rs
@@ -189,16 +189,8 @@ pub(super) fn ghost_signals(
         With<Ghost>,
     >,
 ) {
-    /// The rate at which neglect grows for each cycle
-    ///
-    /// Should be positive.
-    const NEGLECT_RATE: f32 = 0.05;
-
     // Ghosts that are ignored will slowly become more important to build.
     for (&structure_id, mut emitter, crafting_state, input_inventory) in ghost_query.iter_mut() {
-        // Always increase neglect over time
-        emitter.neglect_multiplier += NEGLECT_RATE;
-
         if crafting_state.is_changed() {
             match *crafting_state {
                 CraftingState::NeedsInput => {


### PR DESCRIPTION
This is much simpler, easier to intuit and reason about, and the basic loop is still functioning smoothly.

We're still running into some difficulties with ghosts placed off the beaten path never getting built, but I think that's better solved with other tools.

Fixes #471.