### PR TITLE
Use u64 values for IDs instead of strings

### DIFF
--- a/emergence_lib/src/asset_management/manifest/identifier.rs
+++ b/emergence_lib/src/asset_management/manifest/identifier.rs
@@ -38,7 +38,8 @@ const HASH_P: u64 = 53;
 const HASH_M: u64 = 1_000_000_009;
 
 impl<T> Id<T> {
-    pub(crate) fn new(value: u64) -> Self {
+    /// Create a new identifier from the given unique number.
+    pub(crate) const fn new(value: u64) -> Self {
         Self {
             value,
             _phantom: PhantomData,

--- a/emergence_lib/src/asset_management/manifest/identifier.rs
+++ b/emergence_lib/src/asset_management/manifest/identifier.rs
@@ -16,31 +16,62 @@ use std::{
 /// It can be stored as a component to identify the variety of game object used.
 #[derive(Component, Serialize, Deserialize)]
 pub(crate) struct Id<T> {
-    /// The internal string
-    str: &'static str,
+    /// The unique identifier.
+    ///
+    /// This is usually the hash of a string identifier used in the manifest files.
+    /// The number value is used to handle the data more efficiently in the game.
+    value: u64,
+
     /// Marker to make the compiler happy
     _phantom: PhantomData<T>,
 }
 
+/// A constant used in the hashing algorithm of the IDs.
+///
+/// This should be a positive prime number, roughly equal to the number of characters in the input alphabet.
+const HASH_P: u64 = 53;
+
+/// A constant used in the hashing algorithm of the IDs.
+///
+/// This should be a large prime number as it is used for modulo operations.
+/// Larger numbers have a lower chance of a hash collision.
+const HASH_M: u64 = 1_000_000_009;
+
 impl<T> Id<T> {
-    /// Creates a new identifier from a static-lifetime string.
-    pub(crate) const fn new(str: &'static str) -> Id<T> {
-        Id {
-            str,
+    pub(crate) fn new(value: u64) -> Self {
+        Self {
+            value,
             _phantom: PhantomData,
         }
+    }
+
+    /// Creates a new ID from human-readable string identifier.
+    ///
+    /// This ID is created as a hash of the string.
+    pub(crate) fn from_string_id(str: &'static str) -> Self {
+        // Algorithm adopted from <https://cp-algorithms.com/string/string-hashing.html>
+
+        let mut value = 0;
+        let mut p_pow = 1;
+
+        str.bytes().for_each(|byte| {
+            value = (value + (byte as u64 + 1) * p_pow) % HASH_M;
+            p_pow = (p_pow * HASH_P) % HASH_M;
+        });
+
+        Self::new(value)
     }
 }
 
 impl<T> Debug for Id<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Id").field("str", &self.str).finish()
+        f.debug_struct("Id").field("value", &self.value).finish()
     }
 }
 
 impl<T> PartialEq for Id<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.str == other.str
+        self.value == other.value
     }
 }
 
@@ -48,26 +79,26 @@ impl<T> Eq for Id<T> {}
 
 impl<T> PartialOrd for Id<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.str.partial_cmp(other.str)
+        self.value.partial_cmp(&other.value)
     }
 }
 
 impl<T> Ord for Id<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.str.cmp(other.str)
+        self.value.cmp(&other.value)
     }
 }
 
 impl<T> Hash for Id<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.str.hash(state);
+        self.value.hash(state);
     }
 }
 
 impl<T> Clone for Id<T> {
     fn clone(&self) -> Self {
         Self {
-            str: self.str,
+            value: self.value,
             _phantom: PhantomData,
         }
     }
@@ -77,6 +108,6 @@ impl<T> Copy for Id<T> {}
 
 impl<T> Display for Id<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.str)
+        write!(f, "#{}", self.value)
     }
 }

