### PR TITLE
Load item manifest before running game logic

### DIFF
--- a/emergence_game/src/main.rs
+++ b/emergence_game/src/main.rs
@@ -12,6 +12,10 @@ fn main() {
             }),
             ..Default::default()
         }))
+        .add_plugin(emergence_lib::simulation::GeometryPlugin {
+            gen_config: GenerationConfig::default(),
+        })
+        .add_plugin(emergence_lib::asset_management::AssetManagementPlugin)
         .add_plugin(emergence_lib::simulation::SimulationPlugin {
             gen_config: GenerationConfig::default(),
         })
@@ -19,6 +23,5 @@ fn main() {
         .add_plugin(emergence_lib::graphics::GraphicsPlugin)
         .add_plugin(emergence_lib::infovis::InfoVisPlugin)
         .add_plugin(emergence_lib::ui::UiPlugin)
-        .add_plugin(emergence_lib::asset_management::AssetManagementPlugin)
         .run();
 }

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -1,6 +1,7 @@
 //! Generating starting terrain and organisms
 use crate::asset_management::manifest::{Id, StructureManifest, Terrain, UnitManifest};
 use crate::asset_management::units::UnitHandles;
+use crate::asset_management::AssetState;
 use crate::player_interaction::clipboard::ClipboardData;
 use crate::simulation::geometry::{Facing, Height, TilePos};
 use crate::structures::commands::StructureCommandsExt;
@@ -10,7 +11,7 @@ use bevy::app::{App, Plugin};
 use bevy::ecs::prelude::*;
 use bevy::log::info;
 use bevy::math::vec2;
-use bevy::prelude::{CoreSchedule, IntoSystemAppConfigs};
+use bevy::prelude::IntoSystemAppConfigs;
 use bevy::utils::HashMap;
 use hexx::shapes::hexagon;
 use hexx::Hex;
