### PR TITLE
Loading manifests from files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
 name = "emergence_lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bevy",
  "bevy_mod_raycast",
  "bevy_screen_diagnostics",
@@ -1551,6 +1552,7 @@ dependencies = [
  "petitset",
  "rand",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/emergence_game/assets/manifests/items.manifest.json
+++ b/emergence_game/assets/manifests/items.manifest.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "./schema/items.schema.json",
+  "items": {
+    "acacia_leaf": {
+      "stack_size": 10
+    },
+    "leuco_chunk": {
+      "stack_size": 5
+    },
+    "ant_egg": {
+      "stack_size": 5
+    }
+  }
+}

--- a/emergence_game/assets/manifests/schema/items.schema.json
+++ b/emergence_game/assets/manifests/schema/items.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.leafwing-studios.com/Emergence/items",
+  "title": "Item Manifest",
+  "type": "object",
+  "properties": {
+    "items": {
+      "description": "A map from item identifiers to their definition.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "stack_size": {
+            "type": "number",
+            "min": 0
+          }
+        },
+        "required": ["stack_size"]
+      }
+    }
+  },
+  "required": ["items"]
+}

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -27,3 +27,5 @@ hexx = "0.5"
 bevy_mod_raycast = { git = "https://github.com/soerenmeier/bevy_mod_raycast", branch="bevy-0.10"}
 itertools = "0.10.5"
 bevy_screen_diagnostics = "0.2"
+anyhow = "1.0.69"
+serde_json = "1.0.94"