--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -63,7 +63,7 @@ impl FromWorld for StructureHandles {
         let structure_names = vec!["acacia", "leuco", "ant_hive", "hatchery"];
 
         for id in structure_names {
-            let structure_id = Id::new(id);
+            let structure_id = Id::from_string_id(id);
             let structure_path = format!("structures/{id}.gltf#Scene0");
             let scene = asset_server.load(structure_path);
             handles.scenes.insert(structure_id, scene);

--- a/emergence_lib/src/asset_management/units.rs
+++ b/emergence_lib/src/asset_management/units.rs
@@ -41,7 +41,7 @@ impl FromWorld for UnitHandles {
         let unit_names = vec!["ant"];
 
         for str in unit_names {
-            let structure_id = Id::new(str);
+            let structure_id = Id::from_string_id(str);
             let structure_path = format!("units/{str}.gltf#Scene0");
             let scene = asset_server.load(structure_path);
             handles.scenes.insert(structure_id, scene);

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -579,7 +579,7 @@ mod tests {
                 slots: vec![ItemSlot::new_with_count(Id::acacia_leaf(), 10, 5)],
             };
 
-            assert_eq!(format!("{inventory}"), "[acacia_leaf (5/10)]".to_string());
+            assert_eq!(format!("{inventory}"), "[#104638856 (5/10)]".to_string());
         }
     }
 

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -110,9 +110,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_display_item_type_and_count() {
+    fn should_display_item_id_and_count() {
         let item_count = ItemCount::new(Id::acacia_leaf(), 3);
 
-        assert_eq!(format!("{item_count}"), "acacia_leaf (3)".to_string());
+        assert_eq!(format!("{item_count}"), "#104638856 (3)".to_string());
     }
 }

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -15,23 +15,23 @@ pub(crate) mod slot;
 impl Id<Item> {
     /// The item ID of an Acacia leaf.
     pub fn acacia_leaf() -> Self {
-        Self::new("acacia_leaf")
+        Self::from_string_id("acacia_leaf")
     }
 
     /// The item ID of a Leuco chunk.
     pub fn leuco_chunk() -> Self {
-        Self::new("leuco_chunk")
+        Self::from_string_id("leuco_chunk")
     }
 
     /// The item ID of an ant egg.
     pub fn ant_egg() -> Self {
-        Self::new("ant_egg")
+        Self::from_string_id("ant_egg")
     }
 
     /// An item ID solely used for testing.
     #[cfg(test)]
     pub fn test() -> Self {
-        Self::new("test")
+        Self::from_string_id("test")
     }
 }
 

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -197,6 +197,6 @@ mod tests {
             energy: Some(Energy(20.)),
         };
 
-        assert_eq!(format!("{recipe}"), "[] -> [acacia_leaf (1)] | 1.00 s")
+        assert_eq!(format!("{recipe}"), "[] -> [#104638856 (1)] | 1.00 s")
     }
 }

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -14,22 +14,22 @@ use super::{inventory::Inventory, ItemCount};
 impl Id<Recipe> {
     /// The ID of the recipe for the leaf production of acacia plants.
     pub fn acacia_leaf_production() -> Self {
-        Self::new("acacia_leaf_production")
+        Self::from_string_id("acacia_leaf_production")
     }
 
     /// The ID of the recipe for mushroom production of leuco mushrooms.
     pub fn leuco_chunk_production() -> Self {
-        Self::new("leuco_chunk_production")
+        Self::from_string_id("leuco_chunk_production")
     }
 
     /// The ID of the recipe to make more ant eggs from leuco mushrooms.
     pub fn ant_egg_production() -> Self {
-        Self::new("ant_egg_production")
+        Self::from_string_id("ant_egg_production")
     }
 
     /// The ID of the recipe to hatch ant eggs into adult ants.
     pub fn hatch_ants() -> Self {
-        Self::new("hatch_ants")
+        Self::from_string_id("hatch_ants")
     }
 }
 

