### PR TITLE
Lazy evaluation of a continuous field of signals

### DIFF
--- a/emergence_lib/src/graphics/mod.rs
+++ b/emergence_lib/src/graphics/mod.rs
@@ -2,7 +2,10 @@
 
 use bevy::prelude::*;
 
-use crate::{asset_management::AssetState, player_interaction::InteractionSystem};
+use crate::{
+    asset_management::AssetState, player_interaction::InteractionSystem,
+    signals::debug_signal_overlay_disabled,
+};
 
 use self::{
     atmosphere::AtmospherePlugin, lighting::LightingPlugin, selection::display_tile_overlay,
@@ -29,7 +32,11 @@ impl Plugin for GraphicsPlugin {
             .add_systems(
                 (inherit_materials, remove_ghostly_shadows).in_base_set(CoreSet::PostUpdate),
             )
-            .add_system(display_tile_overlay.after(InteractionSystem::SelectTiles));
+            .add_system(
+                display_tile_overlay
+                    .after(InteractionSystem::SelectTiles)
+                    .run_if(debug_signal_overlay_disabled),
+            );
     }
 }
 

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -3,6 +3,8 @@
 //! By collecting information about the local environment into a slowly updated, tile-centric data structure,
 //! we can scale path-finding and decisionmaking in a clear and comprehensible way.
 
+mod equation;
+
 use bevy::{prelude::*, utils::HashMap};
 use core::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 use itertools::Itertools;
@@ -14,14 +16,18 @@ use crate::simulation::geometry::{MapGeometry, TilePos};
 use crate::simulation::SimulationSet;
 use crate::units::goals::Goal;
 
-/// The fraction of signals in each cell that will move to each of 6 neighbors each frame.
-///
-/// Higher values will result in more spread out signals.
-///
-/// If no neighbor exists, total diffusion will be reduced correspondingly.
-/// As a result, this value *must* be below 1/6,
-/// and probably should be below 1/7 to avoid weirdness.
-pub const DIFFUSION_FRACTION: f32 = 0.1;
+use self::equation::DiffusionEquation;
+
+/// The diffusivity of signals: how fast signals diffuse to neighboring tiles, in seconds per
+/// tile.
+pub const DIFFUSIVITY: f32 = 0.2;
+
+/// The decay rate of signals: how fast signals decay, in "signal strength" per second.
+pub const DECAY_RATE: f32 = 2.0;
+
+/// The strength below which a signal is considered negligible. The total
+/// quantity of a single emission is considered when trimming signals.
+pub const DECAY_THRESHOLD: f32 = 0.1;
 
 /// The resources and systems need to work with signals
 pub(crate) struct SignalsPlugin;