--- a/emergence_lib/src/asset_management/manifest/identifier.rs
+++ b/emergence_lib/src/asset_management/manifest/identifier.rs
@@ -49,7 +49,7 @@ impl<T> Id<T> {
     /// Creates a new ID from human-readable string identifier.
     ///
     /// This ID is created as a hash of the string.
-    pub(crate) fn from_string_id(str: &'static str) -> Self {
+    pub(crate) fn from_string_id(str: &str) -> Self {
         // Algorithm adopted from <https://cp-algorithms.com/string/string-hashing.html>
 
         let mut value = 0;

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 
 use bevy::{
     asset::{AssetLoader, LoadContext, LoadedAsset},
-    reflect::TypeUuid,
     utils::BoxedFuture,
 };
 use serde::Deserialize;

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -9,11 +9,7 @@ use bevy::{
 };
 use serde::Deserialize;
 
-/// A utility trait to ensure that all trait bounds are satisfied.
-pub trait RawManifest: std::fmt::Debug + TypeUuid + Send + Sync + 'static {
-    /// The path of the asset.
-    fn path() -> &'static str;
-}
+use super::raw::RawManifest;
 
 /// A loader for `.manifest.json` files.
 #[derive(Debug, Clone)]

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -10,7 +10,10 @@ use bevy::{
 use serde::Deserialize;
 
 /// A utility trait to ensure that all trait bounds are satisfied.
-pub trait RawManifest: TypeUuid + Send + Sync + 'static {}
+pub trait RawManifest: TypeUuid + Send + Sync + 'static {
+    /// The path of the asset.
+    fn path() -> &'static str;
+}
 
 /// A loader for `.manifest.json` files.
 #[derive(Debug, Clone)]

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -13,7 +13,7 @@ use super::raw::RawManifest;
 
 /// A loader for `.manifest.json` files.
 #[derive(Debug, Clone)]
-pub struct RawManifestLoader<M>
+pub(crate) struct RawManifestLoader<M>
 where
     M: RawManifest,
 {

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -6,7 +6,6 @@ use bevy::{
     asset::{AssetLoader, LoadContext, LoadedAsset},
     utils::BoxedFuture,
 };
-use serde::Deserialize;
 
 use super::raw::RawManifest;
 
@@ -22,7 +21,7 @@ where
 
 impl<M> AssetLoader for RawManifestLoader<M>
 where
-    M: RawManifest + for<'de> Deserialize<'de>,
+    M: RawManifest,
 {
     fn extensions(&self) -> &[&str] {
         &["manifest.json"]
@@ -43,7 +42,7 @@ where
 
 impl<M> Default for RawManifestLoader<M>
 where
-    M: RawManifest + for<'de> Deserialize<'de>,
+    M: RawManifest,
 {
     fn default() -> Self {
         Self {

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 pub trait RawManifest: TypeUuid + Send + Sync + 'static {}
 
 /// A loader for `.manifest.json` files.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RawManifestLoader<M>
 where
     M: RawManifest,
@@ -40,5 +40,16 @@ where
             load_context.set_default_asset(LoadedAsset::new(raw_manifest));
             Ok(())
         })
+    }
+}
+
+impl<M> Default for RawManifestLoader<M>
+where
+    M: RawManifest + for<'de> Deserialize<'de>,
+{
+    fn default() -> Self {
+        Self {
+            _phantom_manifest: PhantomData::default(),
+        }
     }
 }

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -10,7 +10,7 @@ use bevy::{
 use serde::Deserialize;
 
 /// A utility trait to ensure that all trait bounds are satisfied.
-pub trait RawManifest: TypeUuid + Send + Sync + 'static {
+pub trait RawManifest: std::fmt::Debug + TypeUuid + Send + Sync + 'static {
     /// The path of the asset.
     fn path() -> &'static str;
 }

--- a/emergence_lib/src/asset_management/manifest/loader.rs
+++ b/emergence_lib/src/asset_management/manifest/loader.rs
@@ -1,0 +1,44 @@
+//! A loader for manifest assets.
+
+use std::marker::PhantomData;
+
+use bevy::{
+    asset::{AssetLoader, LoadContext, LoadedAsset},
+    reflect::TypeUuid,
+    utils::BoxedFuture,
+};
+use serde::Deserialize;
+
+/// A utility trait to ensure that all trait bounds are satisfied.
+pub trait RawManifest: TypeUuid + Send + Sync + 'static {}
+
+/// A loader for `.manifest.json` files.
+#[derive(Debug, Clone, Default)]
+pub struct RawManifestLoader<M>
+where
+    M: RawManifest,
+{
+    /// Use the generic to make the compiler happy.
+    _phantom_manifest: PhantomData<M>,
+}
+
+impl<M> AssetLoader for RawManifestLoader<M>
+where
+    M: RawManifest + for<'de> Deserialize<'de>,
+{
+    fn extensions(&self) -> &[&str] {
+        &["manifest.json"]
+    }
+
+    fn load<'a>(
+        &'a self,
+        bytes: &'a [u8],
+        load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, anyhow::Result<(), anyhow::Error>> {
+        Box::pin(async move {
+            let raw_manifest = serde_json::from_slice::<M>(bytes)?;
+            load_context.set_default_asset(LoadedAsset::new(raw_manifest));
+            Ok(())
+        })
+    }
+}

--- a/emergence_lib/src/asset_management/manifest/mod.rs
+++ b/emergence_lib/src/asset_management/manifest/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use self::identifier::*;
 mod emergence_markers;
 mod identifier;
 mod loader;
-mod plugin;
+pub(crate) mod plugin;
 mod raw;
 
 use bevy::{prelude::*, utils::HashMap};

--- a/emergence_lib/src/asset_management/manifest/mod.rs
+++ b/emergence_lib/src/asset_management/manifest/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use self::identifier::*;
 
 mod emergence_markers;
 mod identifier;
+mod loader;
 
 use bevy::{prelude::*, utils::HashMap};
 use std::fmt::Debug;

--- a/emergence_lib/src/asset_management/manifest/mod.rs
+++ b/emergence_lib/src/asset_management/manifest/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use self::identifier::*;
 mod emergence_markers;
 mod identifier;
 mod loader;
+mod plugin;
+mod raw;
 
 use bevy::{prelude::*, utils::HashMap};
 use std::fmt::Debug;

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -1,0 +1,15 @@
+//! The plugin to handle loading of manifest assets.
+
+use bevy::prelude::*;
+
+use super::{loader::RawManifestLoader, raw::RawItemManifest};
+
+/// A plugin to load and process manifest assets.
+struct ManifestPlugin;
+
+impl Plugin for ManifestPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_asset_loader::<RawManifestLoader<RawItemManifest>>()
+            .add_asset::<RawItemManifest>();
+    }
+}

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -28,6 +28,9 @@ where
     M: RawManifest,
 {
     /// The handle to the raw manifest asset.
+    ///
+    /// We mainly need this for the asset to not be unloaded.
+    #[allow(dead_code)]
     handle: Handle<M>,
 }
 

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -67,8 +67,7 @@ where
     /// The handle to the raw manifest asset.
     ///
     /// We mainly need this for the asset to not be unloaded.
-    #[allow(dead_code)]
-    handle: Handle<M>,
+    _handle: Handle<M>,
 }
 
 /// Initiate the loading of the manifest.
@@ -78,7 +77,7 @@ where
 {
     let handle: Handle<M> = asset_server.load(M::path());
 
-    commands.insert_resource(RawManifestHandle::<M> { handle });
+    commands.insert_resource(RawManifestHandle::<M> { _handle: handle });
 }
 
 /// Wait for the manifest to be fully loaded and then process it.

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -3,8 +3,8 @@
 use bevy::prelude::*;
 
 use super::{
-    loader::{RawManifest, RawManifestLoader},
-    raw::RawItemManifest,
+    loader::RawManifestLoader,
+    raw::{RawItemManifest, RawManifest},
 };
 
 /// A plugin to load and process manifest assets.

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -2,7 +2,10 @@
 
 use bevy::prelude::*;
 
-use super::{loader::RawManifestLoader, raw::RawItemManifest};
+use super::{
+    loader::{RawManifest, RawManifestLoader},
+    raw::RawItemManifest,
+};
 
 /// A plugin to load and process manifest assets.
 struct ManifestPlugin;
@@ -10,6 +13,29 @@ struct ManifestPlugin;
 impl Plugin for ManifestPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset_loader::<RawManifestLoader<RawItemManifest>>()
-            .add_asset::<RawItemManifest>();
+            .add_asset::<RawItemManifest>()
+            .add_startup_system(initiate_manifest_loading::<RawItemManifest>);
     }
