### PR TITLE
Add a clear color to make the sky less weird

### DIFF
--- a/emergence_lib/src/asset_management/palette.rs
+++ b/emergence_lib/src/asset_management/palette.rs
@@ -90,6 +90,14 @@ pub(crate) const LIGHT_MOON: Color = Color::Hsla {
     alpha: 1.,
 };
 
+/// The color of a clear and sunny sky.
+pub(crate) const SKY_SUNNY: Color = Color::Hsla {
+    hue: 202.,
+    saturation: 0.8,
+    lightness: 0.8,
+    alpha: 1.0,
+};
+
 /// The color of starlight
 pub(crate) const LIGHT_STARS: Color = Color::WHITE;
 

--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -1,0 +1,14 @@
+//! Controls how the atmosphere and sky look.
+
+use bevy::prelude::*;
+
+use crate::asset_management::palette::SKY_SUNNY;
+
+/// Logic and resources to modify the sky and atmosphere.
+pub(super) struct AtmospherePlugin;
+
+impl Plugin for AtmospherePlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(ClearColor(SKY_SUNNY));
+    }
+}

--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -5,9 +5,11 @@ use bevy::prelude::*;
 use crate::{asset_management::AssetState, player_interaction::InteractionSystem};
 
 use self::{
-    lighting::LightingPlugin, selection::display_tile_overlay, structures::remove_ghostly_shadows,
+    atmosphere::AtmospherePlugin, lighting::LightingPlugin, selection::display_tile_overlay,
+    structures::remove_ghostly_shadows,
 };
 
+mod atmosphere;
 pub(crate) mod lighting;
 mod selection;
 mod structures;
@@ -21,6 +23,7 @@ pub struct GraphicsPlugin;
 impl Plugin for GraphicsPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(LightingPlugin)
+            .add_plugin(AtmospherePlugin)
             .add_system(units::display_held_item.run_if(in_state(AssetState::Ready)))
             // Run these after Update to avoid panics due to despawned entities
             .add_systems(


### PR DESCRIPTION
I also experimented with atmospheric fog.

The following settings looked fairly good, but were very strange when the camera was zoomed in and out. If this didn't involve moving the camera, or the fog was changed to compensate, maybe that would work well.

```rust
/// Sets up the atmospheric fog to increase the sense of depth
fn configure_fog(camera_query: Query<Entity, With<Camera>>, mut commands: Commands) {
    let camera_entity = camera_query.single();
    commands.entity(camera_entity).insert(FogSettings {
        color: Color::GRAY,
        directional_light_color: LIGHT_SUN,
        directional_light_exponent: 30.,
        falloff: FogFalloff::from_visibility_colors(
            1000.0, // distance in world units up to which objects retain visibility (>= 5% contrast)
            Color::rgb(0.35, 0.5, 0.66), // atmospheric extinction color (after light is lost due to absorption by atmospheric particles)
            Color::rgb(0.8, 0.844, 1.0), // atmospheric inscattering color (light gained due to scattering from the sun)
        ),
    });
}
```