### PR TITLE
Remove unnecessary display tests

### DIFF
--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -555,34 +555,6 @@ mod tests {
         }
     }
 
-    mod display {
-        use super::super::*;
-
-        #[test]
-        fn should_display_with_no_slots() {
-            let inventory = Inventory::new(0);
-
-            assert_eq!(format!("{inventory}"), "[]".to_string());
-        }
-
-        #[test]
-        fn should_display_with_empty_slot() {
-            let inventory = Inventory::new(1);
-
-            assert_eq!(format!("{inventory}"), "[_]".to_string());
-        }
-
-        #[test]
-        fn should_display_with_filled_slot() {
-            let inventory = Inventory {
-                max_slot_count: 1,
-                slots: vec![ItemSlot::new_with_count(Id::acacia_leaf(), 10, 5)],
-            };
-
-            assert_eq!(format!("{inventory}"), "[#104638856 (5/10)]".to_string());
-        }
-    }
-
     #[test]
     fn should_count_item() {
         let inventory = Inventory {

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -104,15 +104,3 @@ impl Display for ItemCount {
         write!(f, "{} ({})", self.item_id, self.count)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn should_display_item_id_and_count() {
-        let item_count = ItemCount::new(Id::acacia_leaf(), 3);
-
-        assert_eq!(format!("{item_count}"), "#104638856 (3)".to_string());
-    }
-}

--- a/emergence_lib/src/items/recipe.rs
+++ b/emergence_lib/src/items/recipe.rs
@@ -181,22 +181,3 @@ impl Display for RecipeData {
         write!(f, "[{input_str}] -> [{output_str}] | {duration_str} s")
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn should_display_inputs_outputs_craft_time() {
-        let recipe = RecipeData {
-            inputs: Vec::new(),
-            outputs: vec![ItemCount::one(Id::acacia_leaf())],
-            craft_time: Duration::from_secs(1),
-            work_required: false,
-            energy: Some(Energy(20.)),
-        };
-
-        assert_eq!(format!("{recipe}"), "[] -> [#104638856 (1)] | 1.00 s")
-    }
-}

--- a/emergence_lib/src/items/slot.rs
+++ b/emergence_lib/src/items/slot.rs
@@ -191,24 +191,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_display_item_type_count_and_capacity_for_empty_slot() {
-        let item_slot = ItemSlot::new(Id::acacia_leaf(), 10);
-
-        assert_eq!(format!("{item_slot}"), "#104638856 (0/10)".to_string());
-    }
-
-    #[test]
-    fn should_display_item_type_count_and_capacity_for_filled_slot() {
-        let item_slot = ItemSlot {
-            item_id: Id::acacia_leaf(),
-            max_item_count: 10,
-            count: 6,
-        };
-
-        assert_eq!(format!("{item_slot}"), "#104638856 (6/10)".to_string());
-    }
-
-    #[test]
     fn should_be_empty_when_count_is_0() {
         let item_slot = ItemSlot {
             item_id: Id::acacia_leaf(),


### PR DESCRIPTION
Follow up to #508.

Since we use numbers for IDs now instead of strings, the display implementations for most structs won't be used in the UI directly (soon-ish).

Let's remove the tests for them.