### PR TITLE
Improve wandering behavior by making multimodal

### DIFF
--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -96,7 +96,7 @@ impl Signals {
         let mut best_score = SignalStrength::ZERO;
 
         let neighboring_signals = match goal {
-            Goal::Wander => return None,
+            Goal::Wander { .. } => return None,
             Goal::Pickup(item_id) | Goal::Eat(item_id) => {
                 let push_signals =
                     self.neighboring_signals(SignalType::Push(*item_id), tile_pos, map_geometry);
@@ -517,7 +517,7 @@ mod tests {
             None
         );
         assert_eq!(
-            signals.upstream(TilePos::ORIGIN, &Goal::Wander, &map_geometry),
+            signals.upstream(TilePos::ORIGIN, &Goal::default(), &map_geometry),
             None
         );
     }

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -67,7 +67,7 @@ pub(super) fn choose_actions(
         if action.finished() {
             *action = match goal {
                 // Alternate between spinning and moving forward.
-                Goal::Wander => match action.action() {
+                Goal::Wander { .. } => match action.action() {
                     UnitAction::Spin { .. } => CurrentAction::move_forward(
                         unit_tile_pos,
                         facing,
@@ -286,7 +286,7 @@ pub(super) fn finish_actions(
                         }
                     } else {
                         // If the target isn't there, pick a new goal
-                        *unit.goal = Goal::Wander;
+                        *unit.goal = Goal::default();
                     }
                 }
                 UnitAction::DropOff {
@@ -298,7 +298,7 @@ pub(super) fn finish_actions(
                     {
                         *unit.goal = match unit.unit_inventory.held_item {
                             // We should be holding something, if we're not find something else to do
-                            None => Goal::Wander,
+                            None => Goal::default(),
                             Some(held_item_id) => {
                                 if held_item_id == *item_id {
                                     let item_count = ItemCount::new(held_item_id, 1);
@@ -319,7 +319,7 @@ pub(super) fn finish_actions(
                                     match transfer_result {
                                         Ok(()) => {
                                             unit.unit_inventory.held_item = None;
-                                            Goal::Wander
+                                            Goal::default()
                                         }
                                         Err(..) => Goal::Store(held_item_id),
                                     }
@@ -331,7 +331,7 @@ pub(super) fn finish_actions(
                         }
                     } else {
                         // If the target isn't there, pick a new goal
-                        *unit.goal = Goal::Wander;
+                        *unit.goal = Goal::default();
                     }
                 }
                 UnitAction::Spin { rotation_direction } => match rotation_direction {
@@ -357,7 +357,7 @@ pub(super) fn finish_actions(
                     }
 
                     if !success {
-                        *unit.goal = Goal::Wander;
+                        *unit.goal = Goal::default();
                     }
                 }
                 UnitAction::Demolish { structure_entity } => {
@@ -367,7 +367,7 @@ pub(super) fn finish_actions(
                     }
 
                     // Whether we succeeded or failed, pick something else to do
-                    *unit.goal = Goal::Wander;
+                    *unit.goal = Goal::default();
                 }
                 UnitAction::Eat => {
                     if let Some(held_item) = unit.unit_inventory.held_item {

--- a/emergence_lib/src/units/goals.rs
+++ b/emergence_lib/src/units/goals.rs
@@ -3,7 +3,8 @@
 use bevy::prelude::*;
 use rand::distributions::WeightedIndex;
 use rand::prelude::Distribution;
-use rand::{thread_rng, Rng};
+use rand::rngs::ThreadRng;
+use rand::thread_rng;
 
 use crate::asset_management::manifest::{
     Id, Item, ItemManifest, Structure, StructureManifest, Unit, UnitManifest,
@@ -13,6 +14,7 @@ use crate::simulation::geometry::TilePos;
 
 use super::impatience::ImpatiencePool;
 use super::item_interaction::UnitInventory;
+use super::WanderingBehavior;
 
 /// A unit's current goals.
 ///
@@ -20,13 +22,15 @@ use super::item_interaction::UnitInventory;
 /// Once a goal is complete, they will typically transition back into [`Goal::Wander`] and attempt to find something new to do.
 ///
 /// This component serves as a state machine.
-#[derive(Component, PartialEq, Eq, Clone, Default, Debug)]
+#[derive(Component, PartialEq, Clone, Debug)]
 pub(crate) enum Goal {
     /// Attempting to find something useful to do
     ///
     /// Units will try and follow a signal, if they can pick up a trail, but will not fixate on it until the signal is strong enough.
-    #[default]
-    Wander,
+    Wander {
+        /// How many actions will this unit take before picking a new goal?
+        remaining_actions: Option<u8>,
+    },
     /// Attempting to pick up an object
     #[allow(dead_code)]
     Pickup(Id<Item>),
@@ -45,6 +49,14 @@ pub(crate) enum Goal {
     Eat(Id<Item>),
     /// Attempting to destroy a structure
     Demolish(Id<Structure>),
+}
+
+impl Default for Goal {
+    fn default() -> Self {
+        Goal::Wander {
+            remaining_actions: None,
+        }
+    }
 }
 
 impl TryFrom<SignalType> for Goal {
@@ -73,7 +85,10 @@ impl Goal {
         structure_manifest: &StructureManifest,
     ) -> String {
         match self {
-            Goal::Wander => "Wander".to_string(),
+            Goal::Wander { remaining_actions } => format!(
+                "Wander ({} actions remaining)",
+                remaining_actions.unwrap_or(0)
+            ),
             Goal::Pickup(item) => format!("Pickup {}", item_manifest.name(*item)),
             Goal::Store(item) => format!("Store {}", item_manifest.name(*item)),
             Goal::Deliver(item) => format!("Deliver {}", item_manifest.name(*item)),
@@ -106,44 +121,80 @@ pub(super) fn choose_goal(
             // If you're holding something, try to put it away nicely
             *goal = if let Some(held_item) = unit_inventory.held_item {
                 // Don't get stuck trying to do a hopeless storage task forever
-                if *goal != Goal::Wander && *goal != Goal::Store(held_item) {
+                if !matches!(*goal, Goal::Store(..) | Goal::Wander { .. }) {
                     Goal::Store(held_item)
                 } else {
-                    Goal::Wander
+                    Goal::Wander {
+                        remaining_actions: None,
+                    }
                 }
             } else {
-                Goal::Wander
+                Goal::Wander {
+                    remaining_actions: None,
+                }
             };
 
             // Reset impatience when we choose a new goal
             impatience_pool.reset();
         }
 
-        // By default, goals are reset to wandering when completed.
-        // Pick a new goal when wandering.
-        // If anything fails, just keep wandering for now.
-        if let Goal::Wander = *goal {
-            let unit_data = unit_manifest.get(*id);
-            // Continuing wandering for longer increases exploration, and allows units to spread out across the map more readily.
-            if rng.gen_bool(1. / unit_data.mean_free_wander_period) {
-                return;
-            }
+        if let Goal::Wander { remaining_actions } = *goal {
+            let wandering_behavior = &unit_manifest.get(*id).wandering_behavior;
+            *goal = compute_new_goal(
+                remaining_actions,
+                tile_pos,
+                wandering_behavior,
+                rng,
+                &signals,
+            );
 
-            let current_signals = signals.all_signals_at_position(tile_pos);
-            let mut goal_relevant_signals = current_signals.goal_relevant_signals();
-            if let Ok(goal_weights) = WeightedIndex::new(
-                goal_relevant_signals
-                    .clone()
-                    .map(|(_type, strength)| strength.value()),
-            ) {
-                let selected_goal_index = goal_weights.sample(rng);
-                if let Some(selected_signal) = goal_relevant_signals.nth(selected_goal_index) {
-                    let selected_signal_type = *selected_signal.0;
-                    *goal = selected_signal_type.try_into().unwrap();
-                    // Reset impatience when we choose a new goal
-                    impatience_pool.reset();
-                }
-            }
+            // Reset impatience when we choose a new goal
+            impatience_pool.reset();
         }
+    }
+}
+
+/// Pick a new goal when wandering.
+///
+// By default, goals are reset to wandering when completed.
+/// If anything fails, just keep wandering for now.
+fn compute_new_goal(
+    mut remaining_actions: Option<u8>,
+    tile_pos: TilePos,
+    wandering_behavior: &WanderingBehavior,
+    rng: &mut ThreadRng,
+    signals: &Signals,
+) -> Goal {
+    // When we first get a wandering goal, pick a number of actions to take before picking a new goal.
+    if remaining_actions.is_none() {
+        remaining_actions = Some(wandering_behavior.sample(rng));
+    }
+
+    // If we have actions left while wandering, use them up before picking a new goal.
+    if let Some(n) = remaining_actions {
+        if n != 0 {
+            return Goal::Wander {
+                remaining_actions: Some(n - 1),
+            };
+        }
+    }
+
+    // Pick a new goal based on the signals at this tile
+    let current_signals = signals.all_signals_at_position(tile_pos);
+    let mut goal_relevant_signals = current_signals.goal_relevant_signals();
+    if let Ok(goal_weights) = WeightedIndex::new(
+        goal_relevant_signals
+            .clone()
+            .map(|(_type, strength)| strength.value()),
+    ) {
+        let selected_goal_index = goal_weights.sample(rng);
+        if let Some(selected_signal) = goal_relevant_signals.nth(selected_goal_index) {
+            let selected_signal_type = *selected_signal.0;
+            selected_signal_type.try_into().unwrap()
+        } else {
+            Goal::Wander { remaining_actions }
+        }
+    } else {
+        Goal::Wander { remaining_actions }
     }
 }

--- a/emergence_lib/src/units/goals.rs
+++ b/emergence_lib/src/units/goals.rs
@@ -29,7 +29,7 @@ pub(crate) enum Goal {
     /// Units will try and follow a signal, if they can pick up a trail, but will not fixate on it until the signal is strong enough.
     Wander {
         /// How many actions will this unit take before picking a new goal?
-        remaining_actions: Option<u8>,
+        remaining_actions: Option<u16>,
     },
     /// Attempting to pick up an object
     #[allow(dead_code)]
@@ -159,7 +159,7 @@ pub(super) fn choose_goal(
 // By default, goals are reset to wandering when completed.
 /// If anything fails, just keep wandering for now.
 fn compute_new_goal(
-    mut remaining_actions: Option<u8>,
+    mut remaining_actions: Option<u16>,
     tile_pos: TilePos,
     wandering_behavior: &WanderingBehavior,
     rng: &mut ThreadRng,

--- a/emergence_lib/src/units/hunger.rs
+++ b/emergence_lib/src/units/hunger.rs
@@ -50,7 +50,9 @@ pub(super) fn check_for_hunger(mut unit_query: Query<(&mut Goal, &EnergyPool, &D
         if energy_pool.is_hungry() {
             *goal = Goal::Eat(diet.item);
         } else if matches!(*goal, Goal::Eat(..)) && energy_pool.is_satiated() {
-            *goal = Goal::Wander
+            *goal = Goal::Wander {
+                remaining_actions: None,
+            }
         }
     }
 }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -50,6 +50,7 @@ pub(crate) struct UnitData {
     wandering_behavior: WanderingBehavior,
 }
 
+/// Controls the distribution of wandering durations on a per-unit-type basis.
 #[derive(Debug, Clone)]
 struct WanderingBehavior {
     /// How many actions will units take while wandering before picking a new goal?
@@ -59,6 +60,7 @@ struct WanderingBehavior {
 }
 
 impl WanderingBehavior {
+    /// Randomly choose the number of actions to take while wandering.
     fn sample(&self, rng: &mut ThreadRng) -> u16 {
         self.wander_durations[self.weights.sample(rng)]
     }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -53,19 +53,19 @@ pub(crate) struct UnitData {
 #[derive(Debug, Clone)]
 struct WanderingBehavior {
     /// How many actions will units take while wandering before picking a new goal?
-    wander_durations: Vec<u8>,
+    wander_durations: Vec<u16>,
     /// The relative probability of each value in `mean_free_wander_period`.
     weights: WeightedIndex<f32>,
 }
 
 impl WanderingBehavior {
-    fn sample(&self, rng: &mut ThreadRng) -> u8 {
+    fn sample(&self, rng: &mut ThreadRng) -> u16 {
         self.wander_durations[self.weights.sample(rng)]
     }
 }
 
-impl FromIterator<(u8, f32)> for WanderingBehavior {
-    fn from_iter<T: IntoIterator<Item = (u8, f32)>>(iter: T) -> Self {
+impl FromIterator<(u16, f32)> for WanderingBehavior {
+    fn from_iter<T: IntoIterator<Item = (u16, f32)>>(iter: T) -> Self {
         let mut wander_durations = Vec::new();
         let mut weights = Vec::new();
         for (duration, weight) in iter {
@@ -101,7 +101,7 @@ impl Default for UnitManifest {
                 },
                 diet: Diet::new(Id::from_name("leuco_chunk"), Energy(50.)),
                 max_impatience: 10,
-                wandering_behavior: WanderingBehavior::from_iter([(2, 0.8), (40, 0.2)]),
+                wandering_behavior: WanderingBehavior::from_iter([(2, 0.5), (1024, 0.5)]),
             },
         );
 

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -101,7 +101,11 @@ impl Default for UnitManifest {
                 },
                 diet: Diet::new(Id::from_name("leuco_chunk"), Energy(50.)),
                 max_impatience: 10,
-                wandering_behavior: WanderingBehavior::from_iter([(2, 0.5), (1024, 0.5)]),
+                wandering_behavior: WanderingBehavior::from_iter([
+                    (0, 0.7),
+                    (64, 0.2),
+                    (1024, 0.1),
+                ]),
             },
         );
 

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 use bevy::prelude::*;
 use bevy_mod_raycast::RaycastMesh;
 use leafwing_abilities::prelude::Pool;
+use rand::{distributions::WeightedIndex, prelude::Distribution, rngs::ThreadRng};
 
 use self::{
     actions::CurrentAction, goals::Goal, hunger::Diet, impatience::ImpatiencePool,
@@ -43,8 +44,39 @@ pub(crate) struct UnitData {
     diet: Diet,
     /// How much impatience this unit can accumulate before getting too frustrated and picking a new task.
     max_impatience: u8,
-    /// How many actions (on average) will this unit take while wandering before picking a new goal?
-    mean_free_wander_period: f64,
+    /// How many actions will units of this type take while wandering before picking a new goal?
+    ///
+    /// This stores a [`WeightedIndex`] to allow for multimodal distributions.
+    wandering_behavior: WanderingBehavior,
+}
+
+#[derive(Debug, Clone)]
+struct WanderingBehavior {
+    /// How many actions will units take while wandering before picking a new goal?
+    wander_durations: Vec<u8>,
+    /// The relative probability of each value in `mean_free_wander_period`.
+    weights: WeightedIndex<f32>,
+}
+
+impl WanderingBehavior {
+    fn sample(&self, rng: &mut ThreadRng) -> u8 {
+        self.wander_durations[self.weights.sample(rng)]
+    }
+}
+
+impl FromIterator<(u8, f32)> for WanderingBehavior {
+    fn from_iter<T: IntoIterator<Item = (u8, f32)>>(iter: T) -> Self {
+        let mut wander_durations = Vec::new();
+        let mut weights = Vec::new();
+        for (duration, weight) in iter {
+            wander_durations.push(duration);
+            weights.push(weight);
+        }
+        WanderingBehavior {
+            wander_durations,
+            weights: WeightedIndex::new(weights).unwrap(),
+        }
+    }
 }
 
 impl UnitData {
@@ -69,7 +101,7 @@ impl Default for UnitManifest {
                 },
                 diet: Diet::new(Id::from_name("leuco_chunk"), Energy(50.)),
                 max_impatience: 10,
-                mean_free_wander_period: 20.,
+                wandering_behavior: WanderingBehavior::from_iter([(2, 0.8), (40, 0.2)]),
             },
         );
 


### PR DESCRIPTION
This PR attempts to make it easier to control wandering behavior by:

1. Swapping to a much simpler (and better communicated) `actions_remaining` mechanism for wandering.
2. Sampling how long ants will wander for from a multimodal distribution.