### PR TITLE
Visualize status of units and workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_mod_billboard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0073b07413bff1989a129922bf458774a1a786aa5cc06d4553efd7ba3e7d6772"
+dependencies = [
+ "bevy",
+ "bitflags",
+]
+
+[[package]]
 name = "bevy_mod_raycast"
 version = "0.7.0"
 source = "git+https://github.com/soerenmeier/bevy_mod_raycast?branch=bevy-0.10#ebec4facf385ff789080e32b7fd1f2ea99a6a986"
@@ -1669,6 +1679,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bevy",
+ "bevy_mod_billboard",
  "bevy_mod_raycast",
  "bevy_screen_diagnostics",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,8 +744,7 @@ dependencies = [
 [[package]]
 name = "bevy_mod_billboard"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0073b07413bff1989a129922bf458774a1a786aa5cc06d4553efd7ba3e7d6772"
+source = "git+https://github.com/alice-i-cecile/bevy_mod_billboard/?branch=memory-leak#e0c0ff06c3dd155b00d87b694ff9e8d04d90e391"
 dependencies = [
  "bevy",
  "bitflags",

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -13,6 +13,7 @@ debug_tools = ['dep:debug_tools']
 
 [dependencies]
 bevy = "0.10"
+bevy_mod_billboard = "0.2"
 rand = "0.8"
 noisy_bevy = "0.3"
 leafwing-input-manager = "0.9"

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -13,7 +13,7 @@ debug_tools = ['dep:debug_tools']
 
 [dependencies]
 bevy = "0.10"
-bevy_mod_billboard = "0.2"
+bevy_mod_billboard = {git = "https://github.com/alice-i-cecile/bevy_mod_billboard/", branch = "memory-leak"}
 rand = "0.8"
 noisy_bevy = "0.3"
 leafwing-input-manager = "0.9"

--- a/emergence_lib/src/asset_management/palette.rs
+++ b/emergence_lib/src/asset_management/palette.rs
@@ -4,7 +4,7 @@
 pub(crate) mod infovis {
     use bevy::prelude::Color;
 
-    use crate::signals::SignalKind;
+    use crate::{signals::SignalKind, units::goals::Goal};
 
     /// The alpha value used for selection/hovering/other UI overlay
     const OVERLAY_ALPHA: f32 = 0.5;
@@ -133,6 +133,56 @@ pub(crate) mod infovis {
                 Self::SIGNAL_LIGHTNESS_HIGH,
                 OVERLAY_ALPHA,
             )
+        }
+    }
+
+    impl Goal {
+        /// Gets the color associated with each variety of goal.
+        pub(crate) const fn color(&self) -> Color {
+            match self {
+                Goal::Wander { .. } => Color::Hsla {
+                    hue: 330.,
+                    saturation: 0.2,
+                    lightness: 0.9,
+                    alpha: 1.0,
+                },
+                Goal::Pickup(_) => Color::Hsla {
+                    hue: SignalKind::Pull.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Store(_) => Color::Hsla {
+                    hue: SignalKind::Stores.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Deliver(_) => Color::Hsla {
+                    hue: SignalKind::Push.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Work(_) => Color::Hsla {
+                    hue: SignalKind::Work.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Eat(_) => Color::Hsla {
+                    hue: 60.,
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Demolish(_) => Color::Hsla {
+                    hue: SignalKind::Demolish.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+            }
         }
     }
 }

--- a/emergence_lib/src/asset_management/palette.rs
+++ b/emergence_lib/src/asset_management/palette.rs
@@ -4,7 +4,7 @@
 pub(crate) mod infovis {
     use bevy::prelude::Color;
 
-    use crate::{signals::SignalKind, units::goals::Goal};
+    use crate::{signals::SignalKind, structures::crafting::CraftingState, units::goals::Goal};
 
     /// The alpha value used for selection/hovering/other UI overlay
     const OVERLAY_ALPHA: f32 = 0.5;
@@ -137,7 +137,7 @@ pub(crate) mod infovis {
     }
 
     impl Goal {
-        /// Gets the color associated with each variety of goal.
+        /// Returns the color associated with each variety of goal.
         pub(crate) const fn color(&self) -> Color {
             match self {
                 Goal::Wander { .. } => Color::Hsla {
@@ -182,6 +182,20 @@ pub(crate) mod infovis {
                     lightness: 0.7,
                     alpha: 1.0,
                 },
+            }
+        }
+    }
+
+    impl CraftingState {
+        /// Returns the color associated with each crafting state.
+        pub(crate) const fn color(&self) -> Color {
+            match self {
+                CraftingState::NeedsInput => Color::YELLOW,
+                CraftingState::InProgress { .. } => Color::GREEN,
+                CraftingState::FullAndBlocked => Color::YELLOW,
+                CraftingState::RecipeComplete => Color::PINK,
+                CraftingState::Overproduction => Color::PURPLE,
+                CraftingState::NoRecipe => Color::WHITE,
             }
         }
     }

--- a/emergence_lib/src/ui/mod.rs
+++ b/emergence_lib/src/ui/mod.rs
@@ -3,7 +3,7 @@
 use crate::ui::{
     overlay::OverlayMenuPlugin, production_statistics::ProductionStatisticsPlugin,
     select_structure::SelectStructurePlugin, select_terraforming::SelectTerraformingPlugin,
-    selection_panel::HoverDetailsPlugin,
+    selection_panel::HoverDetailsPlugin, status::StatusPlugin,
 };
 use bevy::prelude::*;
 use bevy_screen_diagnostics::{ScreenDiagnosticsPlugin, ScreenFrameDiagnosticsPlugin};
@@ -14,6 +14,7 @@ mod production_statistics;
 mod select_structure;
 mod select_terraforming;
 mod selection_panel;
+mod status;
 mod wheel_menu;
 
 /// The font handles for the `FiraSans` font family.
@@ -42,6 +43,7 @@ impl Plugin for UiPlugin {
         .add_plugin(ScreenFrameDiagnosticsPlugin)
         .add_plugin(HoverDetailsPlugin)
         .add_plugin(ProductionStatisticsPlugin)
+        .add_plugin(StatusPlugin)
         .add_plugin(OverlayMenuPlugin)
         .add_plugin(SelectStructurePlugin)
         .add_plugin(SelectTerraformingPlugin);

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -49,6 +49,11 @@ fn display_status(
     fonts: Res<FiraSansFontFamily>,
     mut commands: Commands,
 ) {
+    // PERF: immediate mode for now
+    for entity in status_display_query.iter() {
+        commands.entity(entity).despawn_recursive();
+    }
+
     if status_visualization.enabled {
         for (transform, goal) in unit_query.iter() {
             commands
@@ -90,10 +95,6 @@ fn display_status(
                     ..Default::default()
                 })
                 .insert(StatusDisplay);
-        }
-    } else {
-        for entity in status_display_query.iter() {
-            commands.entity(entity).despawn_recursive();
         }
     }
 }

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -4,7 +4,12 @@ use bevy::prelude::*;
 use bevy_mod_billboard::{BillboardPlugin, BillboardTextBundle};
 
 use crate::{
-    asset_management::AssetState, structures::crafting::CraftingState, units::goals::Goal,
+    asset_management::{
+        manifest::{ItemManifest, StructureManifest},
+        AssetState,
+    },
+    structures::crafting::CraftingState,
+    units::goals::Goal,
 };
 
 use super::FiraSansFontFamily;
@@ -47,6 +52,8 @@ fn display_status(
     crafting_query: Query<(&Transform, &CraftingState)>,
     status_display_query: Query<Entity, With<StatusDisplay>>,
     fonts: Res<FiraSansFontFamily>,
+    item_manifest: Res<ItemManifest>,
+    structure_manifest: Res<StructureManifest>,
     mut commands: Commands,
 ) {
     // PERF: immediate mode for now
@@ -70,7 +77,7 @@ fn display_status(
                 .spawn(BillboardTextBundle {
                     transform,
                     text: Text::from_section(
-                        format!("{:?}", goal),
+                        format!("{}", goal.display(&item_manifest, &structure_manifest)),
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),
@@ -98,7 +105,7 @@ fn display_status(
                 .spawn(BillboardTextBundle {
                     transform,
                     text: Text::from_section(
-                        format!("{:?}", crafting_state),
+                        format!("{crafting_state}"),
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -81,7 +81,7 @@ fn display_status(
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),
-                            color: Color::WHITE,
+                            color: goal.color(),
                         },
                     )
                     .with_alignment(TextAlignment::Center),

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -1,6 +1,7 @@
 //! Code to display the status of each unit and crafting structure.
 
 use bevy::prelude::*;
+use bevy_mod_billboard::{BillboardPlugin, BillboardTextBundle};
 
 use crate::{
     asset_management::AssetState, structures::crafting::CraftingState, units::goals::Goal,
@@ -14,7 +15,8 @@ impl Plugin for StatusPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<StatusVisualization>()
             .add_system(toggle_status_visualization.before(display_status))
-            .add_system(display_status.run_if(in_state(AssetState::Ready)));
+            .add_system(display_status.run_if(in_state(AssetState::Ready)))
+            .add_plugin(BillboardPlugin);
     }
 }
 
@@ -50,7 +52,7 @@ fn display_status(
     if status_visualization.enabled {
         for (transform, goal) in unit_query.iter() {
             commands
-                .spawn(Text2dBundle {
+                .spawn(BillboardTextBundle {
                     text: Text::from_section(
                         format!("Goal: {:?}", goal),
                         TextStyle {
@@ -71,7 +73,7 @@ fn display_status(
 
         for (transform, crafting_state) in crafting_query.iter() {
             commands
-                .spawn(Text2dBundle {
+                .spawn(BillboardTextBundle {
                     text: Text::from_section(
                         format!("Crafting: {:?}", crafting_state),
                         TextStyle {

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -109,7 +109,7 @@ fn display_status(
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),
-                            color: Color::WHITE,
+                            color: crafting_state.color(),
                         },
                     )
                     .with_alignment(TextAlignment::Center),

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -14,6 +14,7 @@ use crate::{
 
 use super::FiraSansFontFamily;
 
+/// Plugin that displays the status of each unit and crafting structure.
 pub(super) struct StatusPlugin;
 
 impl Plugin for StatusPlugin {
@@ -32,6 +33,7 @@ struct StatusDisplay;
 /// Controls the visibility of the status display.
 #[derive(Resource, Default)]
 struct StatusVisualization {
+    /// Should we display this information?
     enabled: bool,
 }
 
@@ -46,6 +48,7 @@ fn toggle_status_visualization(
 }
 
 /// Displays the status of each unit and crafting structure.
+#[allow(clippy::too_many_arguments)]
 fn display_status(
     status_visualization: Res<StatusVisualization>,
     unit_query: Query<(&Transform, &Goal)>,
@@ -77,7 +80,7 @@ fn display_status(
                 .spawn(BillboardTextBundle {
                     transform,
                     text: Text::from_section(
-                        format!("{}", goal.display(&item_manifest, &structure_manifest)),
+                        goal.display(&item_manifest, &structure_manifest),
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -1,0 +1,97 @@
+//! Code to display the status of each unit and crafting structure.
+
+use bevy::prelude::*;
+
+use crate::{
+    asset_management::AssetState, structures::crafting::CraftingState, units::goals::Goal,
+};
+
+use super::FiraSansFontFamily;
+
+pub(super) struct StatusPlugin;
+
+impl Plugin for StatusPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<StatusVisualization>()
+            .add_system(toggle_status_visualization.before(display_status))
+            .add_system(display_status.run_if(in_state(AssetState::Ready)));
+    }
+}
+
+/// Marker component for entities that display the status of a unit or crafting structure.
+#[derive(Component)]
+struct StatusDisplay;
+
+/// Controls the visibility of the status display.
+#[derive(Resource, Default)]
+struct StatusVisualization {
+    enabled: bool,
+}
+
+/// Toggles the status display on and off.
+fn toggle_status_visualization(
+    mut status_visualization: ResMut<StatusVisualization>,
+    keyboard_input: Res<Input<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::F2) {
+        status_visualization.enabled = !status_visualization.enabled;
+    }
+}
+
+/// Displays the status of each unit and crafting structure.
+fn display_status(
+    status_visualization: Res<StatusVisualization>,
+    unit_query: Query<(&Transform, &Goal)>,
+    crafting_query: Query<(&Transform, &CraftingState)>,
+    status_display_query: Query<Entity, With<StatusDisplay>>,
+    fonts: Res<FiraSansFontFamily>,
+    mut commands: Commands,
+) {
+    if status_visualization.enabled {
+        for (transform, goal) in unit_query.iter() {
+            commands
+                .spawn(Text2dBundle {
+                    text: Text::from_section(
+                        format!("Goal: {:?}", goal),
+                        TextStyle {
+                            font: fonts.regular.clone_weak(),
+                            font_size: 20.0,
+                            color: Color::WHITE,
+                        },
+                    ),
+                    transform: Transform::from_translation(Vec3::new(
+                        transform.translation.x,
+                        transform.translation.y + 0.5,
+                        transform.translation.z,
+                    )),
+                    ..Default::default()
+                })
+                .insert(StatusDisplay);
+        }
+
+        for (transform, crafting_state) in crafting_query.iter() {
+            commands
+                .spawn(Text2dBundle {
+                    text: Text::from_section(
+                        format!("Crafting: {:?}", crafting_state),
+                        TextStyle {
+                            font: fonts.regular.clone_weak(),
+                            font_size: 20.0,
+                            color: Color::WHITE,
+                        },
+                    ),
+                    transform: Transform::from_translation(Vec3::new(
+                        transform.translation.x,
+                        transform.translation.y + 0.5,
+                        transform.translation.z,
+                    )),
+                    ..Default::default()
+                })
+                .insert(StatusDisplay);
+        }
+    } else {
+        for entity in status_display_query.iter() {
+            commands.entity(entity).despawn_recursive();
+        }
+    }
+}

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -55,44 +55,58 @@ fn display_status(
     }
 
     if status_visualization.enabled {
-        for (transform, goal) in unit_query.iter() {
+        for (unit_transform, goal) in unit_query.iter() {
+            let transform = Transform {
+                translation: Vec3::new(
+                    unit_transform.translation.x,
+                    unit_transform.translation.y + 0.5,
+                    unit_transform.translation.z,
+                ),
+                scale: Vec3::splat(0.0085),
+                ..Default::default()
+            };
+
             commands
                 .spawn(BillboardTextBundle {
+                    transform,
                     text: Text::from_section(
-                        format!("Goal: {:?}", goal),
+                        format!("{:?}", goal),
                         TextStyle {
+                            font_size: 60.0,
                             font: fonts.regular.clone_weak(),
-                            font_size: 20.0,
                             color: Color::WHITE,
                         },
-                    ),
-                    transform: Transform::from_translation(Vec3::new(
-                        transform.translation.x,
-                        transform.translation.y + 0.5,
-                        transform.translation.z,
-                    )),
-                    ..Default::default()
+                    )
+                    .with_alignment(TextAlignment::Center),
+                    ..default()
                 })
                 .insert(StatusDisplay);
         }
 
-        for (transform, crafting_state) in crafting_query.iter() {
+        for (structure_transform, crafting_state) in crafting_query.iter() {
+            let transform = Transform {
+                translation: Vec3::new(
+                    structure_transform.translation.x,
+                    structure_transform.translation.y + 1.0,
+                    structure_transform.translation.z,
+                ),
+                scale: Vec3::splat(0.0085),
+                ..Default::default()
+            };
+
             commands
                 .spawn(BillboardTextBundle {
+                    transform,
                     text: Text::from_section(
-                        format!("Crafting: {:?}", crafting_state),
+                        format!("{:?}", crafting_state),
                         TextStyle {
+                            font_size: 60.0,
                             font: fonts.regular.clone_weak(),
-                            font_size: 20.0,
                             color: Color::WHITE,
                         },
-                    ),
-                    transform: Transform::from_translation(Vec3::new(
-                        transform.translation.x,
-                        transform.translation.y + 0.5,
-                        transform.translation.z,
-                    )),
-                    ..Default::default()
+                    )
+                    .with_alignment(TextAlignment::Center),
+                    ..default()
                 })
                 .insert(StatusDisplay);
         }


### PR DESCRIPTION
Currently controlled via F2. Fixes #355 and fixes #466.

Status:

- [x] resolve crash caused by `bevy_mod_billboard`
```
thread 'Compute Task Pool (14)' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
      note: label = `ui_material_bind_group`
    texture usage is COPY_SRC | COPY_DST which does not contain required usage TEXTURE_BINDING
```
- [x] fix or work around memory leak, see https://github.com/kulkalkul/bevy_mod_billboard/issues/4
- [x] vary text color based on goal type and crafting status


Follow-ups:
1. Use icons to show goals (blocked on icons for items)
2. Use icons to show crafting status

![image](https://user-images.githubusercontent.com/3579909/228552035-b381264b-92aa-41c0-b230-0bbe4216de6a.png)