@@ -24,7 +25,7 @@ use super::geometry::MapGeometry;
 #[derive(Resource, Clone)]
 pub struct GenerationConfig {
     /// Radius of the map.
-    map_radius: u32,
+    pub(super) map_radius: u32,
     /// Initial number of ants.
     n_ant: usize,
     /// Initial number of plants.
@@ -92,13 +93,11 @@ pub(super) struct GenerationPlugin {
 impl Plugin for GenerationPlugin {
     fn build(&self, app: &mut App) {
         info!("Building Generation plugin...");
-        app.insert_resource(self.config.clone())
-            .insert_resource(MapGeometry::new(self.config.map_radius))
-            .add_systems(
-                (generate_terrain, apply_system_buffers, generate_organisms)
-                    .chain()
-                    .in_schedule(CoreSchedule::Startup),
-            );
+        app.insert_resource(self.config.clone()).add_systems(
+            (generate_terrain, apply_system_buffers, generate_organisms)
+                .chain()
+                .in_schedule(OnEnter(AssetState::Ready)),
+        );
     }
 }
 

--- a/emergence_lib/src/simulation/mod.rs
+++ b/emergence_lib/src/simulation/mod.rs
@@ -6,7 +6,7 @@ use crate::asset_management::AssetState;
 use crate::organisms::OrganismPlugin;
 use crate::signals::SignalsPlugin;
 use crate::simulation::generation::{GenerationConfig, GenerationPlugin};
-use crate::simulation::geometry::sync_rotation_to_facing;
+use crate::simulation::geometry::{sync_rotation_to_facing, MapGeometry};
 use crate::simulation::time::TemporalPlugin;
 use crate::structures::StructuresPlugin;
 use crate::terrain::TerrainPlugin;
@@ -16,6 +16,18 @@ use bevy::prelude::*;
 pub mod generation;
 pub mod geometry;
 pub mod time;
+
+/// Sets up world geometry
+pub struct GeometryPlugin {
+    /// Configuration settings for world generation
+    pub gen_config: GenerationConfig,
+}
+
+impl Plugin for GeometryPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(MapGeometry::new(self.gen_config.map_radius));
+    }
+}
 
 /// All of the code needed to make the simulation run
 pub struct SimulationPlugin {

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -11,10 +11,13 @@ use rand::{distributions::Uniform, prelude::Distribution, rngs::ThreadRng};
 
 use crate::{
     asset_management::manifest::{Id, ItemManifest, Manifest, Recipe, RecipeManifest, Structure},
-    items::{inventory::Inventory, recipe::RecipeData},
+    items::{inventory::Inventory, recipe::RecipeData, ItemData},
     organisms::{energy::EnergyPool, Organism},
     signals::{Emitter, SignalStrength, SignalType},
-    simulation::geometry::{MapGeometry, TilePos},
+    simulation::{
+        geometry::{MapGeometry, TilePos},
+        SimulationSet,
+    },
 };
 
 /// The current state in the crafting progress.
@@ -474,9 +477,14 @@ impl Plugin for CraftingPlugin {
         recipe_manifest.insert("ant_egg_production", RecipeData::ant_egg_production());
         recipe_manifest.insert("hatch_ants", RecipeData::hatch_ants());
 
-        app.insert_resource(recipe_manifest)
-            .add_system(progress_crafting)
-            .add_system(gain_energy_when_crafting_completes.after(progress_crafting))
-            .add_system(set_emitter.after(progress_crafting));
+        app.insert_resource(recipe_manifest).add_systems(
+            (
+                progress_crafting,
+                gain_energy_when_crafting_completes.after(progress_crafting),
+                set_emitter.after(progress_crafting),
+            )
+                .in_set(SimulationSet)
+                .in_schedule(CoreSchedule::FixedUpdate),
+        );
     }
 }

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -11,7 +11,7 @@ use rand::{distributions::Uniform, prelude::Distribution, rngs::ThreadRng};
 
 use crate::{
     asset_management::manifest::{Id, ItemManifest, Manifest, Recipe, RecipeManifest, Structure},
-    items::{inventory::Inventory, recipe::RecipeData, ItemData},
+    items::{inventory::Inventory, recipe::RecipeData},
     organisms::{energy::EnergyPool, Organism},
     signals::{Emitter, SignalStrength, SignalType},
     simulation::{

--- a/emergence_lib/src/structures/crafting.rs
+++ b/emergence_lib/src/structures/crafting.rs
@@ -11,7 +11,7 @@ use rand::{distributions::Uniform, prelude::Distribution, rngs::ThreadRng};
 
 use crate::{
     asset_management::manifest::{Id, ItemManifest, Manifest, Recipe, RecipeManifest, Structure},
-    items::{inventory::Inventory, recipe::RecipeData, ItemData},
+    items::{inventory::Inventory, recipe::RecipeData},
     organisms::{energy::EnergyPool, Organism},
     signals::{Emitter, SignalStrength, SignalType},
     simulation::geometry::{MapGeometry, TilePos},
@@ -462,12 +462,6 @@ pub(crate) struct CraftingPlugin;
 impl Plugin for CraftingPlugin {
     fn build(&self, app: &mut App) {
         // TODO: Load this from an asset file
-        let mut item_manifest: ItemManifest = Manifest::new();
-        item_manifest.insert("acacia_leaf", ItemData::acacia_leaf());
-        item_manifest.insert("leuco_chunk", ItemData::leuco_chunk());
-        item_manifest.insert("ant_egg", ItemData::ant_egg());
-
-        // TODO: Load this from an asset file
         let mut recipe_manifest: RecipeManifest = Manifest::new();
         recipe_manifest.insert(
             "acacia_leaf_production",
@@ -480,8 +474,7 @@ impl Plugin for CraftingPlugin {
         recipe_manifest.insert("ant_egg_production", RecipeData::ant_egg_production());
         recipe_manifest.insert("hatch_ants", RecipeData::hatch_ants());
 
-        app.insert_resource(item_manifest)
-            .insert_resource(recipe_manifest)
+        app.insert_resource(recipe_manifest)
             .add_system(progress_crafting)
             .add_system(gain_energy_when_crafting_completes.after(progress_crafting))
             .add_system(set_emitter.after(progress_crafting));

--- a/emergence_lib/src/ui/selection_panel.rs
+++ b/emergence_lib/src/ui/selection_panel.rs
@@ -3,8 +3,11 @@
 use bevy::prelude::*;
 
 use crate::{
-    asset_management::manifest::{
-        ItemManifest, RecipeManifest, StructureManifest, TerrainManifest, UnitManifest,
+    asset_management::{
+        manifest::{
+            ItemManifest, RecipeManifest, StructureManifest, TerrainManifest, UnitManifest,
+        },
+        AssetState,
     },
     player_interaction::{selection::SelectionDetails, InteractionSystem},
 };
@@ -16,8 +19,11 @@ pub(super) struct HoverDetailsPlugin;
 
 impl Plugin for HoverDetailsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(populate_hover_panel)
-            .add_system(update_hover_details.after(InteractionSystem::HoverDetails));
+        app.add_startup_system(populate_hover_panel).add_system(
+            update_hover_details
+                .after(InteractionSystem::HoverDetails)
+                .run_if(in_state(AssetState::Ready)),
+        );
     }
 }
 


### PR DESCRIPTION
Closes #368 (I will create follow-up issues for the rest)

We now got the full manifest-from-asset workflow working for the `ItemManifest`! :tada: 

The `RawManifestHandle` now implements `Loadable` so that we can use the existing asset loading workflow.

We also fixed some related bugs, such as the crafting (and some other) systems not running after the assets have been loaded.

Co-authored by Alice.