### PR TITLE
Improve keyboard and camera controls

### DIFF
--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -241,7 +241,7 @@ fn drag_camera(
     mut mouse_motion_events: EventReader<MouseMotion>,
 ) {
     /// Controls the deadzone for camera dragging
-    const DRAG_THRESHOLD: f32 = 0.01;
+    const DRAG_THRESHOLD: f32 = 2.;
 
     if actions.pressed(PlayerAction::DragCamera) {
         for event in mouse_motion_events.iter() {

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -128,6 +128,8 @@ pub(crate) struct CameraSettings {
     inclination: Rotation,
     /// The rate in radians per second that the inclination changes.
     inclination_speed: Speed,
+    /// How much should dragging the mouse rotate the camera?
+    drag_ratio: f32,
 }
 
 impl Default for CameraSettings {
@@ -142,6 +144,7 @@ impl Default for CameraSettings {
             facing: Rotation::default(),
             inclination: Rotation::from_radians(0.5 * PI / 2.),
             inclination_speed: Speed::new(0.5, 1.0, 2.0),
+            drag_ratio: 0.05,
         }
     }
 }
@@ -230,8 +233,8 @@ fn drag_camera(
 ) {
     if actions.pressed(PlayerAction::DragCamera) {
         let mut settings = camera_query.single_mut();
-        let rotation_rate = settings.rotation_speed.delta(time.delta());
-        let inclination_rate = settings.inclination_speed.delta(time.delta());
+        let rotation_rate = settings.rotation_speed.delta(time.delta()) * settings.drag_ratio;
+        let inclination_rate = settings.inclination_speed.delta(time.delta()) * settings.drag_ratio;
 
         for mouse_motion in mouse_motion_events.iter() {
             settings.facing += Rotation::from_radians(mouse_motion.delta.x * rotation_rate);

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -3,7 +3,6 @@
 //! This RTS-style camera can zoom, pan and rotate.
 
 use std::f32::consts::PI;
-use std::f32::consts::TAU;
 
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::input::mouse::MouseMotion;
@@ -56,10 +55,8 @@ const STARTING_DISTANCE_FROM_ORIGIN: f32 = 30.;
 fn setup_camera(mut commands: Commands) {
     let focus = CameraFocus::default();
     let settings = CameraSettings::default();
-    let facing = CameraFacing::default();
-    let planar_angle = facing.planar_angle.into_radians();
 
-    let transform = compute_camera_transform(&focus, planar_angle, settings.inclination);
+    let transform = compute_camera_transform(&focus, settings.facing, settings.inclination);
     let projection = Projection::Perspective(PerspectiveProjection {
         fov: 0.2,
         ..Default::default()
@@ -74,7 +71,6 @@ fn setup_camera(mut commands: Commands) {
         })
         .insert(settings)
         .insert(focus)
-        .insert(facing)
         .insert(RaycastSource::<Terrain>::new())
         .insert(RaycastSource::<Id<Structure>>::new())
         .insert(RaycastSource::<Id<Unit>>::new())
@@ -103,15 +99,6 @@ impl Default for CameraFocus {
     }
 }
 
-/// The direction that the camera is facing.
-///
-/// This is stored as a rotation around the vertical axis, in radians.
-#[derive(Component, Debug, Default)]
-struct CameraFacing {
-    /// The angle in radians that the camera forms around the z-axis.
-    planar_angle: Rotation,
-}
-
 /// Configure how the camera moves and feels.
 #[derive(Component)]
 pub(crate) struct CameraSettings {
@@ -119,6 +106,8 @@ pub(crate) struct CameraSettings {
     zoom_speed: Speed,
     /// Controls the rate that the camera can moves from side to side.
     pan_speed: Speed,
+    /// The angle in radians that the camera forms around the y axis.
+    facing: Rotation,
     /// Controls how fast the camera rotates around the vertical axis.
     ///
     /// Units are in radians per second.
@@ -136,13 +125,9 @@ pub(crate) struct CameraSettings {
     /// Increasing this value will result in a "smoother ride" over the hills and valleys of the map.
     float_radius: u32,
     /// The angle in radians that the camera forms with the ground.
-    ///
-    /// This value should be between 0 (horizontal) and PI / 2 (vertical).
-    inclination: f32,
+    inclination: Rotation,
     /// The rate in radians per second that the inclination changes.
-    ///
-    /// This value should be positive.
-    inclination_speed: f32,
+    inclination_speed: Speed,
 }
 
 impl Default for CameraSettings {
@@ -154,8 +139,9 @@ impl Default for CameraSettings {
             min_zoom: 10.,
             max_zoom: 500.,
             float_radius: 3,
-            inclination: 0.5 * PI / 2.,
-            inclination_speed: 1.,
+            facing: Rotation::default(),
+            inclination: Rotation::from_radians(0.5 * PI / 2.),
+            inclination_speed: Speed::new(0.5, 1.0, 2.0),
         }
     }
 }
@@ -237,25 +223,19 @@ fn mousewheel_zoom(
 
 /// Use middle-mouse + drag to rotate the camera and tilt it up and down
 fn drag_camera(
-    mut actions: ResMut<ActionState<PlayerAction>>,
+    actions: Res<ActionState<PlayerAction>>,
     mut mouse_motion_events: EventReader<MouseMotion>,
+    mut camera_query: Query<&mut CameraSettings>,
+    time: Res<Time>,
 ) {
-    /// Controls the deadzone for camera dragging
-    const DRAG_THRESHOLD: f32 = 2.;
-
     if actions.pressed(PlayerAction::DragCamera) {
-        for event in mouse_motion_events.iter() {
-            match event.delta.x {
-                x if x > DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraLeft),
-                x if x < -DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraRight),
-                _ => (),
-            }
+        let mut settings = camera_query.single_mut();
+        let rotation_rate = settings.rotation_speed.delta(time.delta());
+        let inclination_rate = settings.inclination_speed.delta(time.delta());
 
-            match event.delta.y {
-                y if y > DRAG_THRESHOLD => actions.press(PlayerAction::TiltCameraUp),
-                y if y < -DRAG_THRESHOLD => actions.press(PlayerAction::TiltCameraDown),
-                _ => (),
-            }
+        for mouse_motion in mouse_motion_events.iter() {
+            settings.facing += Rotation::from_radians(mouse_motion.delta.x * rotation_rate);
+            settings.inclination += Rotation::from_radians(mouse_motion.delta.y * inclination_rate);
         }
     }
 }
@@ -269,14 +249,16 @@ fn set_camera_inclination(
     let mut settings = camera_query.single_mut();
 
     let delta = if actions.pressed(PlayerAction::TiltCameraUp) {
-        settings.inclination_speed * time.delta_seconds()
+        settings.inclination_speed.delta(time.delta())
     } else if actions.pressed(PlayerAction::TiltCameraDown) {
-        -settings.inclination_speed * time.delta_seconds()
+        -settings.inclination_speed.delta(time.delta())
     } else {
         return;
     };
+    let proposed = settings.inclination.into_radians() + delta;
     // Cannot actually use PI/2., as this results in a singular matrix which causes look_at to fail in weird ways
-    settings.inclination = (settings.inclination + delta).clamp(0.0, PI / 2. - 1e-6);
+    let actual = proposed.clamp(0.0, PI / 2. - 1e-6);
+    settings.inclination = Rotation::from_radians(actual);
 }
 
 /// Zooms the camera in and out
@@ -305,22 +287,14 @@ fn zoom(
 
 /// Pan the camera
 fn translate_camera(
-    mut camera_query: Query<
-        (
-            &Transform,
-            &mut CameraFocus,
-            &CameraFacing,
-            &mut CameraSettings,
-        ),
-        With<Camera3d>,
-    >,
+    mut camera_query: Query<(&Transform, &mut CameraFocus, &mut CameraSettings), With<Camera3d>>,
     time: Res<Time>,
     actions: Res<ActionState<PlayerAction>>,
     map_geometry: Res<MapGeometry>,
     selection: Res<CurrentSelection>,
     tile_pos_query: Query<&TilePos>,
 ) {
-    let (transform, mut focus, facing, mut settings) = camera_query.single_mut();
+    let (transform, mut focus, mut settings) = camera_query.single_mut();
 
     // Pan
     if actions.pressed(PlayerAction::Pan) {
@@ -337,7 +311,7 @@ fn translate_camera(
             z: scaled_xy.x,
         };
 
-        let facing_angle = facing.planar_angle.into_radians();
+        let facing_angle = settings.facing.into_radians();
         let rotation = Quat::from_rotation_y(facing_angle);
         let oriented_translation = rotation.mul_vec3(unoriented_translation);
 
@@ -367,80 +341,40 @@ fn translate_camera(
 
 /// Rotates the camera around the [`CameraFocus`].
 fn rotate_camera(
-    mut query: Query<(&mut CameraFacing, &mut CameraSettings), With<Camera3d>>,
+    mut query: Query<&mut CameraSettings, With<Camera3d>>,
     actions: Res<ActionState<PlayerAction>>,
     time: Res<Time>,
 ) {
-    let (mut facing, mut settings) = query.single_mut();
+    let mut settings = query.single_mut();
 
     let delta = settings.rotation_speed.delta(time.delta());
 
     // Set facing
     if actions.pressed(PlayerAction::RotateCameraLeft) {
-        facing.planar_angle -= Rotation::from_radians(delta);
+        settings.facing -= Rotation::from_radians(delta);
     }
 
     if actions.pressed(PlayerAction::RotateCameraRight) {
-        facing.planar_angle += Rotation::from_radians(delta);
+        settings.facing += Rotation::from_radians(delta);
     }
 }
 
 /// Move the camera around a central point, constantly looking at it and maintaining a fixed distance.
 fn move_camera_to_goal(
-    mut query: Query<
-        (
-            &mut Transform,
-            &CameraFacing,
-            &CameraFocus,
-            &mut CameraSettings,
-        ),
-        With<Camera3d>,
-    >,
-    mut cached_planar_angle: Local<Option<f32>>,
-    time: Res<Time>,
+    mut query: Query<(&mut Transform, &CameraFocus, &CameraSettings), With<Camera3d>>,
 ) {
-    /// Differences in target angle below this amount are ignored.
-    ///
-    /// This reduces camera jitter.
-    const ROTATION_EPSILON: f32 = 1e-3;
-
-    let (mut transform, facing, focus, mut settings) = query.single_mut();
-
-    // Determine our goal
-    let final_planar_angle = facing.planar_angle.into_radians();
-
-    // The cached planar angle must begin uninitialized: otherwise changes to the default facing will result in a delay as  we pan towards it.
-    // If it was uninitialized, start it at the final location.
-    let intermediate_planar_angle = cached_planar_angle.unwrap_or(final_planar_angle);
-
-    // Compute the shortest distance between them
-    // Formula from https://stackoverflow.com/a/7869457
-    let signed_rotation =
-        (final_planar_angle - intermediate_planar_angle + PI).rem_euclid(TAU) - PI;
-
-    if signed_rotation.abs() < ROTATION_EPSILON {
-        *cached_planar_angle = Some(final_planar_angle);
-    } else {
-        // Compute the correct rotation
-        let max_rotation = settings.rotation_speed.delta(time.delta());
-
-        // Make sure not to overshoot
-        let actual_signed_distance = if signed_rotation > 0. {
-            signed_rotation.min(max_rotation)
-        } else {
-            signed_rotation.max(-max_rotation)
-        };
-
-        // Actually mutate the intermediate angle
-        *cached_planar_angle = Some(intermediate_planar_angle + actual_signed_distance);
-    }
+    let (mut transform, focus, settings) = query.single_mut();
 
     // Replace the previous transform
-    *transform = compute_camera_transform(focus, intermediate_planar_angle, settings.inclination);
+    *transform = compute_camera_transform(focus, settings.facing, settings.inclination);
 }
 
 /// Computes the camera transform such that it is looking at `focus`
-fn compute_camera_transform(focus: &CameraFocus, planar_angle: f32, inclination: f32) -> Transform {
+fn compute_camera_transform(
+    focus: &CameraFocus,
+    facing: Rotation,
+    inclination: Rotation,
+) -> Transform {
     // Always begin due "south" of the focus.
     let mut transform =
         Transform::from_translation(focus.translation + Vec3::NEG_X * focus.distance);
@@ -448,11 +382,14 @@ fn compute_camera_transform(focus: &CameraFocus, planar_angle: f32, inclination:
     // Tilt up
     transform.translate_around(
         focus.translation,
-        Quat::from_axis_angle(Vec3::NEG_Z, inclination),
+        Quat::from_axis_angle(Vec3::NEG_Z, inclination.into_radians()),
     );
 
     // Rotate left and right
-    transform.translate_around(focus.translation, Quat::from_rotation_y(planar_angle));
+    transform.translate_around(
+        focus.translation,
+        Quat::from_rotation_y(facing.into_radians()),
+    );
 
     // Look at the focus
     transform.look_at(focus.translation, Vec3::Y);

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -238,7 +238,10 @@ fn drag_camera(
 
         for mouse_motion in mouse_motion_events.iter() {
             settings.facing += Rotation::from_radians(mouse_motion.delta.x * rotation_rate);
-            settings.inclination += Rotation::from_radians(mouse_motion.delta.y * inclination_rate);
+            let proposed_inclination =
+                settings.inclination.into_radians() + mouse_motion.delta.y * inclination_rate;
+            let actual_inclination = proposed_inclination.clamp(0.0, PI / 2. - 1e-6);
+            settings.inclination = Rotation::from_radians(actual_inclination);
         }
     }
 }

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -326,7 +326,7 @@ fn translate_camera(
     }
 
     // Snap to selected object
-    if actions.pressed(PlayerAction::SnapToSelection) {
+    if actions.pressed(PlayerAction::CenterCameraOnSelection) {
         let tile_to_snap_to = match &*selection {
             CurrentSelection::Ghost(entity)
             | CurrentSelection::Unit(entity)

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -246,8 +246,8 @@ fn drag_camera(
     if actions.pressed(PlayerAction::DragCamera) {
         for event in mouse_motion_events.iter() {
             match event.delta.x {
-                x if x > DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraRight),
-                x if x < -DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraLeft),
+                x if x > DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraLeft),
+                x if x < -DRAG_THRESHOLD => actions.press(PlayerAction::RotateCameraRight),
                 _ => (),
             }
 

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -149,7 +149,7 @@ impl Default for CameraSettings {
     fn default() -> Self {
         CameraSettings {
             zoom_speed: Speed::new(400., 300.0, 1000.0),
-            pan_speed: Speed::new(50., 100.0, 150.0),
+            pan_speed: Speed::new(10., 20.0, 20.0),
             rotation_speed: Speed::new(1.0, 2.0, 4.0),
             min_zoom: 10.,
             max_zoom: 500.,

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -194,7 +194,7 @@ fn copy_selection(
     structure_query: Query<ClipboardQuery, Without<Preview>>,
     map_geometry: Res<MapGeometry>,
 ) {
-    if actions.just_pressed(PlayerAction::Pipette) {
+    if actions.just_pressed(PlayerAction::Copy) {
         // We want to replace our selection, rather than add to it
         let mut map = HashMap::new();
 

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -86,26 +86,26 @@ pub(crate) enum PlayerAction {
     Line,
     /// Selects a structure from a wheel menu.
     SelectStructure,
+    /// Set the height of a tile.
+    SelectTerraform,
     /// Selects the structure on the tile under the player's cursor.
     ///
     /// If there is no structure there, the player's selection is cleared.
-    Pipette,
+    Copy,
     /// Sets the zoning of all currently selected tiles to the currently selected structure.
     ///
     /// If no structure is selected to build, zoning will be set to [`Zoning::None`](zoning::Zoning::None).
-    Zone,
+    Paste,
     /// Sets the zoning of all currently selected tiles to [`Zoning::None`](zoning::Zoning::None).
     ClearZoning,
     /// Sets the zoning of all currently selected tiles to [`Zoning::KeepClear`](zoning::Zoning::KeepClear).
     KeepClear,
-    /// Set the height of a tile.
-    Terraform,
     /// Rotates the conents of the clipboard counterclockwise.
     RotateClipboardLeft,
     /// Rotates the contents of the clipboard clockwise.
     RotateClipboardRight,
     /// Snaps the camera to the selected object
-    SnapToSelection,
+    CenterCameraOnSelection,
     /// Drag the camera with the cursor
     DragCamera,
     /// Move the camera from side to side
@@ -140,15 +140,15 @@ impl PlayerAction {
             Multiple => Modifier::Shift.into(),
             Area => Modifier::Control.into(),
             Line => Modifier::Alt.into(),
-            SelectStructure => KeyCode::E.into(),
-            Pipette => KeyCode::Q.into(),
-            Zone => KeyCode::Return.into(),
+            SelectStructure => KeyCode::Key1.into(),
+            SelectTerraform => KeyCode::Key2.into(),
+            Copy => UserInput::modified(Modifier::Control, KeyCode::C),
+            Paste => UserInput::modified(Modifier::Control, KeyCode::V),
             ClearZoning => KeyCode::Back.into(),
             KeepClear => KeyCode::Delete.into(),
-            Terraform => KeyCode::G.into(),
             RotateClipboardLeft => UserInput::modified(Modifier::Shift, KeyCode::R),
             RotateClipboardRight => KeyCode::R.into(),
-            SnapToSelection => KeyCode::L.into(),
+            CenterCameraOnSelection => KeyCode::L.into(),
             DragCamera => MouseButton::Middle.into(),
             Pan => VirtualDPad::wasd().into(),
             MoveCursor => VirtualDPad::arrow_keys().into(),
@@ -158,8 +158,8 @@ impl PlayerAction {
             // Plus and Equals are swapped. See: https://github.com/rust-windowing/winit/issues/2682
             TiltCameraUp => UserInput::modified(Modifier::Alt, KeyCode::Equals),
             TiltCameraDown => UserInput::modified(Modifier::Alt, KeyCode::Minus),
-            RotateCameraLeft => KeyCode::Z.into(),
-            RotateCameraRight => KeyCode::C.into(),
+            RotateCameraLeft => KeyCode::Q.into(),
+            RotateCameraRight => KeyCode::E.into(),
         }
     }
 
@@ -181,14 +181,14 @@ impl PlayerAction {
             Area => LeftTrigger.into(),
             Line => LeftTrigger2.into(),
             SelectStructure => RightThumb.into(),
-            Pipette => West.into(),
-            Zone => North.into(),
+            Copy => West.into(),
+            Paste => North.into(),
             ClearZoning => DPadUp.into(),
             KeepClear => DPadDown.into(),
-            Terraform => UserInput::chord([radius_modifier, North]),
+            SelectTerraform => UserInput::chord([radius_modifier, North]),
             RotateClipboardLeft => DPadLeft.into(),
             RotateClipboardRight => DPadRight.into(),
-            SnapToSelection => GamepadButtonType::LeftThumb.into(),
+            CenterCameraOnSelection => GamepadButtonType::LeftThumb.into(),
             DragCamera => GamepadButtonType::RightThumb.into(),
             Pan => DualAxis::left_stick().into(),
             MoveCursor => DualAxis::right_stick().into(),

--- a/emergence_lib/src/player_interaction/zoning.rs
+++ b/emergence_lib/src/player_interaction/zoning.rs
@@ -107,7 +107,7 @@ fn set_zoning(
     }
 
     // Apply zoning
-    if actions.pressed(PlayerAction::Zone) {
+    if actions.pressed(PlayerAction::Paste) {
         match &*clipboard {
             Clipboard::Terraform(terraform_choice) => {
                 for terrain_entity in relevant_terrain_entities {

--- a/emergence_lib/src/ui/select_terraforming.rs
+++ b/emergence_lib/src/ui/select_terraforming.rs
@@ -39,7 +39,7 @@ impl Plugin for SelectTerraformingPlugin {
 }
 
 impl Choice for TerraformingChoice {
-    const ACTIVATION: PlayerAction = PlayerAction::Terraform;
+    const ACTIVATION: PlayerAction = PlayerAction::SelectTerraform;
 }
 
 /// Update the set of choices available to build whenever the terrain manifest is updated


### PR DESCRIPTION
- more consistent with other games in the genre (rotate camera on Q/E, select options on 1/2/3)
- add drag-to-rotate (fixes #548)
- makes rotation continuous
- makes drag motion smooth and intutive
- makes camera panning way less jerky (fixes #543)
- improves the code quality of our camera code