### PR TITLE
Read structure and terrain names from manifest

### DIFF
--- a/emergence_lib/src/asset_management/manifest/emergence_markers.rs
+++ b/emergence_lib/src/asset_management/manifest/emergence_markers.rs
@@ -2,11 +2,10 @@
 
 use crate::{
     items::{recipe::RecipeData, ItemData},
-    terrain::TerrainData,
     units::UnitData,
 };
 
-use super::{structure::StructureData, Manifest};
+use super::{structure::StructureData, terrain::TerrainData, Manifest};
 
 /// The marker type for [`Id<Recipe>`](super::Id).
 pub struct Recipe;

--- a/emergence_lib/src/asset_management/manifest/emergence_markers.rs
+++ b/emergence_lib/src/asset_management/manifest/emergence_markers.rs
@@ -2,12 +2,11 @@
 
 use crate::{
     items::{recipe::RecipeData, ItemData},
-    structures::StructureData,
     terrain::TerrainData,
     units::UnitData,
 };
 
-use super::Manifest;
+use super::{structure::StructureData, Manifest};
 
 /// The marker type for [`Id<Recipe>`](super::Id).
 pub struct Recipe;

--- a/emergence_lib/src/asset_management/manifest/mod.rs
+++ b/emergence_lib/src/asset_management/manifest/mod.rs
@@ -13,6 +13,7 @@ mod loader;
 pub(crate) mod plugin;
 mod raw;
 pub(crate) mod structure;
+pub(crate) mod terrain;
 
 use bevy::{prelude::*, utils::HashMap};
 use std::fmt::Debug;

--- a/emergence_lib/src/asset_management/manifest/mod.rs
+++ b/emergence_lib/src/asset_management/manifest/mod.rs
@@ -12,6 +12,7 @@ mod identifier;
 mod loader;
 pub(crate) mod plugin;
 mod raw;
+pub(crate) mod structure;
 
 use bevy::{prelude::*, utils::HashMap};
 use std::fmt::Debug;
@@ -76,6 +77,14 @@ where
         self.name_map
             .get(&id)
             .unwrap_or_else(|| panic!("ID {id:?} not found in manifest"))
+    }
+
+    /// Returns the complete list of names of the loaded options.
+    ///
+    /// The order is arbitrary.
+    pub fn names(&self) -> impl IntoIterator<Item = &str> {
+        let variants = self.variants();
+        variants.into_iter().map(|id| self.name(id))
     }
 
     /// The complete list of loaded options.

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -9,7 +9,7 @@ use crate::asset_management::{AssetCollectionExt, AssetState, Loadable};
 use super::{
     loader::RawManifestLoader,
     raw::{RawItemManifest, RawManifest},
-    Manifest, StructureManifest,
+    Manifest, StructureManifest, TerrainManifest,
 };
 
 /// A plugin to handle the creation of all manifest resources.
@@ -18,6 +18,7 @@ pub struct ManifestPlugin;
 impl Plugin for ManifestPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<StructureManifest>()