--- a/emergence_lib/src/items/slot.rs
+++ b/emergence_lib/src/items/slot.rs
@@ -194,7 +194,7 @@ mod tests {
     fn should_display_item_type_count_and_capacity_for_empty_slot() {
         let item_slot = ItemSlot::new(Id::acacia_leaf(), 10);
 
-        assert_eq!(format!("{item_slot}"), "acacia_leaf (0/10)".to_string());
+        assert_eq!(format!("{item_slot}"), "#104638856 (0/10)".to_string());
     }
 
     #[test]
@@ -205,7 +205,7 @@ mod tests {
             count: 6,
         };
 
-        assert_eq!(format!("{item_slot}"), "acacia_leaf (6/10)".to_string());
+        assert_eq!(format!("{item_slot}"), "#104638856 (6/10)".to_string());
     }
 
     #[test]

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -398,8 +398,8 @@ fn degrade_signals(mut signals: ResMut<Signals>) {
 mod tests {
     use super::*;
 
-    const TEST_ITEM: Id<Item> = Id::new("test_item");
-    const TEST_STRUCTURE: Id<Structure> = Id::new("test_structure");
+    const TEST_ITEM: Id<Item> = Id::from_string_id("test_item");
+    const TEST_STRUCTURE: Id<Structure> = Id::from_string_id("test_structure");
 
     #[test]
     fn neighboring_signals_checks_origin_tile() {

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -398,8 +398,8 @@ fn degrade_signals(mut signals: ResMut<Signals>) {
 mod tests {
     use super::*;
 
-    const TEST_ITEM: Id<Item> = Id::from_string_id("test_item");
-    const TEST_STRUCTURE: Id<Structure> = Id::from_string_id("test_structure");
+    const TEST_ITEM: Id<Item> = Id::new(12345);
+    const TEST_STRUCTURE: Id<Structure> = Id::new(67890);
 
     #[test]
     fn neighboring_signals_checks_origin_tile() {

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -198,7 +198,7 @@ fn generate_organisms(
         commands.spawn(UnitBundle::new(
             Id::ant(),
             ant_position,
-            unit_manifest.get(Id::new("ant")).clone(),
+            unit_manifest.get(Id::from_string_id("ant")).clone(),
             &unit_handles,
             &map_geometry,
         ));
@@ -207,7 +207,7 @@ fn generate_organisms(
     // Plant
     let plant_positions = entity_positions.split_off(entity_positions.len() - n_plant);
     for position in plant_positions {
-        let structure_id = Id::new("acacia");
+        let structure_id = Id::from_string_id("acacia");
 
         let item = ClipboardData {
             structure_id,
@@ -224,7 +224,7 @@ fn generate_organisms(
     // Fungi
     let fungus_positions = entity_positions.split_off(entity_positions.len() - n_fungi);
     for position in fungus_positions {
-        let structure_id = Id::new("leuco");
+        let structure_id = Id::from_string_id("leuco");
 
         let item = ClipboardData {
             structure_id,
@@ -241,7 +241,7 @@ fn generate_organisms(
     // Hives
     let hive_positions = entity_positions.split_off(entity_positions.len() - n_hive);
     for position in hive_positions {
-        let structure_id = Id::new("ant_hive");
+        let structure_id = Id::from_string_id("ant_hive");
 
         let item = ClipboardData {
             structure_id,

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -74,7 +74,7 @@ impl Default for StructureManifest {
 
         // TODO: read these from files
         map.insert(
-            Id::new("leuco"),
+            Id::from_string_id("leuco"),
             StructureData {
                 organism: Some(OrganismVariety {
                     energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
@@ -93,7 +93,7 @@ impl Default for StructureManifest {
         };
 
         map.insert(
-            Id::new("acacia"),
+            Id::from_string_id("acacia"),
             StructureData {
                 organism: Some(OrganismVariety {
                     energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
@@ -108,7 +108,7 @@ impl Default for StructureManifest {
         );
 
         map.insert(
-            Id::new("ant_hive"),
+            Id::from_string_id("ant_hive"),
             StructureData {
                 organism: None,
                 crafts: true,
@@ -125,7 +125,7 @@ impl Default for StructureManifest {
         );
 
         map.insert(
-            Id::new("hatchery"),
+            Id::from_string_id("hatchery"),
             StructureData {
                 organism: None,
                 crafts: true,

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -43,7 +43,7 @@ impl Default for UnitManifest {
 
         // TODO: load this from disk
         map.insert(
-            Id::new("ant"),
+            Id::from_string_id("ant"),
             UnitData {
                 energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
                 diet: Diet::new(Id::leuco_chunk(), Energy(50.)),
@@ -59,7 +59,7 @@ impl Id<Unit> {
     // TODO: read these from disk
     /// The id of an ant
     pub(crate) fn ant() -> Self {
-        Self::new("ant")
+        Self::from_string_id("ant")
     }
 }
 

--- a/emergence_lib/src/units/reproduction.rs
+++ b/emergence_lib/src/units/reproduction.rs
@@ -37,7 +37,7 @@ pub(super) fn hatch_ant_eggs(
                     commands.spawn(UnitBundle::new(
                         Id::ant(),
                         pos_to_spawn,
-                        unit_manifest.get(Id::new("ant")).clone(),
+                        unit_manifest.get(Id::from_string_id("ant")).clone(),
                         &unit_handles,
                         &map_geometry,
                     ));


### PR DESCRIPTION
In preparation for #368.

Strings are great for humans, but computers prefer to work with numbers.
In this PR, we switch the internal data format from the identifiers from strings to `u64`s.

To make it easier to generate the IDs and cross reference them, we generate them with a hash function, adopted from <https://cp-algorithms.com/string/string-hashing.html#calculation-of-the-hash-of-a-string>.
This will make it easier later to load the manifest files correctly.

We can switch the hashing function later to make it more resistant to hash collisions, but for now I'm not too worried about it (and we can detect hash collisions later on).