### PR TITLE
Use sparse registry for cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   check-lints:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
 jobs:
   check-lints:
@@ -44,8 +45,6 @@ jobs:
       - name: Build & run tests
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- test
-        env:
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   check-compiles:
     runs-on: ubuntu-latest
@@ -78,8 +77,6 @@ jobs:
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- doc
-        env:
-          RUSTFLAGS: "-C debuginfo=0"
   #      - name: Installs cargo-deadlinks
   #        run: cargo install --force cargo-deadlinks
   #      - name: Checks dead links

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   check-advisories:

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   check-unused-dependencies:


### PR DESCRIPTION
Use the new sparse registry for cargo in CI to speed up the time to update when needed.

I also slightly simplified the usage of the `RUSTFLAGS` env variable.