### PR TITLE
start camera at correct location

### DIFF
--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -217,7 +217,7 @@ impl Facing {
 impl Default for Facing {
     fn default() -> Self {
         Facing {
-            direction: Direction::Top,
+            direction: Direction::TopRight,
         }
     }
 }


### PR DESCRIPTION
#419 + 1

The default for Facing conflicts with the default Local<f32> for the camera goal system. 

This could also get fixed by calculating the initial intermediate_planar_angle on first call (likely detect a 0.0 time-delta) to match whatever initial Facing is passed, or pull the intermediate_planar_angle out to something in our control (not the bevy Local initializer etc etc) 🤷‍♂️ . 

This likely doesn't matter unless camera angle being saved off in scenes for continuity (some city builders do stuff like that). With this fix, if we serialize Facing, re-loading the scene will cause an up 180 degree pivot initially 😵‍💫.