+}
+
+/// Resource to store the handle to a [`RawManifest`] while it is being loaded.
+///
+/// This is necessary to stop the asset from being discarded.
+#[derive(Debug, Default, Clone, Resource)]
+struct RawManifestHandle<M>
+where
+    M: RawManifest,
+{
+    /// The handle to the raw manifest asset.
+    handle: Handle<M>,
+}
+
+/// Initiate the loading of the manifest.
+fn initiate_manifest_loading<M>(mut commands: Commands, asset_server: Res<AssetServer>)
+where
+    M: RawManifest,
+{
+    let handle: Handle<M> = asset_server.load(M::path());
+
+    commands.insert_resource(RawManifestHandle::<M> { handle });
 }

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -96,6 +96,8 @@ fn detect_manifest_creation<M>(
                 continue;
             };
 
+            info!("Manifest asset {} loaded!", M::path());
+
             // Create the manifest and insert it as a resource
             commands.insert_resource(raw_manifest.process());
         }
@@ -116,6 +118,8 @@ fn detect_manifest_modification<M>(
                 warn!("Raw manifest modified, but asset not available!");
                 continue;
             };
+
+            debug!("Manifest asset {} modified.", M::path());
 
             // Update the manifest resource
             *manifest = raw_manifest.process();

--- a/emergence_lib/src/asset_management/manifest/raw.rs
+++ b/emergence_lib/src/asset_management/manifest/raw.rs
@@ -24,4 +24,8 @@ pub struct RawItemManifest {
     items: HashMap<String, RawItemData>,
 }
 
-impl RawManifest for RawItemManifest {}
+impl RawManifest for RawItemManifest {
+    fn path() -> &'static str {
+        "manifests/items.manifest.json"
+    }
+}

--- a/emergence_lib/src/asset_management/manifest/raw.rs
+++ b/emergence_lib/src/asset_management/manifest/raw.rs
@@ -5,7 +5,11 @@
 use bevy::{reflect::TypeUuid, utils::HashMap};
 use serde::Deserialize;
 
-use super::loader::RawManifest;
+/// A utility trait to ensure that all trait bounds are satisfied.
+pub trait RawManifest: std::fmt::Debug + TypeUuid + Send + Sync + 'static {
+    /// The path of the asset.
+    fn path() -> &'static str;
+}
 
 /// The item data as seen in the original manifest file.
 ///

