### PR TITLE
Remove unecessary pending maps in diffuse

### DIFF
--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -166,10 +166,7 @@ impl Signals {
 
     /// Diffuses signals from one cell into the next
     pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
-        let mut pending_additions = HashMap::new();
-        let mut pending_removals = HashMap::new();
-
-        for (&signal_type, original_map) in self.maps.iter() {
+        for original_map in self.maps.values_mut() {
             let mut addition_map = SignalMap::default();
             let mut removal_map = SignalMap::default();
 
@@ -182,15 +179,7 @@ impl Signals {
                 }
             }
 
-            pending_additions.insert(signal_type, addition_map);
-            pending_removals.insert(signal_type, removal_map);
-        }
-
-        // We cannot do this in one step, as we need to avoid bizarre iteration order dependencies
-        for (signal_type, original_map) in self.maps.iter_mut() {
-            let addition_map = pending_additions.get(signal_type).unwrap();
-            let removal_map = pending_additions.get(signal_type).unwrap();
-
+            // We cannot do this in one step, as we need to avoid bizarre iteration order dependencies
             for (&removal_pos, &removal_strength) in removal_map.map.iter() {
                 original_map.subtract_signal(removal_pos, removal_strength)
             }


### PR DESCRIPTION
Simplifies diffuse code by not storing pending changes between signals, which has a noticeable performance improvement.

The comment that "We cannot do this in one step, as we need to avoid bizarre iteration order dependencies" is correct in that we do need to make `addition_map` and `removal_map` and store changes in them before we apply them, but there's no reason to keep them around between signals and not apply them immediately - changes to one signal don't affect another signal.

Benchmark:

```
     Running benches/signals.rs (target/release/deps/signals-e82e00caa29fb839)
add_signal_minimal      time:   [208.48 ns 210.05 ns 211.80 ns]
                        change: [-2.1082% -1.3124% -0.5846%] (p = 0.00 < 0.05)
                        Change within noise threshold.

signal_diffusion_minimal
                        time:   [450.77 ns 452.79 ns 454.67 ns]
                        change: [-26.969% -26.727% -26.472%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  10 (10.00%) high mild
  8 (8.00%) high severe

add_signal_tiny         time:   [13.886 µs 13.904 µs 13.924 µs]
                        change: [-0.3100% -0.1866% -0.0695%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

signal_diffusion_tiny   time:   [65.869 µs 65.960 µs 66.056 µs]
                        change: [-8.7252% -8.6003% -8.4599%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

add_signal_modest       time:   [11.697 ms 11.714 ms 11.732 ms]
                        change: [-0.0620% +0.1192% +0.3130%] (p = 0.22 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

Benchmarking signal_diffusion_modest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.3s, or reduce sample count to 70.
signal_diffusion_modest time:   [62.705 ms 62.794 ms 62.903 ms]
                        change: [-11.342% -11.146% -10.960%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

```