### PR TITLE
Improve signal and action logic to reduce cases of stuck ants

### DIFF
--- a/emergence_lib/src/asset_management/manifest.rs
+++ b/emergence_lib/src/asset_management/manifest.rs
@@ -78,7 +78,7 @@ mod identifier {
 
     impl<T> Id<T> {
         /// Creates a new identifier from a static-lifetime string.
-        pub(crate) fn new(str: &'static str) -> Id<T> {
+        pub(crate) const fn new(str: &'static str) -> Id<T> {
             Id {
                 str,
                 _phantom: PhantomData,

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -42,6 +42,12 @@ impl Display for TilePos {
 }
 
 impl TilePos {
+    /// The position of the central tile
+    #[allow(dead_code)]
+    pub(crate) const ORIGIN: TilePos = TilePos {
+        hex: Hex { x: 0, y: 0 },
+    };
+
     /// Generates a new [`TilePos`] from axial coordinates.
     #[cfg(test)]
     pub(crate) fn new(x: i32, y: i32) -> Self {
@@ -141,6 +147,20 @@ pub(crate) struct MapGeometry {
 }
 
 impl MapGeometry {
+    /// Creates a new [`MapGeometry`] of the provided raidus.
+    ///
+    /// All indexes will be empty.
+    pub(crate) fn new(radius: u32) -> Self {
+        MapGeometry {
+            layout: HexLayout::default(),
+            radius,
+            terrain_index: HashMap::default(),
+            structure_index: HashMap::default(),
+            ghost_index: HashMap::default(),
+            preview_index: HashMap::default(),
+            height_index: HashMap::default(),
+        }
+    }
     /// Is the provided `tile_pos` in the map?
     pub(crate) fn is_valid(&self, tile_pos: TilePos) -> bool {
         let distance = Hex::ZERO.distance_to(tile_pos.hex);
@@ -172,21 +192,6 @@ impl MapGeometry {
             Some(structure_entity)
         } else {
             None
-        }
-    }
-}
-
-impl MapGeometry {
-    /// Initializes the geometry for a new map.
-    pub(super) fn new(radius: u32) -> Self {
-        MapGeometry {
-            layout: HexLayout::default(),
-            radius,
-            terrain_index: HashMap::default(),
-            structure_index: HashMap::default(),
-            ghost_index: HashMap::default(),
-            preview_index: HashMap::default(),
-            height_index: HashMap::default(),
         }
     }
 }

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -504,6 +504,12 @@ impl CurrentAction {
         let ahead = unit_tile_pos.neighbor(facing.direction);
         if let Some(workplace) = workplace_query.needs_work(ahead, structure_id, map_geometry) {
             CurrentAction::work(workplace)
+        // Let units work even if they're standing on the structure
+        // This is particularly relevant in the case of ghosts, where it's easy enough to end up on top of the structure trying to work on it
+        } else if let Some(workplace) =
+            workplace_query.needs_work(unit_tile_pos, structure_id, map_geometry)
+        {
+            CurrentAction::work(workplace)
         } else {
             let neighboring_tiles = unit_tile_pos.all_neighbors(map_geometry);
             let mut workplaces: Vec<(Entity, TilePos)> = Vec::new();

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -167,6 +167,9 @@ pub(super) fn handle_actions(
                                 }
                             }
                         }
+                    } else {
+                        // If the target isn't there, pick a new goal
+                        *unit.goal = Goal::Wander;
                     }
                 }
                 UnitAction::DropOff {
@@ -197,6 +200,9 @@ pub(super) fn handle_actions(
                                 }
                             }
                         }
+                    } else {
+                        // If the target isn't there, pick a new goal
+                        *unit.goal = Goal::Wander;
                     }
                 }
                 UnitAction::Spin { rotation_direction } => match rotation_direction {


### PR DESCRIPTION
There were two distinct failure modes here:

1. Units wouldn't idle when at the peak of their signal type: this was a straightforward logic bug, identified via the new tests.
2. Units would get stuck while on top of ghosts that they were trying to build.

We're still really lacking some anti-clumping and work discovery mechanics, but there's some real progress here!