### PR TITLE
Use custom filtered array iterator to avoid allocs

### DIFF
--- a/emergence_lib/src/filtered_array_iter.rs
+++ b/emergence_lib/src/filtered_array_iter.rs
@@ -1,0 +1,65 @@
+//! Allocation-less struct to non-lazily filter array iterators
+
+use std::{array, iter};
+
+/// Allocation-less struct to non-lazily filter array iterators
+pub struct FilteredArrayIter<T, const N: usize> {
+    /// Holds the original array, with filtered elements swapped to the end
+    arr: [T; N],
+    /// The number of elements not-filtered.
+    len: usize,
+}
+
+impl<T, const N: usize> From<[T; N]> for FilteredArrayIter<T, N> {
+    fn from(arr: [T; N]) -> Self {
+        Self { arr, len: N }
+    }
+}
+
+impl<T, const N: usize> IntoIterator for FilteredArrayIter<T, N> {
+    type Item = T;
+
+    type IntoIter = iter::Take<array::IntoIter<T, N>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.arr.into_iter().take(self.len)
+    }
+}
+
+impl<T, const N: usize> FilteredArrayIter<T, N> {
+    /// Analagous to [`std::iter::Iterator::filter`], but evaluates
+    /// the predicate immediately instead of waiting until we iterate
+    /// over the array.
+    ///
+    /// Does not keep the order of iteration constant.
+    ///
+    /// Removes elements where predicate(element) = false, but defers
+    /// drop until the whole structure is dropped.
+    pub fn filter(&mut self, mut predicate: impl FnMut(&T) -> bool) {
+        let mut i = 0;
+        while i < self.len {
+            if predicate(&self.arr[i]) {
+                i += 1
+            } else {
+                self.arr.swap(i, self.len - 1);
+                self.len -= 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::array;
+
+    #[test]
+    fn filtered_array() {
+        let arr: [usize; 10] = array::from_fn(|i| i);
+        let mut filtered_array = FilteredArrayIter::from(arr);
+        filtered_array.filter(|i| i % 2 == 0);
+        filtered_array.filter(|i| i % 3 == 0);
+        let out = filtered_array.into_iter().collect::<Vec<_>>();
+        assert_eq!(out, [0, 6]);
+    }
+}

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod asset_management;
 pub mod curves;
 pub mod enum_iter;
+pub mod filtered_array_iter;
 pub mod graphics;
 pub mod items;
 pub mod organisms;


### PR DESCRIPTION
Inspired by #511, this fixes two existing perf comments to speed up the existing implementation by ~~\~20%~~ 6%.

Adding a custom pseudo-iter struct is maybe not entirely ideal, but no better solution jumps out at me.

Benchmark results (updated)

```
     Running benches/signals.rs (target/release/deps/signals-e82e00caa29fb839)
add_signal_minimal      time:   [208.96 ns 210.43 ns 211.90 ns]
                        change: [-1.3134% -0.5343% +0.2403%] (p = 0.19 > 0.05)
                        No change in performance detected.

signal_diffusion_minimal
                        time:   [647.15 ns 648.92 ns 651.22 ns]
                        change: [-3.4220% -2.9647% -2.4861%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

add_signal_tiny         time:   [14.200 µs 14.217 µs 14.238 µs]
                        change: [-1.1334% -0.8924% -0.6689%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

signal_diffusion_tiny   time:   [87.663 µs 87.733 µs 87.827 µs]
                        change: [-7.0851% -6.9576% -6.8299%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

add_signal_modest       time:   [12.076 ms 12.093 ms 12.113 ms]
                        change: [-0.2305% -0.0466% +0.1480%] (p = 0.63 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

Benchmarking signal_diffusion_modest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.9s, or reduce sample count to 50.
signal_diffusion_modest time:   [88.672 ms 88.899 ms 89.148 ms]
                        change: [-6.6802% -6.4190% -6.1307%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```