+            .init_resource::<TerrainManifest>()
             .add_plugin(RawManifestPlugin::<RawItemManifest>::new())
             // This is needed to ensure that the manifest resources are actually created in time for AssetState::Ready
             .add_system(

--- a/emergence_lib/src/asset_management/manifest/plugin.rs
+++ b/emergence_lib/src/asset_management/manifest/plugin.rs
@@ -9,7 +9,7 @@ use crate::asset_management::{AssetCollectionExt, AssetState, Loadable};
 use super::{
     loader::RawManifestLoader,
     raw::{RawItemManifest, RawManifest},
-    Manifest,
+    Manifest, StructureManifest,
 };
 
 /// A plugin to handle the creation of all manifest resources.
@@ -17,7 +17,8 @@ pub struct ManifestPlugin;
 
 impl Plugin for ManifestPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(RawManifestPlugin::<RawItemManifest>::new())
+        app.init_resource::<StructureManifest>()
+            .add_plugin(RawManifestPlugin::<RawItemManifest>::new())
             // This is needed to ensure that the manifest resources are actually created in time for AssetState::Ready
             .add_system(
                 apply_system_buffers

--- a/emergence_lib/src/asset_management/manifest/structure.rs
+++ b/emergence_lib/src/asset_management/manifest/structure.rs
@@ -1,3 +1,5 @@
+//! Data and manifest definitions for structure.
+
 use crate::{
     items::inventory::Inventory,
     organisms::{

--- a/emergence_lib/src/asset_management/manifest/structure.rs
+++ b/emergence_lib/src/asset_management/manifest/structure.rs
@@ -1,0 +1,172 @@
+use crate::{
+    items::inventory::Inventory,
+    organisms::{
+        energy::{Energy, EnergyPool},
+        OrganismVariety,
+    },
+    structures::crafting::{ActiveRecipe, InputInventory},
+};
+use bevy::utils::{Duration, HashSet};
+
+use leafwing_abilities::prelude::Pool;
+
+use super::{Id, Item, Manifest, StructureManifest, Terrain};
+
+/// Information about a single [`Id<Structure>`] variety of structure.
+#[derive(Debug, Clone)]
+pub(crate) struct StructureData {
+    /// Data needed for living structures
+    pub(crate) organism: Option<OrganismVariety>,
+    /// What base variety of structure is this?
+    ///
+    /// Determines the components that this structure gets.
+    pub(crate) kind: StructureKind,
+    /// The amount of work by units required to complete the construction of this building.
+    ///
+    /// If this is [`Duration::ZERO`], no work will be needed at all.
+    pub(crate) build_duration: Duration,
+    /// The set of items needed to create a new copy of this structure
+    pub(crate) construction_materials: InputInventory,
+    /// The set of terrain types that this structure can be built on
+    pub(crate) allowed_terrain_types: HashSet<Id<Terrain>>,
+}
+
+/// What set of components should this structure have?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StructureKind {
+    /// Stores items.
+    Storage {
+        /// The number of slots in the inventory, controlling how large it is.
+        max_slot_count: usize,
+        /// Is any item allowed here, or just one?
+        reserved_for: Option<Id<Item>>,
+    },
+    /// Crafts items, turning inputs into outputs.
+    Crafting {
+        /// Does this structure start with a recipe pre-selected?
+        starting_recipe: ActiveRecipe,
+    },
+}
+
+impl StructureData {
+    /// Returns the starting recipe of the structure
+    ///
+    /// If no starting recipe is set, [`ActiveRecipe::NONE`] will be returned.
+    pub fn starting_recipe(&self) -> &ActiveRecipe {
+        if let StructureKind::Crafting { starting_recipe } = &self.kind {
+            starting_recipe
+        } else {
+            &ActiveRecipe::NONE
+        }
+    }
+
+    /// Returns the set of terrain types that this structure can be built on
+    pub fn allowed_terrain_types(&self) -> &HashSet<Id<Terrain>> {
+        &self.allowed_terrain_types
+    }
+}
+
+impl Default for StructureManifest {
+    fn default() -> Self {
+        let mut manifest: StructureManifest = Manifest::new();
+
+        let leuco_construction_materials = InputInventory {
+            inventory: Inventory::new_from_item(Id::from_name("leuco_chunk"), 1),
+        };
+
+        // TODO: read these from files
+        manifest.insert(
+            "leuco",
+            StructureData {
+                organism: Some(OrganismVariety {
+                    energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
+                }),
+                kind: StructureKind::Crafting {
+                    starting_recipe: ActiveRecipe::new(Id::from_name("leuco_chunk_production")),
+                },
+                build_duration: Duration::from_secs(5),
+                construction_materials: leuco_construction_materials,
+                allowed_terrain_types: HashSet::from_iter([
+                    Id::from_name("loam"),
+                    Id::from_name("muddy"),
+                ]),
+            },
+        );
+
+        let acacia_construction_materials = InputInventory {
+            inventory: Inventory::new_from_item(Id::from_name("acacia_leaf"), 2),
+        };
+
+        manifest.insert(
+            "acacia",
+            StructureData {
+                organism: Some(OrganismVariety {
+                    energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
+                }),
+                kind: StructureKind::Crafting {
+                    starting_recipe: ActiveRecipe::new(Id::from_name("acacia_leaf_production")),
+                },
+                build_duration: Duration::ZERO,
+                construction_materials: acacia_construction_materials,
+                allowed_terrain_types: HashSet::from_iter([
+                    Id::from_name("loam"),
+                    Id::from_name("muddy"),
+                ]),
+            },
+        );
+
+        manifest.insert(
+            "ant_hive",
+            StructureData {
+                organism: None,
+                kind: StructureKind::Crafting {
+                    starting_recipe: ActiveRecipe::new(Id::from_name("ant_egg_production")),
+                },
+                construction_materials: InputInventory::default(),
+                build_duration: Duration::from_secs(10),
+                allowed_terrain_types: HashSet::from_iter([
+                    Id::from_name("loam"),
+                    Id::from_name("muddy"),
+                    Id::from_name("rocky"),
+                ]),
+            },
+        );
+
+        manifest.insert(
+            "hatchery",
+            StructureData {
+                organism: None,
+                kind: StructureKind::Crafting {
+                    starting_recipe: ActiveRecipe::new(Id::from_name("hatch_ants")),
+                },
+                construction_materials: InputInventory::default(),
+                build_duration: Duration::from_secs(5),
+                allowed_terrain_types: HashSet::from_iter([
+                    Id::from_name("loam"),
+                    Id::from_name("muddy"),
+                    Id::from_name("rocky"),
+                ]),
+            },
+        );
+
+        manifest.insert(
+            "storage",
+            StructureData {
+                organism: None,
+                kind: StructureKind::Storage {
+                    max_slot_count: 3,
+                    reserved_for: None,
+                },
+                construction_materials: InputInventory::default(),
+                build_duration: Duration::from_secs(10),
+                allowed_terrain_types: HashSet::from_iter([
+                    Id::from_name("loam"),
+                    Id::from_name("muddy"),
+                    Id::from_name("rocky"),
+                ]),
+            },
+        );
+
+        manifest
+    }
+}

--- a/emergence_lib/src/asset_management/manifest/terrain.rs
+++ b/emergence_lib/src/asset_management/manifest/terrain.rs
@@ -2,7 +2,7 @@
 
 use super::TerrainManifest;
 
-/// Data stored in a [`TerrainManifest`] for each [`Id<Terrain>`].
+/// Data stored in a [`TerrainManifest`] for each [`Id<Terrain>`](super::Id).
 #[derive(Debug)]
 pub(crate) struct TerrainData {
     /// The walking speed multiplier associated with this terrain type.

--- a/emergence_lib/src/asset_management/manifest/terrain.rs
+++ b/emergence_lib/src/asset_management/manifest/terrain.rs
@@ -1,3 +1,5 @@
+//! Data and manifest definitions for terrain.
+
 use super::TerrainManifest;
 
 /// Data stored in a [`TerrainManifest`] for each [`Id<Terrain>`].

--- a/emergence_lib/src/asset_management/manifest/terrain.rs
+++ b/emergence_lib/src/asset_management/manifest/terrain.rs
@@ -1,0 +1,37 @@
+use super::TerrainManifest;
+
+/// Data stored in a [`TerrainManifest`] for each [`Id<Terrain>`].
+#[derive(Debug)]
+pub(crate) struct TerrainData {
+    /// The walking speed multiplier associated with this terrain type.
+    ///
+    /// These values should always be strictly positive.
+    /// Higher values make units walk faster.
+    /// 1.0 is "normal speed".
+    walking_speed: f32,
+}
+
+impl TerrainData {
+    /// Constructs a new [`TerrainData`] object
+    pub(crate) fn new(walking_speed: f32) -> Self {
+        TerrainData { walking_speed }
+    }
+
+    /// Returns the relative walking speed of units on this terrain
+    pub(crate) fn walking_speed(&self) -> f32 {
+        self.walking_speed
+    }
+}
+
+impl Default for TerrainManifest {
+    // TODO: load this from file
+    fn default() -> Self {
+        let mut manifest = TerrainManifest::new();
+
+        manifest.insert("rocky", TerrainData::new(2.0));
+        manifest.insert("loam", TerrainData::new(1.0));
+        manifest.insert("muddy", TerrainData::new(0.5));
+
+        manifest
+    }
+}

--- a/emergence_lib/src/asset_management/mod.rs
+++ b/emergence_lib/src/asset_management/mod.rs
@@ -42,13 +42,13 @@ pub struct AssetManagementPlugin;
 impl Plugin for AssetManagementPlugin {
     fn build(&self, app: &mut App) {
         app.add_state::<AssetState>()
+            .add_plugin(ManifestPlugin)
             .add_asset_collection::<TerrainHandles>()
             .add_asset_collection::<StructureHandles>()
             .add_asset_collection::<UnitHandles>()
             .add_asset_collection::<UiElements>()
             .add_asset_collection::<Icons<Id<Structure>>>()
-            .add_asset_collection::<Icons<TerraformingChoice>>()
-            .add_plugin(ManifestPlugin);
+            .add_asset_collection::<Icons<TerraformingChoice>>();
     }
 }
 

--- a/emergence_lib/src/asset_management/structures.rs
+++ b/emergence_lib/src/asset_management/structures.rs
@@ -1,8 +1,10 @@
 //! Asset loading for structures
 
 use crate::{
-    asset_management::hexagonal_column, enum_iter::IterableEnum,
-    player_interaction::selection::ObjectInteraction, simulation::geometry::MapGeometry,
+    asset_management::{hexagonal_column, manifest::StructureManifest},
+    enum_iter::IterableEnum,
+    player_interaction::selection::ObjectInteraction,
+    simulation::geometry::MapGeometry,
     structures::construction::GhostKind,
 };
 use bevy::{asset::LoadState, prelude::*, utils::HashMap};
@@ -57,14 +59,13 @@ impl FromWorld for StructureHandles {
             picking_mesh,
         };
 
+        let structure_manifest = world.resource::<StructureManifest>();
+        let structure_names = structure_manifest.names();
         let asset_server = world.resource::<AssetServer>();
 
-        // TODO: discover this from the file directory
-        let structure_names = vec!["acacia", "leuco", "ant_hive", "hatchery", "storage"];
-
-        for id in structure_names {
-            let structure_id = Id::from_name(id);
-            let structure_path = format!("structures/{id}.gltf#Scene0");
+        for name in structure_names {
+            let structure_id = Id::from_name(name);
+            let structure_path = format!("structures/{name}.gltf#Scene0");
             let scene = asset_server.load(structure_path);
             handles.scenes.insert(structure_id, scene);
         }

--- a/emergence_lib/src/asset_management/terrain.rs
+++ b/emergence_lib/src/asset_management/terrain.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     hexagonal_column,
-    manifest::{Id, Terrain},
+    manifest::{Id, Terrain, TerrainManifest},
     palette::COLUMN_COLOR,
     Loadable,
 };
@@ -32,10 +32,10 @@ pub(crate) struct TerrainHandles {
 
 impl FromWorld for TerrainHandles {
     fn from_world(world: &mut World) -> Self {
+        let names = world.resource::<TerrainManifest>().names();
         let asset_server = world.resource::<AssetServer>();
 
         let mut scenes = HashMap::new();
-        let names: [&str; 3] = ["loam", "muddy", "rocky"];
         for name in names {
             let path_string = format!("terrain/{name}.gltf#Scene0");
             let scene = asset_server.load(path_string);

--- a/emergence_lib/src/asset_management/terrain.rs
+++ b/emergence_lib/src/asset_management/terrain.rs
@@ -6,12 +6,11 @@ use crate::{
     enum_iter::IterableEnum,
     player_interaction::selection::ObjectInteraction,
     simulation::geometry::{Height, MapGeometry},
-    terrain::TerrainData,
 };
 
 use super::{
     hexagonal_column,
-    manifest::{Id, Terrain, TerrainManifest},
+    manifest::{Id, Terrain},
     palette::COLUMN_COLOR,
     Loadable,
 };
@@ -86,18 +85,5 @@ impl Loadable for TerrainHandles {
         }
 
         LoadState::Loaded
-    }
-}
-
-impl Default for TerrainManifest {
-    // TODO: load this from file
-    fn default() -> Self {
-        let mut manifest = TerrainManifest::new();
-
-        manifest.insert("rocky", TerrainData::new(2.0));
-        manifest.insert("loam", TerrainData::new(1.0));
-        manifest.insert("muddy", TerrainData::new(0.5));
-
-        manifest
     }
 }

--- a/emergence_lib/src/asset_management/ui.rs
+++ b/emergence_lib/src/asset_management/ui.rs
@@ -7,7 +7,7 @@ use core::hash::Hash;
 use crate::player_interaction::terraform::TerraformingChoice;
 
 use super::{
-    manifest::{Id, Structure},
+    manifest::{Id, Structure, StructureManifest},
     Loadable,
 };
 
@@ -50,10 +50,10 @@ impl<D: Send + Sync + 'static + Hash + Eq> Icons<D> {
 impl FromWorld for Icons<Id<Structure>> {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
-        let mut map = HashMap::new();
+        let structure_manifest = world.resource::<StructureManifest>();
+        let structure_names = structure_manifest.names();
 
-        // TODO: discover this from the file directory
-        let structure_names = vec!["acacia", "leuco", "ant_hive", "hatchery", "storage"];
+        let mut map = HashMap::new();
 
         for id in structure_names {
             let structure_id = Id::from_name(id);

--- a/emergence_lib/src/asset_management/ui.rs
+++ b/emergence_lib/src/asset_management/ui.rs
@@ -7,7 +7,7 @@ use core::hash::Hash;
 use crate::player_interaction::terraform::TerraformingChoice;
 
 use super::{
-    manifest::{Id, Structure, StructureManifest},
+    manifest::{Id, Structure, StructureManifest, TerrainManifest},
     Loadable,
 };
 
@@ -71,8 +71,7 @@ impl FromWorld for Icons<TerraformingChoice> {
         let asset_server = world.resource::<AssetServer>();
         let mut map = HashMap::new();
 
-        // TODO: discover this from the file directory
-        let terrain_names = vec!["muddy", "rocky", "loam"];
+        let terrain_names = world.resource::<TerrainManifest>().names();
 
         for id in terrain_names {
             let terrain_id = Id::from_name(id);

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -9,7 +9,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom, thread_rng};
 
 use crate::{
     asset_management::{
-        manifest::{ItemManifest, RecipeManifest},
+        manifest::{structure::StructureKind, ItemManifest, RecipeManifest},
         structures::StructureHandles,
     },
     graphics::InheritedMaterial,
@@ -22,7 +22,7 @@ use crate::{
 use super::{
     construction::{GhostBundle, GhostKind, PreviewBundle},
     crafting::{CraftingBundle, StorageInventory},
-    StructureBundle, StructureKind, StructureManifest,
+    StructureBundle, StructureManifest,
 };
 
 /// An extension trait for [`Commands`] for working with structures.

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -3,20 +3,11 @@
 //! Typically, these will produce and transform resources (much like machines in other factory builders),
 //! but they can also be used for defense, research, reproduction, storage and more exotic effects.
 
-use bevy::{
-    prelude::*,
-    utils::{Duration, HashSet},
-};
+use bevy::prelude::*;
 use bevy_mod_raycast::RaycastMesh;
-use leafwing_abilities::prelude::Pool;
 
 use crate::{
-    asset_management::manifest::{Id, Item, Manifest, Structure, StructureManifest, Terrain},
-    items::inventory::Inventory,
-    organisms::{
-        energy::{Energy, EnergyPool},
-        OrganismVariety,
-    },
+    asset_management::manifest::{Id, Structure, StructureManifest},
     player_interaction::{clipboard::ClipboardData, selection::ObjectInteraction},
     simulation::{
         geometry::{Facing, TilePos},
@@ -26,169 +17,23 @@ use crate::{
 
 use self::{
     construction::{ghost_lifecycle, ghost_signals},
-    crafting::{ActiveRecipe, CraftingPlugin, InputInventory},
+    crafting::CraftingPlugin,
 };
 
 pub(crate) mod commands;
 pub(crate) mod construction;
 pub(crate) mod crafting;
 
-/// Information about a single [`Id<Structure>`] variety of structure.
-#[derive(Debug, Clone)]
-pub(crate) struct StructureData {
-    /// Data needed for living structures
-    organism: Option<OrganismVariety>,
-    /// What base variety of structure is this?
-    ///
-    /// Determines the components that this structure gets.
-    kind: StructureKind,
-    /// The amount of work by units required to complete the construction of this building.
-    ///
-    /// If this is [`Duration::ZERO`], no work will be needed at all.
-    build_duration: Duration,
-    /// The set of items needed to create a new copy of this structure
-    construction_materials: InputInventory,
-    /// The set of terrain types that this structure can be built on
-    pub(crate) allowed_terrain_types: HashSet<Id<Terrain>>,
-}
+/// The systems that make structures tick.
+pub(super) struct StructuresPlugin;
 
-/// What set of components should this structure have?
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum StructureKind {
-    /// Stores items.
-    Storage {
-        /// The number of slots in the inventory, controlling how large it is.
-        max_slot_count: usize,
-        /// Is any item allowed here, or just one?
-        reserved_for: Option<Id<Item>>,
-    },
-    /// Crafts items, turning inputs into outputs.
-    Crafting {
-        /// Does this structure start with a recipe pre-selected?
-        starting_recipe: ActiveRecipe,
-    },
-}
-
-impl StructureData {
-    /// Returns the starting recipe of the structure
-    ///
-    /// If no starting recipe is set, [`ActiveRecipe::NONE`] will be returned.
-    pub fn starting_recipe(&self) -> &ActiveRecipe {
-        if let StructureKind::Crafting { starting_recipe } = &self.kind {
-            starting_recipe
-        } else {
-            &ActiveRecipe::NONE
-        }
-    }
-
-    /// Returns the set of terrain types that this structure can be built on
-    pub fn allowed_terrain_types(&self) -> &HashSet<Id<Terrain>> {
-        &self.allowed_terrain_types
-    }
-}
-
-impl Default for StructureManifest {
-    fn default() -> Self {
-        let mut manifest: StructureManifest = Manifest::new();
-
-        let leuco_construction_materials = InputInventory {
-            inventory: Inventory::new_from_item(Id::from_name("leuco_chunk"), 1),
-        };
-
-        // TODO: read these from files
-        manifest.insert(
-            "leuco",
-            StructureData {
-                organism: Some(OrganismVariety {
-                    energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
-                }),
-                kind: StructureKind::Crafting {
-                    starting_recipe: ActiveRecipe::new(Id::from_name("leuco_chunk_production")),
-                },
-                build_duration: Duration::from_secs(5),
-                construction_materials: leuco_construction_materials,
-                allowed_terrain_types: HashSet::from_iter([
-                    Id::from_name("loam"),
-                    Id::from_name("muddy"),
-                ]),
-            },
+impl Plugin for StructuresPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugin(CraftingPlugin).add_systems(
+            (ghost_signals, ghost_lifecycle)
+                .in_set(SimulationSet)
+                .in_schedule(CoreSchedule::FixedUpdate),
         );
-
-        let acacia_construction_materials = InputInventory {
-            inventory: Inventory::new_from_item(Id::from_name("acacia_leaf"), 2),
-        };
-
-        manifest.insert(
-            "acacia",
-            StructureData {
-                organism: Some(OrganismVariety {
-                    energy_pool: EnergyPool::new_full(Energy(100.), Energy(-1.)),
-                }),
-                kind: StructureKind::Crafting {
-                    starting_recipe: ActiveRecipe::new(Id::from_name("acacia_leaf_production")),
-                },
-                build_duration: Duration::ZERO,
-                construction_materials: acacia_construction_materials,
-                allowed_terrain_types: HashSet::from_iter([
-                    Id::from_name("loam"),
-                    Id::from_name("muddy"),
-                ]),
-            },
-        );
-
-        manifest.insert(
-            "ant_hive",
-            StructureData {
-                organism: None,
-                kind: StructureKind::Crafting {
-                    starting_recipe: ActiveRecipe::new(Id::from_name("ant_egg_production")),
-                },
-                construction_materials: InputInventory::default(),
-                build_duration: Duration::from_secs(10),
-                allowed_terrain_types: HashSet::from_iter([
-                    Id::from_name("loam"),
-                    Id::from_name("muddy"),
-                    Id::from_name("rocky"),
-                ]),
-            },
-        );
-
-        manifest.insert(
-            "hatchery",
-            StructureData {
-                organism: None,
-                kind: StructureKind::Crafting {
-                    starting_recipe: ActiveRecipe::new(Id::from_name("hatch_ants")),
-                },
-                construction_materials: InputInventory::default(),
-                build_duration: Duration::from_secs(5),
-                allowed_terrain_types: HashSet::from_iter([
-                    Id::from_name("loam"),
-                    Id::from_name("muddy"),
-                    Id::from_name("rocky"),
-                ]),
-            },
-        );
-
-        manifest.insert(
-            "storage",
-            StructureData {
-                organism: None,
-                kind: StructureKind::Storage {
-                    max_slot_count: 3,
-                    reserved_for: None,
-                },
-                construction_materials: InputInventory::default(),
-                build_duration: Duration::from_secs(10),
-                allowed_terrain_types: HashSet::from_iter([
-                    Id::from_name("loam"),
-                    Id::from_name("muddy"),
-                    Id::from_name("rocky"),
-                ]),
-            },
-        );
-
-        manifest
     }
 }
 
@@ -230,23 +75,8 @@ impl StructureBundle {
             scene_bundle: SceneBundle {
                 scene: scene_handle,
                 transform: Transform::from_translation(world_pos),
-                ..default()
+                ..Default::default()
             },
         }
-    }
-}
-
-/// The systems that make structures tick.
-pub(super) struct StructuresPlugin;
-
-impl Plugin for StructuresPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_plugin(CraftingPlugin)
-            .init_resource::<StructureManifest>()
-            .add_systems(
-                (ghost_signals, ghost_lifecycle)
-                    .in_set(SimulationSet)
-                    .in_schedule(CoreSchedule::FixedUpdate),
-            );
     }
 }

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -4,7 +4,7 @@ use bevy::ecs::system::Command;
 use bevy::prelude::*;
 use bevy_mod_raycast::RaycastMesh;
 
-use crate::asset_management::manifest::{Id, Terrain, TerrainManifest};
+use crate::asset_management::manifest::{Id, Terrain};
 use crate::asset_management::terrain::TerrainHandles;
 use crate::player_interaction::selection::ObjectInteraction;
 use crate::player_interaction::zoning::Zoning;
@@ -16,34 +16,11 @@ pub(crate) struct TerrainPlugin;
 
 impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<TerrainManifest>().add_system(
+        app.add_system(
             respond_to_height_changes
                 .in_set(SimulationSet)
                 .in_schedule(CoreSchedule::FixedUpdate),
         );
-    }
-}
-
-/// Data stored in a [`TerrainManifest`] for each [`Id<Terrain>`].
-#[derive(Debug)]
-pub(crate) struct TerrainData {
-    /// The walking speed multiplier associated with this terrain type.
-    ///
-    /// These values should always be strictly positive.
-    /// Higher values make units walk faster.
-    /// 1.0 is "normal speed".
-    walking_speed: f32,
-}
-
-impl TerrainData {
-    /// Constructs a new [`TerrainData`] object
-    pub(crate) fn new(walking_speed: f32) -> Self {
-        TerrainData { walking_speed }
-    }
-
-    /// Returns the relative walking speed of units on this terrain
-    pub(crate) fn walking_speed(&self) -> f32 {
-        self.walking_speed
     }
 }
 


### PR DESCRIPTION
Progress towards #577 and #578.

This significantly reduces the amount of manually duplicated lists we have to maintain in the mean time.

I had to move the data definition into the `manifest` module, as these must be ready before we load in our handles.