@@ -34,7 +40,7 @@ impl Plugin for SignalsPlugin {
                 "acacia_leaf",
             ))))
             .add_systems(
-                (emit_signals, diffuse_signals, degrade_signals)
+                (emit_signals, update_signals)
                     .chain()
                     .in_set(SimulationSet)
                     .in_schedule(CoreSchedule::FixedUpdate),
@@ -50,17 +56,17 @@ impl Plugin for SignalsPlugin {
 /// The central resource that tracks all signals.
 #[derive(Resource, Debug, Default)]
 pub struct Signals {
-    /// The spatialized map for each signal
-    maps: HashMap<SignalType, SignalMap>,
+    /// The equations associated to each signal type.
+    signal_equations: HashMap<SignalType, DiffusionEquation>,
 }
 
 impl Signals {
     /// Returns the signal strength of `signal_type` at the given `tile_pos`.
     ///
     /// Missing values will be filled with [`SignalStrength::ZERO`].
-    pub fn get(&self, signal_type: SignalType, tile_pos: TilePos) -> SignalStrength {
-        match self.maps.get(&signal_type) {
-            Some(map) => map.get(tile_pos),
+    fn get(&self, signal_type: SignalType, tile_pos: TilePos) -> SignalStrength {
+        match self.signal_equations.get(&signal_type) {
+            Some(equation) => equation.evaluate_signal(tile_pos),
             None => SignalStrength::ZERO,
         }
     }
@@ -72,12 +78,12 @@ impl Signals {
         tile_pos: TilePos,
         signal_strength: SignalStrength,
     ) {
-        match self.maps.get_mut(&signal_type) {
-            Some(map) => map.add_signal(tile_pos, signal_strength),
+        match self.signal_equations.get_mut(&signal_type) {
+            Some(equation) => equation.emit_signal(tile_pos, signal_strength),
             None => {
-                let mut new_map = SignalMap::default();
-                new_map.add_signal(tile_pos, signal_strength);
-                self.maps.insert(signal_type, new_map);
+                let mut new_equation = DiffusionEquation::default();
+                new_equation.emit_signal(tile_pos, signal_strength);
+                self.signal_equations.insert(signal_type, new_equation);
             }
         }
     }
@@ -87,7 +93,7 @@ impl Signals {
     /// This is useful for decision-making.
     pub(crate) fn all_signals_at_position(&self, tile_pos: TilePos) -> LocalSignals {
         let mut all_signals = HashMap::new();
-        for &signal_type in self.maps.keys() {
+        for &signal_type in self.signal_equations.keys() {
             let strength = self.get(signal_type, tile_pos);
             all_signals.insert(signal_type, strength);
         }
@@ -193,43 +199,6 @@ impl Signals {
 
         signal_strength_map
     }
-
-    /// Diffuses signals from one cell into the next
-    pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
-        for original_map in self.maps.values_mut() {
-            let num_elements = original_map.map.len();
-            let size_hint = num_elements * 6;
-            let mut addition_map = Vec::with_capacity(size_hint);
-            let mut removal_map = Vec::with_capacity(size_hint);
-
-            for (&occupied_tile, original_strength) in original_map
-                .map
-                .iter()
-                .filter(|(_, signal_strength)| SignalStrength::ZERO.ne(signal_strength))
-            {
-                let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
-
-                let mut num_neighbors = 0.0;
-                for neighboring_tile in occupied_tile.empty_neighbors(map_geometry) {
-                    num_neighbors += 1.0;
-                    addition_map.push((neighboring_tile, amount_to_send_to_each_neighbor));
-                }
-                removal_map.push((
-                    occupied_tile,
-                    amount_to_send_to_each_neighbor * num_neighbors,
-                ));
-            }
-
-            // We cannot do this in one step, as we need to avoid bizarre iteration order dependencies
-            for (removal_pos, removal_strength) in removal_map.into_iter() {
-                original_map.subtract_signal(removal_pos, removal_strength)
-            }
-
-            for (addition_pos, addition_strength) in addition_map.into_iter() {
-                original_map.add_signal(addition_pos, addition_strength)
-            }
-        }
-    }
 }
 
 /// All of the signals on a single tile.
@@ -270,41 +239,6 @@ impl LocalSignals {
         }
 
         string
-    }
-}
-
-/// Stores the [`SignalStrength`] of the given [`SignalType`] at each [`TilePos`].
-#[derive(Debug, Default)]
-struct SignalMap {
-    /// The lookup data structure
-    map: HashMap<TilePos, SignalStrength>,
-}
-
-impl SignalMap {
-    /// Returns the signal strenth at the given [`TilePos`].
-    ///
-    /// Missing values will be filled with [`SignalStrength::ZERO`].
-    fn get(&self, tile_pos: TilePos) -> SignalStrength {
-        *self.map.get(&tile_pos).unwrap_or(&SignalStrength::ZERO)
-    }
-
-    /// Returns a mutable reference to the signal strength at the given [`TilePos`].
-    ///
-    /// Missing values will be inserted with [`SignalStrength::ZERO`].
-    fn get_mut(&mut self, tile_pos: TilePos) -> &mut SignalStrength {
-        self.map.entry(tile_pos).or_insert(SignalStrength::ZERO)
-    }
-
-    /// Adds the `signal_strength` to the signal at `tile_pos`.
-    fn add_signal(&mut self, tile_pos: TilePos, signal_strength: SignalStrength) {
-        *self.get_mut(tile_pos) += signal_strength
-    }
-
-    /// Subtracts the `signal_strength` to the signal at `tile_pos`.
-    ///
-    /// The value is capped a minimum of [`SignalStrength::ZERO`].
-    fn subtract_signal(&mut self, tile_pos: TilePos, signal_strength: SignalStrength) {
-        *self.get_mut(tile_pos) -= signal_strength;
     }
 }
 
@@ -432,44 +366,20 @@ fn emit_signals(mut signals: ResMut<Signals>, emitter_query: Query<(&TilePos, &E
 }
 
 /// Spreads signals between tiles.
-fn diffuse_signals(mut signals: ResMut<Signals>, map_geometry: Res<MapGeometry>) {
-    let map_geometry = &*map_geometry;
-    signals.diffuse(map_geometry, DIFFUSION_FRACTION);
-}
-
-/// Degrades signals, allowing them to approach an asymptotically constant level.
-fn degrade_signals(mut signals: ResMut<Signals>) {
-    /// The fraction of signal that will decay at each step.
-    ///
-    /// Higher values lead to faster decay and improved signal responsiveness.
-    /// This must always be between 0 and 1.
-    const DEGRADATION_FRACTION: f32 = 0.01;
-
-    /// The value below which decayed signals are eliminated completely
-    ///
-    /// Increasing this value will:
-    ///  - increase computational costs
-    ///  - increase the range at which tasks can be detected
-    ///  - increase the amount of time units will wait around for more production
-    const EPSILON_STRENGTH: SignalStrength = SignalStrength(1e-8);
-
-    for signal_map in signals.maps.values_mut() {
-        let mut tiles_to_clear: Vec<TilePos> = Vec::with_capacity(signal_map.map.len());
-
-        for (tile_pos, signal_strength) in signal_map.map.iter_mut() {
-            let new_strength = *signal_strength * (1. - DEGRADATION_FRACTION);
-
-            if new_strength > EPSILON_STRENGTH {
-                *signal_strength = new_strength;
-            } else {
-                tiles_to_clear.push(*tile_pos);
-            }
-        }
-
-        for tile_to_clear in tiles_to_clear {
-            signal_map.map.remove(&tile_to_clear);
+fn update_signals(mut signals: ResMut<Signals>, time: Res<Time>) {
+    let current_time = time.elapsed_seconds_wrapped();
+    let mut signals_to_clear = Vec::new();
+    for (signal_type, equation) in signals.signal_equations.iter_mut() {
+        equation.advance_time(current_time);
+        if equation.trim_neglible_emissions() {
+            signals_to_clear.push(*signal_type);
         }
     }
+    for signal_type in signals_to_clear {
+        signals.signal_equations.remove(&signal_type);
+        trace!("Cleared signal {:?}", signal_type);
+    }
+    trace!("{} Signal types left", signals.signal_equations.len());
 }
 
 #[derive(Resource, Debug)]

--- a/emergence_lib/src/signals/equation.rs
+++ b/emergence_lib/src/signals/equation.rs
@@ -43,18 +43,16 @@ impl DiffusionEquation {
             let time = self.time - time;
             debug_assert!(time > 0.0);
             // Using hex's distance makes distances a little bit "squished" in directions of the
-            // polygons' vertices.
+            // polygons' vertices, and a contour-line plot of signal strength would show hexagons
+            // instead of circles.
             // TODO: Should we use another distance function ? e.g. one that computes a distance
             //       equivalent to world distance.
             let x = source.distance_to(at_tile.hex) as f32;
-            sum += strength
-                / 2.0
-                / (1.0 + DECAY_RATE * time)
-                / (consts::PI * DIFFUSIVITY * time).sqrt()
-                * (0.25 * x * -x / DIFFUSIVITY / time).exp();
+            sum += strength / (4.0 * (1.0 + DECAY_RATE * time) * consts::PI * DIFFUSIVITY * time)
+                * (-0.25 * x * x / (DIFFUSIVITY * time)).exp();
             // Same expression, with precision loss optimized by Herbie (though it should be negligible):
-            // sum += (t * consts::PI * DIFFUSIVITY).powf(0.5) * 0.5 / (DECAY.mul_add(time, 1))
-            //     * (-x * x).div(DIFFUSIVITY * 4.0 * time).exp();
+            // sum += 0.25 * consts::FRAC_1_PI * (strength / DIFFUSIVITY)
+            //     * ((x / DIFFUSIVITY * (-0.25 * x / time)).exp() / time);
         }
         SignalStrength(sum)
     }

--- a/emergence_lib/src/signals/equation.rs
+++ b/emergence_lib/src/signals/equation.rs
@@ -1,0 +1,119 @@
+use std::{collections::VecDeque, f32::consts};
+
+use bevy::prelude::trace;
+
+use crate::simulation::geometry::TilePos;
+
+use super::{SignalStrength, DECAY_RATE, DECAY_THRESHOLD, DIFFUSIVITY};
+
+#[derive(Clone, Copy, Debug)]
+pub struct SignalEmission {
+    /// Time at which the signal was emitted.
+    pub time: f32,
+    /// Strength of the emitted signal.
+    pub strength: f32,
+    /// Position of the signal source.
+    pub source: TilePos,
+}
+
+/// A solver for the diffusion equation, optimized towards emergence's use case.
+///
+/// The characteristics of emergence relevant to the problem can be summarized as the following:
+/// - Few occasional sources emitting "packets" of signal
+// NOTE: One equation per signal type implies they don't interact together.
+#[derive(Default, Debug)]
+pub struct DiffusionEquation {
+    /// A list of signal sources
+    emissions: VecDeque<SignalEmission>,
+    /// The time at which the equation is evaluated.
+    time: f32,
+}
+
+impl DiffusionEquation {
+    /// Integrate contributions to the signal field to compute its value.
+    #[inline]
+    pub fn evaluate_signal(&self, at_tile: TilePos) -> SignalStrength {
+        let mut sum = 0.0;
+        for SignalEmission {
+            time,
+            strength,
+            source,
+        } in &self.emissions
+        {
+            let time = self.time - time;
+            debug_assert!(time > 0.0);
+            // Using hex's distance makes distances a little bit "squished" in directions of the
+            // polygons' vertices.
+            // TODO: Should we use another distance function ? e.g. one that computes a distance
+            //       equivalent to world distance.
+            let x = source.distance_to(at_tile.hex) as f32;
+            sum += strength
+                / 2.0
+                / (1.0 + DECAY_RATE * time)
+                / (consts::PI * DIFFUSIVITY * time).sqrt()
+                * (0.25 * x * -x / DIFFUSIVITY / time).exp();
+            // Same expression, with precision loss optimized by Herbie (though it should be negligible):
+            // sum += (t * consts::PI * DIFFUSIVITY).powf(0.5) * 0.5 / (DECAY.mul_add(time, 1))
+            //     * (-x * x).div(DIFFUSIVITY * 4.0 * time).exp();
+        }
+        SignalStrength(sum)
+    }
+
+    /// Start emitting a signal of given `strength` at the `source_tile` position.
+    #[inline]
+    pub fn emit_signal(&mut self, source: TilePos, SignalStrength(strength): SignalStrength) {
+        self.emissions.push_back(SignalEmission {
+            time: self.time,
+            strength,
+            source,
+        });
+    }
+
+    /// Sets the time at which the equation will be evaluated to the given `current_time`. This
+    // doesn't recompute anything and is very cheap.
+    #[inline]
+    pub fn advance_time(&mut self, current_time: f32) {
+        debug_assert!(self.time <= current_time);
+        self.time = current_time;
+    }
+
+    /// Get rid of signal emissions that do contribute to negligible amounts to the global
+    /// signal.
+    ///
+    /// If `true` is returned, any further evaluation of this equation will be
+    /// [`SignalStrength::ZERO`][super::SignalStrength::ZERO] unless
+    /// [`emit_signal`][DiffusionEquation::emit_signal] is called.
+    pub fn trim_neglible_emissions(&mut self) -> bool {
+        trace!("Attempting trimming among {} sources", self.emissions.len());
+        let mut visited = 0;
+        while visited < self.emissions.len() {
+            match self.emissions.pop_back() {
+                // If the emission has been there long enough, decay will eventually take over.
+                // The comparison here checks whether the area under the curve of the solution
+                // (which could be seen as the amount of pheromones) is lower than some threshold
+                // proportional to the strength of the signal. Since this area is directly
+                // proportional to the strength as well, this implies the signal emission will
+                // be trimmed after some time inversely proportional to the decay rate.
+                // Intuitively, this would be like waiting until the most of pheromones
+                // dispersed by the emitted signal decay, the precise amount we consider
+                // negligible being more for fast decaying signals (we'll trim it earlier), and
+                // less for slowly decaying ones (we'll trim it later)
+                Some(SignalEmission { time, strength, .. })
+                    if DECAY_THRESHOLD * (1.0 + DECAY_RATE * (self.time - time)) > strength => {}
+                Some(emission) => {
+                    trace!(
+                        "Total strength left for emission {:?}: {}",
+                        emission,
+                        emission.strength / (1.0 + DECAY_RATE * emission.time)
+                    );
+                    self.emissions.push_front(emission);
+                    visited += 1;
+                }
+                None => {
+                    return true;
+                }
+            }
+        }
+        return self.emissions.is_empty();
+    }
+}

--- a/emergence_lib/src/signals/mod.rs
+++ b/emergence_lib/src/signals/mod.rs
@@ -23,7 +23,7 @@ use self::equation::DiffusionEquation;
 pub const DIFFUSIVITY: f32 = 0.2;
 
 /// The decay rate of signals: how fast signals decay, in "signal strength" per second.
-pub const DECAY_RATE: f32 = 2.0;
+pub const DECAY_RATE: f32 = 1.5;
 
 /// The strength below which a signal is considered negligible. The total
 /// quantity of a single emission is considered when trimming signals.

--- a/emergence_lib/src/signals/mod.rs
+++ b/emergence_lib/src/signals/mod.rs
@@ -440,7 +440,6 @@ fn debug_display_signal_overlay(
             overlay_query.get_mut(overlay_entity).unwrap();
 
         let signal_strength = signals.get(displayed_signal.0, *tile_pos).0;
-        // Just a simple dark red (low strength) to bright yellow (high strength) color scheme
         // The scale is logarithmic, so that small nuances are still pretty visible
         let scaled_strength = signal_strength.ln_1p() / 6.0;
         let color_index = if signal_strength < f32::EPSILON {

--- a/emergence_lib/src/signals/mod.rs
+++ b/emergence_lib/src/signals/mod.rs
@@ -36,9 +36,9 @@ impl Plugin for SignalsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Signals>()
             .init_resource::<DebugColorScheme>()
-            .insert_resource(DebugDisplayedSignal(SignalType::Push(Id::from_name(
-                "acacia_leaf",
-            ))))
+            // .insert_resource(DebugDisplayedSignal(SignalType::Push(Id::from_name(
+            //     "acacia_leaf",
+            // ))))
             .add_systems(
                 (emit_signals, update_signals)
                     .chain()
@@ -64,7 +64,7 @@ impl Signals {
     /// Returns the signal strength of `signal_type` at the given `tile_pos`.
     ///
     /// Missing values will be filled with [`SignalStrength::ZERO`].
-    fn get(&self, signal_type: SignalType, tile_pos: TilePos) -> SignalStrength {
+    pub(crate) fn get(&self, signal_type: SignalType, tile_pos: TilePos) -> SignalStrength {
         match self.signal_equations.get(&signal_type) {
             Some(equation) => equation.evaluate_signal(tile_pos),
             None => SignalStrength::ZERO,


### PR DESCRIPTION
Fixes #511

These patches implement an algorithm solving the diffusion equation "on-demand". It is still only a draft, and needs optimization to perform better than the fixed-time step diffusion passes.

# Closed form of the solution to diffusion

As pointed out by @RobWalt [here](https://github.com/Leafwing-Studios/Emergence/issues/511#issuecomment-1474352241), solving the simplified diffusion equation in our case boils down to computing a convolution of a so-called fundamental solution and initial conditions. The fundamental solution is the solution with no border condition and a Dirac delta as initial conditions.

![u(x,t) = int(phi(x-y,t)g(y)dy)](https://user-images.githubusercontent.com/26892280/226018851-18344504-d346-4910-98b5-0008ca05b695.png)

The approach I took may be different than what was outlined in the comment linked above, so I'll develop a bit further. I'll ignore border conditions (obstruction by structures) for now.

It would make sense to model emission of signals as Dirac delta functions (at the instant they are emitted), which then get diffused. This means that solving for 1 just-emitted emission is trivial: this is just the fundamental solution.

![fundamental solution](https://user-images.githubusercontent.com/26892280/225958271-24321387-048b-4db6-b9d3-18a4249d71ea.png)

For one emission emitted some time ago, we would have to compute the convolution. Unless we keep track of when (and where) signals are emitted:

`u(x, t) = ϕ(x-x0, t-T0)`

For several emissions (potentially emitted at different times), we could solve for one emission while the second hasn't been emitted, then do the complete convolution, and so forth for the following ones. However, convolutions are distributive, so the solution is the sum of the contributions of each emissions, no matter when they were emitted.

So generally for `n` emissions:

`u(x, t) = ϕ(x-x0, t-T0) + ϕ(x-x1, t-T1) + ... + ϕ(x-xn, t-Tn) `

This allows us to model the field exactly with 2 parameters per signal emissions.

# Expressing decay

The fundamental solution of the simplified diffusion equation we use represents a "density" of the diffused material. We could see it as pheromone concentration. The field being a density means we can integrate over its surface to get a total "amount" of pheromones. This "volume" is constant for the fundamental solution previously described, which means no signal strength is lost, it only gets displaced.

We could interpret decay as a gradual loss of signal strength, which would need us to use a fundamental solution that keeps the same shape as without decay, but with a decreasing volume. This is actually quite easy, we just need to add a dividing factor to the fundamental solution:

```
ϕ(x, t) = 1/(1 + D t) exp(-x^2/(4 k t)) / sqrt(4 pi k t)
          ^^^^^^^^^^^
```

# The algorithm

We use 3 types:
- `SignalEmission`, representing a single emission pulse: its location, the time when it was emitted, and its strength.
- DiffusionEquation, representing a single equation, parametrized by several `SignalEmission`s, and the current time.
- `Signals`, mapping signal types to their equation.

Every time the `update_signals` system runs, we increment the current time of each `DiffusionEquation`. We then prune `SignalEmission`s which are considered negligible: any emission whose strength is smaller than `Th (1 + D t)` (where `D` is the decay rate, `t` the time since emission, and `Th` some threshold) is removed from the equation. This is equivalent to pruning emissions whose volume under the curve is less than `Th`.

To emit a signal, we simply add a `SignalEmission` to the `DiffusionEquation`, with emission time set to the current time.

When a signal is accessed, we get the associated `DiffusionEquation` and iterate over its emissions. We compute the fundamental solution for each emission and accumulate them before returning the result. There is one subtlety: The distance is computed in tiles (using hexx' `Hex::distance_to` function), meaning that contour lines of equal signal strength are hexagons instead of circles.

# Possible improvements

Some of the features the previous signals implementation had, and some that may be needed/nice later, are not handled yet by this algorithm:

- Structures should block signal propagation.
- Diffusivity may vary from place to place.

The amount of signal emissions stored seems to be the bottleneck, making this *slower* than the previous signal diffusion. But I'm pretty sure we could prune way more aggressively emissions, and that past some time their shape is so similar we can approximate a bunch with just one.

- Approximating "old" emissions with only one.
- Prune emissions more aggressively
- Prune emissions based on the amount stored rather than on the time they were emitted.

There's also some other things to investigate:

- When incrementing time, we iterate over each signal type, is this okay ?
- Would caching field value per tile be useful ?
- How to speed up the "debug" signal overlay ?

# Todos

- [ ] Fix current pruning, which seems to work well only for some signals, or is not aggressive enough, to the point some signals easily reach 20k+ emissions (oopsie). 
- [ ] Correctly expose/hide the signals API (`pub` vs `pub(crate)` vs private)
- [ ] Correctly integrate the "debug" signal overlay (currently requires uncommenting code)
- [ ] Write adequate/missing documentation
- [ ] Ensure tests and benchmarks still work and make sense
- [ ] Benchmark
- [ ] Allow approximating two (or more) emissions with one.
- [ ] Make the pruning of signal emissions from equations smarter.
- [ ] Appease clippy