### PR TITLE
Animate celestial body illuminance

### DIFF
--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -50,7 +50,7 @@ pub(crate) struct CelestialBody {
     ///
     /// A value of 0.0 corresponds to east -> west travel.
     travel_axis: f32,
-    /// The maximum illuminance of the [`DirectionalLight`]
+    /// The base illuminance of the [`DirectionalLight`]
     illuminance: f32,
     /// The number of in-game days required to complete a full cycle.
     pub(crate) days_per_cycle: f32,
@@ -153,11 +153,8 @@ fn set_celestial_body_transform(
 /// Changes the lighting properties of the sun and moon throughout their cycles
 fn animate_celestial_body_lighting(mut query: Query<(&CelestialBody, &mut DirectionalLight)>) {
     for (celestial_body, mut directional_light) in query.iter_mut() {
-        if celestial_body.progress > 0.5 {
-            // We *cannot* disable lights or shadows completely here because it introduces perf-tanking branching
-            directional_light.illuminance = 0.;
-        } else {
-            directional_light.illuminance = celestial_body.illuminance;
-        }
+        // We want this to be 0 at midnight, and reach a peak at noon
+        let relative_intensity = celestial_body.progress.sin() + 1.0;
+        directional_light.illuminance = celestial_body.illuminance * relative_intensity;
     }
 }

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -26,7 +26,8 @@ impl Plugin for LightingPlugin {
         .insert_resource(DirectionalLightShadowMap { size: 8192 })
         // Need to wait for the player camera to spawn
         .add_startup_system(spawn_celestial_bodies.in_base_set(StartupSet::PostStartup))
-        .add_system(set_celestial_body_transform);
+        .add_system(set_celestial_body_transform)
+        .add_system(toggle_lights_based_on_ground_clipping);
     }
 }
 
@@ -140,5 +141,16 @@ fn set_celestial_body_transform(
 
         // Look at the origin to point in the right direction
         transform.look_at(Vec3::ZERO, Vec3::Y);
+    }
+}
+
+/// Disables lights that are under the ground
+fn toggle_lights_based_on_ground_clipping(mut query: Query<(&CelestialBody, &mut Visibility)>) {
+    for (celestial_body, mut visibility) in query.iter_mut() {
+        if celestial_body.progress > 0.5 {
+            *visibility = Visibility::Hidden;
+        } else {
+            *visibility = Visibility::Visible;
+        }
     }
 }

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -132,12 +132,16 @@ fn set_celestial_body_transform(
 }
 
 /// Disables lights that are under the ground
-fn toggle_lights_based_on_ground_clipping(mut query: Query<(&CelestialBody, &mut Visibility)>) {
-    for (celestial_body, mut visibility) in query.iter_mut() {
+fn toggle_lights_based_on_ground_clipping(
+    mut query: Query<(&CelestialBody, &mut Visibility, &mut DirectionalLight)>,
+) {
+    for (celestial_body, mut visibility, mut directional_light) in query.iter_mut() {
         if celestial_body.progress > 0.5 {
             *visibility = Visibility::Hidden;
+            directional_light.shadows_enabled = false;
         } else {
             *visibility = Visibility::Visible;
+            directional_light.shadows_enabled = true;
         }
     }
 }

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -105,6 +105,19 @@ fn spawn_celestial_bodies(mut commands: Commands, camera_query: Query<&CameraSet
             ..default()
         })
         .insert(CelestialBody::sun());
+
+    commands
+        .spawn(DirectionalLightBundle {
+            directional_light: DirectionalLight {
+                color: LIGHT_MOON,
+                illuminance: 1e4,
+                shadows_enabled: true,
+                ..Default::default()
+            },
+            cascade_shadow_config,
+            ..default()
+        })
+        .insert(CelestialBody::moon());
 }
 
 /// Moves celestial bodies to the correct position and orientation

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -105,19 +105,6 @@ fn spawn_celestial_bodies(mut commands: Commands, camera_query: Query<&CameraSet
             ..default()
         })
         .insert(CelestialBody::sun());
-
-    commands
-        .spawn(DirectionalLightBundle {
-            directional_light: DirectionalLight {
-                color: LIGHT_MOON,
-                illuminance: 1e4,
-                shadows_enabled: true,
-                ..Default::default()
-            },
-            cascade_shadow_config,
-            ..default()
-        })
-        .insert(CelestialBody::moon());
 }
 
 /// Moves celestial bodies to the correct position and orientation

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -146,14 +146,12 @@ fn set_celestial_body_transform(
 
 /// Disables lights that are under the ground
 fn toggle_lights_based_on_ground_clipping(
-    mut query: Query<(&CelestialBody, &mut Visibility, &mut DirectionalLight)>,
+    mut query: Query<(&CelestialBody, &mut DirectionalLight)>,
 ) {
-    for (celestial_body, mut visibility, mut directional_light) in query.iter_mut() {
+    for (celestial_body, mut directional_light) in query.iter_mut() {
         if celestial_body.progress > 0.5 {
-            *visibility = Visibility::Hidden;
             directional_light.shadows_enabled = false;
         } else {
-            *visibility = Visibility::Visible;
             directional_light.shadows_enabled = true;
         }
     }


### PR DESCRIPTION
Fixes #534.

I've encountered some very strange performance issues while investigating this.

1. With two directional lights (https://github.com/Leafwing-Studios/Emergence/pull/542/commits/f35a00080d0676bb5f10a761e4b02f5e381f3106), making one of them invisible via `Visibility` results in a massive and sustained performance drop.
2. With one light (https://github.com/Leafwing-Studios/Emergence/pull/542/commits/05a822cd85fe2f22bfddd26f3f6043b9afde3424), making it invisible results in a large performance improvement. This makes sense! No need to compute shadows!
3. Changing whether or not shadows are enabled (https://github.com/Leafwing-Studios/Emergence/pull/542/commits/b7b445ed8d416d9075bcc788879666b68b2a41db) has the same pattern.
4. Simply animating the light intensity poses no issues 🙃 

Definitely looks like shader branching issues.