### PR TITLE
Fix previews

### DIFF
--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -262,6 +262,7 @@ fn rotate_selection(actions: Res<ActionState<PlayerAction>>, mut clipboard: ResM
 }
 
 /// Preview the current clipboard under the cursor
+#[allow(clippy::too_many_arguments)]
 fn preview_clipboard(
     clipboard: Res<Clipboard>,
     hovered_tiles: Res<HoveredTiles>,

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -191,7 +191,7 @@ impl SelectedTiles {
 }
 
 /// The set of tiles that are being hovered
-#[derive(Resource, Debug, Default, Deref, DerefMut)]
+#[derive(Resource, Debug, Default, Deref)]
 pub(crate) struct HoveredTiles {
     /// The set of tiles that are hovered over
     hovered: HashSet<TilePos>,

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     ecs::system::Command,
-    prelude::{Commands, DespawnRecursiveExt, Mut, World},
+    prelude::{warn, Commands, DespawnRecursiveExt, Mut, World},
 };
 use hexx::Direction;
 use rand::{rngs::ThreadRng, seq::SliceRandom, thread_rng};
@@ -326,19 +326,20 @@ impl Command for SpawnPreviewCommand {
 
         // Check that the tile is within the bounds of the map
         if !map_geometry.is_valid(self.tile_pos) {
+            warn!("Preview position {:?} not valid.", self.tile_pos);
             return;
         }
 
         // Compute the world position
         let world_pos = self.tile_pos.top_of_tile(&map_geometry);
 
-        // Remove any existing previews
+        // Remove any existing previews at this location
         let maybe_existing_preview = map_geometry.preview_index.remove(&self.tile_pos);
-
         if let Some(existing_preview) = maybe_existing_preview {
             world.entity_mut(existing_preview).despawn_recursive();
         }
 
+        // Fetch the scene and material to use
         let structure_handles = world.resource::<StructureHandles>();
         let scene_handle = structure_handles
             .scenes
@@ -365,6 +366,7 @@ impl Command for SpawnPreviewCommand {
             ))
             .id();
 
+        // Update the index to reflect the new state
         let mut geometry = world.resource_mut::<MapGeometry>();
         geometry.preview_index.insert(self.tile_pos, preview_entity);
     }


### PR DESCRIPTION
This PR has three effects.

1. Use the `HoveredTiles` computation rather than the cursor pos to detect where previews should be placed.
2. Fixes #570.
3. Also previews what zoning will do when we have a single structure selected + a a selection.

Debugging status:
- [x] preview_clipboard runs
- [x] commands are sent to generate previews
- [x] clipboard data is good
- [x] position is valid
- [x] models are loaded
- [x] textures are loaded

Problem: we are despawning our previews too aggressively.