--- a/emergence_lib/src/asset_management/manifest/raw.rs
+++ b/emergence_lib/src/asset_management/manifest/raw.rs
@@ -1,0 +1,27 @@
+//! The raw manifest data before it has been processed.
+//!
+//! The processing will primarily remove the string IDs and replace them by numbers.
+
+use bevy::{reflect::TypeUuid, utils::HashMap};
+use serde::Deserialize;
+
+use super::loader::RawManifest;
+
+/// The item data as seen in the original manifest file.
+///
+/// This will be converted to [`crate::items::ItemData`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawItemData {
+    /// The maximum number of items that can fit in a stack.
+    stack_size: usize,
+}
+
+/// The item manifest as seen in the manifest file.
+#[derive(Debug, Clone, Deserialize, TypeUuid)]
+#[uuid = "cd9f4571-b0c4-4641-8d27-1c9c5ad4c812"]
+pub struct RawItemManifest {
+    /// The data for each item.
+    items: HashMap<String, RawItemData>,
+}
+
+impl RawManifest for RawItemManifest {}

--- a/emergence_lib/src/asset_management/manifest/raw.rs
+++ b/emergence_lib/src/asset_management/manifest/raw.rs
@@ -10,12 +10,14 @@ use crate::items::ItemData;
 use super::{Id, Item, Manifest};
 
 /// A utility trait to ensure that all trait bounds are satisfied.
-pub(crate) trait RawManifest: std::fmt::Debug + TypeUuid + Send + Sync + 'static {
+pub(crate) trait RawManifest:
+    std::fmt::Debug + TypeUuid + Send + Sync + for<'de> Deserialize<'de> + 'static
+{
     /// The marker type for the manifest ID.
-    type Marker: 'static;
+    type Marker: 'static + Send + Sync;
 
     /// The type of the processed manifest data.
-    type Data: std::fmt::Debug;
+    type Data: std::fmt::Debug + Send + Sync;
 
     /// The path of the asset.
     fn path() -> &'static str;

--- a/emergence_lib/src/asset_management/mod.rs
+++ b/emergence_lib/src/asset_management/mod.rs
@@ -12,7 +12,10 @@
 
 use std::any::TypeId;
 
-use self::{structures::StructureHandles, terrain::TerrainHandles, units::UnitHandles};
+use self::{
+    manifest::plugin::ManifestPlugin, structures::StructureHandles, terrain::TerrainHandles,
+    units::UnitHandles,
+};
 use bevy::{
     asset::LoadState,
     prelude::*,
@@ -35,7 +38,8 @@ impl Plugin for AssetManagementPlugin {
         app.init_resource::<TerrainHandles>()
             .add_state::<AssetState>()
             .add_asset_collection::<StructureHandles>()
-            .add_asset_collection::<UnitHandles>();
+            .add_asset_collection::<UnitHandles>()
+            .add_plugin(ManifestPlugin);
     }
 }
 

--- a/emergence_lib/src/items/mod.rs
+++ b/emergence_lib/src/items/mod.rs
@@ -43,6 +43,11 @@ pub struct ItemData {
 }
 
 impl ItemData {
+    /// Create new item data.
+    pub fn new(stack_size: usize) -> Self {
+        Self { stack_size }
+    }
+
     /// The number of items that can fit in a single item slot.
     pub fn stack_size(&self) -> usize {
         self.stack_size


### PR DESCRIPTION
More progress to #368 (we're very close now)!

This PR introduces capabilities to load manifests from files, process them and to make them available as resources once loaded.
Here's the process:

1. The manifest is defined in a `.manifest.json` file in the `assets` folder. I chose JSON for now because everyone knows it and because we can add schemas to get auto completion and linting in IDEs. I added the item manifest as example.
2. The manifest is loaded as an asset. At this point we speak of it as a `RawManifest`, because it uses the string identifiers from the asset file and is not validated yet.
3. Once the loading is completed, the manifest is processed. Currently this just involves the conversion of string identifiers to our `Id`s, but we can apply other processing here in the future.
4. The processed asset is inserted as a resource to be available for gameplay logic.
5. If the manifest asset is modified, it gets processed again and the resource is updated.

## Future Work

- We need to load all manifests and have their resources created before we start the gameplay logic. This is probably not trivial as it is not clear if this should logic should reside in the app or lib and how exactly we want to implement it.
- We need to move the other manifests to the new system (e.g. recipes and units).
- We should apply more data validation, e.g. checking for hash collisions, checking that IDs to external manifests (e.g. item IDs in recipes) are valid, etc.
- We probably need another resource that can map back from ID to the string identifiers if needed. This would be useful to make our UI more readable again before we have proper localization tools.
- Remove the hard-coded definitions.