### PR TITLE
Terraforming takes work

### DIFF
--- a/emergence_game/assets/manifests/base_game.structure_manifest.json
+++ b/emergence_game/assets/manifests/base_game.structure_manifest.json
@@ -10,11 +10,7 @@
 				"Direct": {
 					"work": 5,
 					"materials": {},
-					"allowed_terrain_types": [
-						"rocky",
-						"loam",
-						"muddy"
-					]
+					"allowed_terrain_types": []
 				}
 			},
 			"max_workers": 6
@@ -31,11 +27,7 @@
 					"materials": {
 						"leuco_chunk": 1
 					},
-					"allowed_terrain_types": [
-						"rocky",
-						"loam",
-						"muddy"
-					]
+					"allowed_terrain_types": []
 				}
 			},
 			"max_workers": 6
@@ -185,11 +177,7 @@
 				"Direct": {
 					"work": 5.0,
 					"materials": {},
-					"allowed_terrain_types": [
-						"loam",
-						"muddy",
-						"rocky"
-					]
+					"allowed_terrain_types": []
 				}
 			},
 			"max_workers": 3,

--- a/emergence_lib/src/construction/demolition.rs
+++ b/emergence_lib/src/construction/demolition.rs
@@ -1,0 +1,41 @@
+//! Logic and data related to marking structures for demolition.
+
+use bevy::{ecs::system::SystemParam, prelude::*};
+
+use crate::{
+    asset_management::manifest::Id,
+    simulation::geometry::{MapGeometry, TilePos},
+    structures::structure_manifest::Structure,
+};
+
+/// Marker component for structures that are intended to be deconstructed
+#[derive(Component, Debug)]
+pub(crate) struct MarkedForDemolition;
+
+/// A query for the structures that need to be demolished.
+#[derive(SystemParam)]
+pub(crate) struct DemolitionQuery<'w, 's> {
+    /// The contained query type.
+    query: Query<'w, 's, &'static Id<Structure>, With<MarkedForDemolition>>,
+}
+
+impl<'w, 's> DemolitionQuery<'w, 's> {
+    /// Is there a structure of type `structure_id` at `structure_pos` that needs to be demolished?
+    ///
+    /// If so, returns `Some(matching_structure_entity_that_needs_to_be_demolished)`.
+    pub(crate) fn needs_demolition(
+        &self,
+        structure_pos: TilePos,
+        structure_id: Id<Structure>,
+        map_geometry: &MapGeometry,
+    ) -> Option<Entity> {
+        let entity = map_geometry.get_structure(structure_pos)?;
+
+        let &found_structure_id = self.query.get(entity).ok()?;
+
+        match found_structure_id == structure_id {
+            true => Some(entity),
+            false => None,
+        }
+    }
+}

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -537,6 +537,7 @@ pub(super) fn ghost_lifecycle(
                     }
                     (None, Some(terraforming_action)) => {
                         commands.despawn_ghost_terrain(tile_pos);
+                        commands.apply_terraforming_action(tile_pos, *terraforming_action)
                     }
                     _ => unreachable!(),
                 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -11,7 +11,7 @@ use crate::items::inventory::Inventory;
 use crate::simulation::geometry::MapGeometry;
 use crate::simulation::SimulationSet;
 use crate::structures::commands::StructureCommandsExt;
-use crate::structures::structure_manifest::{ConstructionStrategy, Structure, StructureManifest};
+use crate::structures::structure_manifest::{Structure, StructureManifest};
 use crate::terrain::commands::TerrainCommandsExt;
 use crate::terrain::terrain_manifest::{Terrain, TerrainManifest};
 use crate::{self as emergence_lib, graphics::InheritedMaterial};
@@ -29,6 +29,7 @@ use crate::{
 };
 
 use super::terraform::TerraformingAction;
+use super::ConstructionStrategy;
 
 pub struct GhostPlugin;
 

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -35,9 +35,9 @@ impl Plugin for GhostPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<GhostHandles>().add_systems(
             (
-                validate_ghosts,
-                ghost_signals.after(validate_ghosts),
-                ghost_lifecycle.after(validate_ghosts),
+                validate_ghost_structures,
+                ghost_signals.after(validate_ghost_structures),
+                ghost_lifecycle.after(validate_ghost_structures),
             )
                 .in_set(SimulationSet)
                 .in_schedule(CoreSchedule::FixedUpdate),
@@ -533,7 +533,7 @@ pub(super) fn ghost_lifecycle(
 }
 
 /// Ensures that all ghosts can be built.
-pub(super) fn validate_ghosts(
+pub(super) fn validate_ghost_structures(
     map_geometry: Res<MapGeometry>,
     ghost_query: Query<(&TilePos, &Id<Structure>, &Facing), With<Ghost>>,
     structure_manifest: Res<StructureManifest>,

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -91,8 +91,6 @@ struct GhostBundle {
     workers_present: WorkersPresent,
     /// Tracks work that needs to be done on this building
     crafting_state: CraftingState,
-    /// Makes structures pickable
-    raycast_mesh: RaycastMesh<Ghost>,
     /// The mesh used for raycasting
     picking_mesh: Handle<Mesh>,
     /// The material to be used by all children in the scene
@@ -118,7 +116,6 @@ impl GhostBundle {
             construction_materials,
             workers_present: WorkersPresent::new(6),
             crafting_state: CraftingState::NeedsInput,
-            raycast_mesh: RaycastMesh::default(),
             picking_mesh,
             inherited_material,
             scene_bundle: SceneBundle {
@@ -142,6 +139,8 @@ pub(crate) struct GhostStructureBundle {
     active_recipe: ActiveRecipe,
     /// The direction the ghost is facing
     facing: Facing,
+    /// Makes ghost structures pickable
+    raycast_mesh: RaycastMesh<(Ghost, Structure)>,
 }
 
 impl GhostStructureBundle {
@@ -171,6 +170,7 @@ impl GhostStructureBundle {
             facing: clipboard_data.facing,
             structure_id,
             active_recipe: clipboard_data.active_recipe,
+            raycast_mesh: RaycastMesh::default(),
         }
     }
 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -25,6 +25,8 @@ use crate::{
     simulation::geometry::{Facing, TilePos},
 };
 
+use super::terraform::TerraformingAction;
+
 pub struct GhostPlugin;
 
 impl Plugin for GhostPlugin {
@@ -218,7 +220,7 @@ impl StructurePreviewBundle {
 pub(super) fn ghost_signals(
     mut ghost_query: Query<
         (
-            AnyOf<(&Id<Structure>, &Id<Terrain>)>,
+            AnyOf<(&Id<Structure>, &TerraformingAction)>,
             &mut Emitter,
             Ref<CraftingState>,
             &InputInventory,
@@ -279,7 +281,7 @@ pub(crate) enum WorkplaceId {
     /// This workplace is a structure
     Structure(Id<Structure>),
     /// This workplace is a terrain modification
-    Terrain(Id<Terrain>),
+    Terrain(TerraformingAction),
 }
 
 impl WorkplaceId {
@@ -289,10 +291,10 @@ impl WorkplaceId {
     ///
     /// # Panics
     /// Panics if both `structure_id` and `terrain_id` are `Some`.
-    pub(crate) fn new(ids: (Option<&Id<Structure>>, Option<&Id<Terrain>>)) -> Self {
+    pub(crate) fn new(ids: (Option<&Id<Structure>>, Option<&TerraformingAction>)) -> Self {
         match ids {
             (Some(structure_id), None) => WorkplaceId::Structure(*structure_id),
-            (None, Some(terrain_id)) => WorkplaceId::Terrain(*terrain_id),
+            (None, Some(terraforming_choice)) => WorkplaceId::Terrain(*terraforming_choice),
             _ => panic!("Workplace must be either a terrain XOR a structure"),
         }
     }
@@ -302,9 +304,10 @@ impl WorkplaceId {
         WorkplaceId::Structure(structure_id)
     }
 
-    /// Creates a new [`WorkplaceId`] from a [`Id<Terrain>`].
-    pub(crate) fn terrain(terrain_id: Id<Terrain>) -> Self {
-        WorkplaceId::Terrain(terrain_id)
+    /// Creates a new [`WorkplaceId`] from a [`TerraformingAction`].
+    #[allow(dead_code)]
+    pub(crate) fn terrain(terraforming_choice: TerraformingAction) -> Self {
+        WorkplaceId::Terrain(terraforming_choice)
     }
 
     /// Returns the pretty name of this workplace.
@@ -315,7 +318,9 @@ impl WorkplaceId {
     ) -> &str {
         match self {
             WorkplaceId::Structure(structure_id) => structure_manifest.name(*structure_id),
-            WorkplaceId::Terrain(terrain_id) => terrain_manifest.name(*terrain_id),
+            WorkplaceId::Terrain(terraforming_action) => {
+                &terraforming_action.display(terrain_manifest)
+            }
         }
     }
 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -455,7 +455,7 @@ pub(super) fn ghost_lifecycle(
             &InputInventory,
             &TilePos,
             AnyOf<(&Id<Structure>, &TerraformingAction)>,
-            &Facing,
+            Option<&Facing>,
             &ActiveRecipe,
             &WorkersPresent,
         ),
@@ -470,7 +470,7 @@ pub(super) fn ghost_lifecycle(
         input_inventory,
         &tile_pos,
         ids,
-        &facing,
+        maybe_facing,
         active_recipe,
         workers_present,
     ) in ghost_query.iter_mut()
@@ -512,6 +512,7 @@ pub(super) fn ghost_lifecycle(
                 match ids {
                     (Some(structure_id), None) => {
                         commands.despawn_ghost_structure(tile_pos);
+                        let facing = *maybe_facing.expect("Structure ghosts must have a facing");
 
                         // Spawn the seedling form of a structure if any
                         if let ConstructionStrategy::Seedling(seedling) =

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -540,7 +540,6 @@ pub(super) fn ghost_lifecycle(
                         }
                     }
                     (None, Some(terraforming_action)) => {
-                        commands.despawn_ghost_terrain(tile_pos);
                         commands.apply_terraforming_action(tile_pos, *terraforming_action)
                     }
                     _ => unreachable!(),

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -31,6 +31,7 @@ use crate::{
 use super::terraform::TerraformingAction;
 use super::ConstructionStrategy;
 
+/// Systems and resources for working with ghosts.
 pub struct GhostPlugin;
 
 impl Plugin for GhostPlugin {
@@ -47,14 +48,17 @@ impl Plugin for GhostPlugin {
     }
 }
 
+/// Stores the assets needed to render ghosts.
 #[derive(Debug, Resource)]
 pub(crate) struct GhostHandles {
-    map: HashMap<GhostKind, Handle<StandardMaterial>>,
+    /// The materials used to render ghosts.
+    materials: HashMap<GhostKind, Handle<StandardMaterial>>,
 }
 
 impl GhostHandles {
-    pub fn get(&self, kind: GhostKind) -> Handle<StandardMaterial> {
-        self.map[&kind].clone()
+    /// Gets the material handle for the given [`GhostKind`].
+    pub fn get_material(&self, kind: GhostKind) -> Handle<StandardMaterial> {
+        self.materials[&kind].clone()
     }
 }
 
@@ -66,7 +70,7 @@ impl FromWorld for GhostHandles {
             let material = assets.add(kind.material());
             map.insert(kind, material);
         }
-        GhostHandles { map }
+        GhostHandles { materials: map }
     }
 }
 
@@ -100,6 +104,7 @@ struct GhostBundle {
 }
 
 impl GhostBundle {
+    /// Creates a new [`GhostBundle`].
     fn new(
         tile_pos: TilePos,
         construction_materials: InputInventory,
@@ -183,6 +188,7 @@ pub(crate) struct GhostTerrainBundle {
 }
 
 impl GhostTerrainBundle {
+    /// Creates a new [`GhostTerrainBundle`].
     pub(crate) fn new(
         terraforming_action: TerraformingAction,
         tile_pos: TilePos,
@@ -307,6 +313,7 @@ pub(crate) struct TerrainPreviewBundle {
 }
 
 impl TerrainPreviewBundle {
+    /// Creates a new [`TerrainPreviewBundle`].
     pub(crate) fn new(
         tile_pos: TilePos,
         terraforming_action: TerraformingAction,

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -182,6 +182,8 @@ pub(crate) struct GhostTerrainBundle {
     ghost_bundle: GhostBundle,
     /// The action that will be performed when this terrain is built
     terraforming_action: TerraformingAction,
+    /// Makes ghost terrain pickable
+    raycast_mesh: RaycastMesh<(Ghost, Terrain)>,
 }
 
 impl GhostTerrainBundle {
@@ -208,6 +210,7 @@ impl GhostTerrainBundle {
                 world_pos,
             ),
             terraforming_action,
+            raycast_mesh: RaycastMesh::default(),
         }
     }
 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -384,7 +384,7 @@ pub(super) fn ghost_lifecycle(
                 }
             }
             CraftingState::RecipeComplete => {
-                commands.despawn_ghost(tile_pos);
+                commands.despawn_ghost_structure(tile_pos);
 
                 // Spawn the seedling form of a structure if any
                 if let ConstructionStrategy::Seedling(seedling) =
@@ -434,7 +434,7 @@ pub(super) fn validate_ghosts(
         let allowed_terrain_types = &construction_data.allowed_terrain_types;
 
         if !map_geometry.can_build(tile_pos, footprint, &terrain_query, allowed_terrain_types) {
-            commands.despawn_ghost(tile_pos);
+            commands.despawn_ghost_structure(tile_pos);
         }
     }
 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -215,13 +215,12 @@ impl StructurePreviewBundle {
 }
 
 /// Computes the correct signals for ghosts to send throughout their lifecycle
-// TODO: use a `Ref` instead of &mut in Bevy 0.10
 pub(super) fn ghost_signals(
     mut ghost_query: Query<
         (
             &Id<Structure>,
             &mut Emitter,
-            &mut CraftingState,
+            Ref<CraftingState>,
             &InputInventory,
             &WorkersPresent,
         ),

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -488,9 +488,8 @@ pub(super) fn ghost_lifecycle(
             CraftingState::InProgress { progress, required } => {
                 let mut updated_progress = progress;
 
-                if workers_present.needs_more() {
-                    updated_progress += time.period;
-                }
+                // Scale construction speed linearly with the number of workers present
+                updated_progress += workers_present.current() as u32 * time.period;
 
                 *crafting_state = if updated_progress >= required {
                     CraftingState::RecipeComplete

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -33,7 +33,7 @@ pub struct GhostPlugin;
 
 impl Plugin for GhostPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.init_resource::<GhostHandles>().add_systems(
             (
                 validate_ghosts,
                 ghost_signals.after(validate_ghosts),

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -304,6 +304,7 @@ impl StructurePreviewBundle {
 }
 
 /// The components needed to create a preview of a [`Terrain`].
+#[derive(Bundle)]
 pub(crate) struct TerrainPreviewBundle {
     /// Shared components for all previews
     preview_bundle: PreviewBundle,
@@ -311,6 +312,32 @@ pub(crate) struct TerrainPreviewBundle {
     terrain_id: Id<Terrain>,
     /// The action that will be performed when this terrain is built
     terraforming_action: TerraformingAction,
+}
+
+impl TerrainPreviewBundle {
+    pub(crate) fn new(
+        tile_pos: TilePos,
+        terrain_id: Id<Terrain>,
+        terraforming_action: TerraformingAction,
+        scene_handle: Handle<Scene>,
+        inherited_material: InheritedMaterial,
+        world_pos: Vec3,
+    ) -> Self {
+        TerrainPreviewBundle {
+            preview_bundle: PreviewBundle {
+                preview: Preview,
+                tile_pos,
+                inherited_material,
+                scene_bundle: SceneBundle {
+                    scene: scene_handle.clone_weak(),
+                    transform: Transform::from_translation(world_pos),
+                    ..default()
+                },
+            },
+            terrain_id,
+            terraforming_action,
+        }
+    }
 }
 
 /// Computes the correct signals for ghosts to send throughout their lifecycle

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -178,15 +178,12 @@ impl GhostStructureBundle {
 pub(crate) struct GhostTerrainBundle {
     /// Shared components across all ghosts
     ghost_bundle: GhostBundle,
-    /// The variety of terrain
-    terrain_id: Id<Terrain>,
     /// The action that will be performed when this terrain is built
     terraforming_action: TerraformingAction,
 }
 
 impl GhostTerrainBundle {
     pub(crate) fn new(
-        terrain_id: Id<Terrain>,
         terraforming_action: TerraformingAction,
         tile_pos: TilePos,
         picking_mesh: Handle<Mesh>,
@@ -208,7 +205,6 @@ impl GhostTerrainBundle {
                 inherited_material,
                 world_pos,
             ),
-            terrain_id,
             terraforming_action,
         }
     }
@@ -308,8 +304,6 @@ impl StructurePreviewBundle {
 pub(crate) struct TerrainPreviewBundle {
     /// Shared components for all previews
     preview_bundle: PreviewBundle,
-    /// The variety of terrain
-    terrain_id: Id<Terrain>,
     /// The action that will be performed when this terrain is built
     terraforming_action: TerraformingAction,
 }
@@ -317,7 +311,6 @@ pub(crate) struct TerrainPreviewBundle {
 impl TerrainPreviewBundle {
     pub(crate) fn new(
         tile_pos: TilePos,
-        terrain_id: Id<Terrain>,
         terraforming_action: TerraformingAction,
         scene_handle: Handle<Scene>,
         inherited_material: InheritedMaterial,
@@ -334,7 +327,6 @@ impl TerrainPreviewBundle {
                     ..default()
                 },
             },
-            terrain_id,
             terraforming_action,
         }
     }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -91,8 +91,6 @@ struct GhostBundle {
     workers_present: WorkersPresent,
     /// Tracks work that needs to be done on this building
     crafting_state: CraftingState,
-    /// The mesh used for raycasting
-    picking_mesh: Handle<Mesh>,
     /// The material to be used by all children in the scene
     inherited_material: InheritedMaterial,
     /// The child scene that contains the gltF model used
@@ -105,7 +103,6 @@ impl GhostBundle {
     fn new(
         tile_pos: TilePos,
         construction_materials: InputInventory,
-        picking_mesh: Handle<Mesh>,
         scene_handle: Handle<Scene>,
         inherited_material: InheritedMaterial,
         world_pos: Vec3,
@@ -116,7 +113,6 @@ impl GhostBundle {
             construction_materials,
             workers_present: WorkersPresent::new(6),
             crafting_state: CraftingState::NeedsInput,
-            picking_mesh,
             inherited_material,
             scene_bundle: SceneBundle {
                 scene: scene_handle.clone_weak(),
@@ -141,6 +137,8 @@ pub(crate) struct GhostStructureBundle {
     facing: Facing,
     /// Makes ghost structures pickable
     raycast_mesh: RaycastMesh<(Ghost, Structure)>,
+    /// The mesh used for raycasting
+    picking_mesh: Handle<Mesh>,
 }
 
 impl GhostStructureBundle {
@@ -162,7 +160,6 @@ impl GhostStructureBundle {
             ghost_bundle: GhostBundle::new(
                 tile_pos,
                 construction_materials,
-                picking_mesh,
                 scene_handle,
                 inherited_material,
                 world_pos,
@@ -171,6 +168,7 @@ impl GhostStructureBundle {
             structure_id,
             active_recipe: clipboard_data.active_recipe,
             raycast_mesh: RaycastMesh::default(),
+            picking_mesh,
         }
     }
 }
@@ -182,15 +180,12 @@ pub(crate) struct GhostTerrainBundle {
     ghost_bundle: GhostBundle,
     /// The action that will be performed when this terrain is built
     terraforming_action: TerraformingAction,
-    /// Makes ghost terrain pickable
-    raycast_mesh: RaycastMesh<(Ghost, Terrain)>,
 }
 
 impl GhostTerrainBundle {
     pub(crate) fn new(
         terraforming_action: TerraformingAction,
         tile_pos: TilePos,
-        picking_mesh: Handle<Mesh>,
         scene_handle: Handle<Scene>,
         inherited_material: InheritedMaterial,
         world_pos: Vec3,
@@ -204,13 +199,11 @@ impl GhostTerrainBundle {
             ghost_bundle: GhostBundle::new(
                 tile_pos,
                 construction_materials,
-                picking_mesh,
                 scene_handle,
                 inherited_material,
                 world_pos,
             ),
             terraforming_action,
-            raycast_mesh: RaycastMesh::default(),
         }
     }
 }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -456,7 +456,7 @@ pub(super) fn ghost_lifecycle(
             &TilePos,
             AnyOf<(&Id<Structure>, &TerraformingAction)>,
             Option<&Facing>,
-            &ActiveRecipe,
+            Option<&ActiveRecipe>,
             &WorkersPresent,
         ),
         With<Ghost>,
@@ -471,7 +471,7 @@ pub(super) fn ghost_lifecycle(
         &tile_pos,
         ids,
         maybe_facing,
-        active_recipe,
+        maybe_active_recipe,
         workers_present,
     ) in ghost_query.iter_mut()
     {
@@ -513,6 +513,8 @@ pub(super) fn ghost_lifecycle(
                     (Some(structure_id), None) => {
                         commands.despawn_ghost_structure(tile_pos);
                         let facing = *maybe_facing.expect("Structure ghosts must have a facing");
+                        let active_recipe = maybe_active_recipe
+                            .expect("Structure ghosts must have an active recipe");
 
                         // Spawn the seedling form of a structure if any
                         if let ConstructionStrategy::Seedling(seedling) =

--- a/emergence_lib/src/construction/mod.rs
+++ b/emergence_lib/src/construction/mod.rs
@@ -1,6 +1,14 @@
 //! Tools and systems for constructing structures and terraforming the world.
 
+use bevy::utils::{Duration, HashMap, HashSet};
+
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::crafting::components::InputInventory;
+use crate::items::slot::ItemSlot;
+use crate::terrain::terrain_manifest::Terrain;
+use crate::{asset_management::manifest::Id, structures::structure_manifest::Structure};
 
 pub(crate) mod demolition;
 pub(crate) mod ghosts;
@@ -15,5 +23,77 @@ impl Plugin for ConstructionPlugin {
         app.add_plugin(ghosts::GhostPlugin)
             .add_plugin(terraform::TerraformingPlugin)
             .add_plugin(zoning::ZoningPlugin);
+    }
+}
+
+/// How new structures of this sort can be built.
+///
+/// For structures that are part of a `Lifecycle`, this should generally be the same for all of them.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ConstructionStrategy {
+    /// Follows the construction strategy of another structure.
+    Seedling(Id<Structure>),
+    /// This structure can be built directly.
+    Direct(ConstructionData),
+}
+
+/// The data contained in a [`ConstructionStrategy::Direct`] variant.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConstructionData {
+    /// The amount of work by units required to complete the construction of this building.
+    ///
+    /// If this is [`None`], no work will be needed at all.
+    pub work: Option<Duration>,
+    /// The set of items needed to create a new copy of this structure
+    pub materials: InputInventory,
+    /// The set of terrain types that this structure can be built on
+    pub allowed_terrain_types: HashSet<Id<Terrain>>,
+}
+
+/// The unprocessed equivalent of [`ConstructionStrategy`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RawConstructionStrategy {
+    /// Follows the construction strategy of another structure.
+    Seedling(String),
+    /// This structure can be built directly.
+    Direct {
+        /// The amount of work (in seconds) by units required to complete the construction of this building.
+        ///
+        /// If this is [`None`], no work will be needed at all.
+        work: Option<f32>,
+        /// The set of items needed to create a new copy of this structure
+        materials: HashMap<String, u32>,
+        /// The set of terrain types that this structure can be built on
+        allowed_terrain_types: HashSet<String>,
+    },
+}
+
+impl From<RawConstructionStrategy> for ConstructionStrategy {
+    fn from(raw: RawConstructionStrategy) -> Self {
+        match raw {
+            RawConstructionStrategy::Seedling(seedling_name) => {
+                ConstructionStrategy::Seedling(Id::from_name(seedling_name))
+            }
+            RawConstructionStrategy::Direct {
+                work,
+                materials,
+                allowed_terrain_types,
+            } => {
+                let inventory = materials
+                    .into_iter()
+                    .map(|(item_name, count)| ItemSlot::new(Id::from_name(item_name), count))
+                    .collect();
+
+                let materials = InputInventory::Exact { inventory };
+                ConstructionStrategy::Direct(ConstructionData {
+                    work: work.map(Duration::from_secs_f32),
+                    materials,
+                    allowed_terrain_types: allowed_terrain_types
+                        .into_iter()
+                        .map(Id::from_name)
+                        .collect(),
+                })
+            }
+        }
     }
 }

--- a/emergence_lib/src/construction/mod.rs
+++ b/emergence_lib/src/construction/mod.rs
@@ -21,7 +21,6 @@ pub(crate) struct ConstructionPlugin;
 impl Plugin for ConstructionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(ghosts::GhostPlugin)
-            .add_plugin(terraform::TerraformingPlugin)
             .add_plugin(zoning::ZoningPlugin);
     }
 }

--- a/emergence_lib/src/construction/mod.rs
+++ b/emergence_lib/src/construction/mod.rs
@@ -1,0 +1,19 @@
+//! Tools and systems for constructing structures and terraforming the world.
+
+use bevy::prelude::*;
+
+pub(crate) mod demolition;
+pub(crate) mod ghosts;
+pub(crate) mod terraform;
+pub(crate) mod zoning;
+
+/// Systems and resources for constructing structures and terraforming the world.
+pub(crate) struct ConstructionPlugin;
+
+impl Plugin for ConstructionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugin(ghosts::GhostPlugin)
+            .add_plugin(terraform::TerraformingPlugin)
+            .add_plugin(zoning::ZoningPlugin);
+    }
+}

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -1,5 +1,7 @@
 //! Tools to alter the terrain type and height.
 
+use std::time::Duration;
+
 use bevy::prelude::*;
 
 use crate::{
@@ -10,6 +12,7 @@ use crate::{
         geometry::{Height, MapGeometry, TilePos},
         SimulationSet,
     },
+    structures::structure_manifest::ConstructionData,
     terrain::{
         commands::TerrainCommandsExt,
         terrain_assets::TerrainHandles,
@@ -62,6 +65,25 @@ pub enum TerraformingAction {
 }
 
 impl TerraformingAction {
+    /// The construction requirements for this action.
+    // TODO: actually require materials
+    pub(crate) fn construction_data(&self) -> ConstructionData {
+        match self {
+            Self::Raise => ConstructionData {
+                work: Some(Duration::from_secs(5)),
+                ..Default::default()
+            },
+            Self::Lower => ConstructionData {
+                work: Some(Duration::from_secs(5)),
+                ..Default::default()
+            },
+            Self::Change(_) => ConstructionData {
+                work: Some(Duration::from_secs(5)),
+                ..Default::default()
+            },
+        }
+    }
+
     /// The pretty formatted name of this action.
     pub(crate) fn display(&self, terrain_manifest: &TerrainManifest) -> String {
         match self {

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -37,7 +37,7 @@ impl Plugin for TerraformingPlugin {
 /// These are generally higher level than the actual [`TerraformingAction`]s,
 /// which represent the actual changes to the terrain that can be performed by units.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum TerraformingChoice {
+pub(crate) enum TerraformingTool {
     /// Raise the height of this tile once
     Raise,
     /// Lower the height of this tile once
@@ -47,7 +47,7 @@ pub(crate) enum TerraformingChoice {
 }
 
 /// When `Zoning` is set, this is added  as a component added to terrain ghosts, causing them to be manipulated by units.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum TerraformingAction {
     /// Raise the height of this tile once
     Raise,
@@ -68,12 +68,12 @@ impl TerraformingAction {
     }
 }
 
-impl From<TerraformingChoice> for TerraformingAction {
-    fn from(choice: TerraformingChoice) -> Self {
+impl From<TerraformingTool> for TerraformingAction {
+    fn from(choice: TerraformingTool) -> Self {
         match choice {
-            TerraformingChoice::Raise => Self::Raise,
-            TerraformingChoice::Lower => Self::Lower,
-            TerraformingChoice::Change(terrain) => Self::Change(terrain),
+            TerraformingTool::Raise => Self::Raise,
+            TerraformingTool::Lower => Self::Lower,
+            TerraformingTool::Change(terrain) => Self::Change(terrain),
         }
     }
 }

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -127,23 +127,23 @@ fn apply_terraforming_when_ghosts_complete(
     for (crafting_state, &tile_pos, terraforming_action) in ghost_query.iter() {
         // FIXME: ensure that terraforming only progresses when no structures are present
         if matches!(*crafting_state, CraftingState::RecipeComplete) {
-            commands.despawn_ghost_terrain(tile_pos)
+            commands.despawn_ghost_terrain(tile_pos);
+
+            let terrain_entity = map_geometry.get_terrain(tile_pos).unwrap();
+            let (mut zoning, mut terrain, mut height, mut scene_handle) =
+                terrain_query.get_mut(terrain_entity).unwrap();
+
+            match terraforming_action {
+                TerraformingAction::Raise => *height += Height(1),
+                TerraformingAction::Lower => *height -= Height(1),
+                TerraformingAction::Change(terrain_id) => {
+                    *terrain = *terrain_id;
+                    *scene_handle = terrain_handles.scenes.get(terrain_id).unwrap().clone_weak();
+                }
+            };
+
+            map_geometry.update_height(tile_pos, *height);
+            *zoning = Zoning::None;
         }
-
-        let terrain_entity = map_geometry.get_terrain(tile_pos).unwrap();
-        let (mut zoning, mut terrain, mut height, mut scene_handle) =
-            terrain_query.get_mut(terrain_entity).unwrap();
-
-        match terraforming_action {
-            TerraformingAction::Raise => *height += Height(1),
-            TerraformingAction::Lower => *height -= Height(1),
-            TerraformingAction::Change(terrain_id) => {
-                *terrain = *terrain_id;
-                *scene_handle = terrain_handles.scenes.get(terrain_id).unwrap().clone_weak();
-            }
-        };
-
-        map_geometry.update_height(tile_pos, *height);
-        *zoning = Zoning::None;
     }
 }

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -75,3 +75,13 @@ impl From<TerraformingTool> for TerraformingAction {
         }
     }
 }
+
+impl From<TerraformingAction> for TerraformingTool {
+    fn from(action: TerraformingAction) -> Self {
+        match action {
+            TerraformingAction::Raise => Self::Raise,
+            TerraformingAction::Lower => Self::Lower,
+            TerraformingAction::Change(terrain) => Self::Change(terrain),
+        }
+    }
+}

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -11,14 +11,13 @@ use crate::{
         geometry::{MapGeometry, TilePos},
         SimulationSet,
     },
-    structures::structure_manifest::ConstructionData,
     terrain::{
         commands::TerrainCommandsExt,
         terrain_manifest::{Terrain, TerrainManifest},
     },
 };
 
-use super::{demolition::MarkedForDemolition, zoning::Zoning};
+use super::{demolition::MarkedForDemolition, zoning::Zoning, ConstructionData};
 
 /// Systems that handle terraforming.
 pub(super) struct TerraformingPlugin;

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 
 use crate::{
     asset_management::manifest::Id,
+    player_interaction::InteractionSystem,
     simulation::{
         geometry::{Height, TilePos},
         SimulationSet,
@@ -15,7 +16,7 @@ use crate::{
     },
 };
 
-use super::{zoning::Zoning, InteractionSystem};
+use super::zoning::Zoning;
 
 /// Systems that handle terraforming.
 pub(super) struct TerraformingPlugin;

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -167,7 +167,7 @@ fn set_zoning(
                         }
                         false => {
                             for &tile_pos in relevant_tiles.selection().iter() {
-                                commands.spawn_preview(tile_pos, clipboard_item.clone());
+                                commands.spawn_preview_structure(tile_pos, clipboard_item.clone());
                             }
                         }
                     }
@@ -187,7 +187,7 @@ fn set_zoning(
                                 }
                             }
                             false => {
-                                commands.spawn_preview(tile_pos, clipboard_item);
+                                commands.spawn_preview_structure(tile_pos, clipboard_item);
                             }
                         }
                     }
@@ -233,7 +233,7 @@ fn mark_based_on_zoning(
                 let allowed_terrain_types = &construction_data.allowed_terrain_types;
 
                 if allowed_terrain_types.contains(&terrain) {
-                    commands.spawn_ghost(tile_pos, clipboard_data.clone())
+                    commands.spawn_ghost_structure(tile_pos, clipboard_data.clone())
                 } else {
                     *zoning = Zoning::None;
                     // We bypassed change detection above, so need to manually trigger it here.
@@ -243,9 +243,9 @@ fn mark_based_on_zoning(
             Zoning::Terraform(mark) => {
                 commands.entity(terrain_entity).insert(*mark);
             }
-            Zoning::None => commands.despawn_ghost(tile_pos),
+            Zoning::None => commands.despawn_ghost_structure(tile_pos),
             Zoning::KeepClear => {
-                commands.despawn_ghost(tile_pos);
+                commands.despawn_ghost_structure(tile_pos);
                 if let Some(structure_entity) = map_geometry.get_structure(tile_pos) {
                     commands
                         .entity(structure_entity)

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -5,23 +5,23 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     asset_management::{manifest::Id, AssetState},
+    construction::{demolition::MarkedForDemolition, ghosts::Preview},
+    player_interaction::{
+        clipboard::{Clipboard, ClipboardData},
+        cursor::CursorPos,
+        selection::CurrentSelection,
+        InteractionSystem, PlayerAction,
+    },
     signals::{Emitter, SignalStrength, SignalType},
     simulation::geometry::{Height, MapGeometry, TilePos},
     structures::{
         commands::StructureCommandsExt,
-        construction::{MarkedForDemolition, Preview},
         structure_manifest::{Structure, StructureManifest},
     },
     terrain::terrain_manifest::{Terrain, TerrainManifest},
 };
 
-use super::{
-    clipboard::{Clipboard, ClipboardData},
-    cursor::CursorPos,
-    selection::CurrentSelection,
-    terraform::MarkedForTerraforming,
-    InteractionSystem, PlayerAction,
-};
+use super::terraform::MarkedForTerraforming;
 
 /// Code and data for setting zoning of areas for construction.
 pub(super) struct ZoningPlugin;

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -276,8 +276,12 @@ fn mark_based_on_zoning(
                         .insert(MarkedForDemolition);
                 }
             }
-            Zoning::None => commands.despawn_ghost_structure(tile_pos),
+            Zoning::None => {
+                commands.despawn_ghost_terrain(tile_pos);
+                commands.despawn_ghost_structure(tile_pos);
+            }
             Zoning::KeepClear => {
+                commands.despawn_ghost_terrain(tile_pos);
                 commands.despawn_ghost_structure(tile_pos);
                 if let Some(structure_entity) = map_geometry.get_structure(tile_pos) {
                     commands

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -219,20 +219,28 @@ fn mark_for_demolition(
 
 /// Spawn and despawn ghosts and apply other markings based on zoning.
 fn mark_based_on_zoning(
-    mut terrain_query: Query<(Entity, &mut Zoning, &TilePos, &Id<Terrain>), Changed<Zoning>>,
+    mut terrain_query: Query<(Entity, &mut Zoning, &TilePos), Changed<Zoning>>,
+    can_build_query: Query<&Id<Terrain>>,
     structure_manifest: Res<StructureManifest>,
     mut commands: Commands,
     map_geometry: Res<MapGeometry>,
 ) {
-    for (terrain_entity, mut zoning, &tile_pos, &terrain) in terrain_query.iter_mut() {
+    for (terrain_entity, mut zoning, &tile_pos) in terrain_query.iter_mut() {
         // Reborrowing here would trigger change detection, causing this system to constantly check
         match zoning.bypass_change_detection() {
             Zoning::Structure(clipboard_data) => {
                 let construction_data =
                     structure_manifest.construction_data(clipboard_data.structure_id);
+                let footprint =
+                    structure_manifest.construction_footprint(clipboard_data.structure_id);
                 let allowed_terrain_types = &construction_data.allowed_terrain_types;
 
-                if allowed_terrain_types.contains(&terrain) {
+                if map_geometry.can_build(
+                    tile_pos,
+                    footprint.rotated(clipboard_data.facing),
+                    &can_build_query,
+                    allowed_terrain_types,
+                ) {
                     commands.spawn_ghost_structure(tile_pos, clipboard_data.clone())
                 } else {
                     *zoning = Zoning::None;
@@ -240,8 +248,8 @@ fn mark_based_on_zoning(
                     zoning.set_changed();
                 }
             }
-            Zoning::Terraform(mark) => {
-                commands.entity(terrain_entity).insert(*mark);
+            Zoning::Terraform(terraforming_action) => {
+                commands.entity(terrain_entity).insert(*terraforming_action);
             }
             Zoning::None => commands.despawn_ghost_structure(tile_pos),
             Zoning::KeepClear => {

--- a/emergence_lib/src/crafting/components.rs
+++ b/emergence_lib/src/crafting/components.rs
@@ -105,6 +105,14 @@ pub enum InputInventory {
     },
 }
 
+impl Default for InputInventory {
+    fn default() -> Self {
+        Self::Exact {
+            inventory: Inventory::default(),
+        }
+    }
+}
+
 impl InputInventory {
     /// Returns a reference the underlying [`Inventory`].
     pub fn inventory(&self) -> &Inventory {

--- a/emergence_lib/src/crafting/mod.rs
+++ b/emergence_lib/src/crafting/mod.rs
@@ -5,6 +5,7 @@ use recipe::{RawRecipeManifest, RecipeManifest};
 
 use crate::{
     asset_management::manifest::{plugin::ManifestPlugin, Id},
+    construction::ghosts::WorkplaceId,
     items::item_manifest::{ItemManifest, RawItemManifest},
     organisms::{energy::EnergyPool, lifecycle::Lifecycle, Organism},
     signals::{Emitter, SignalStrength, SignalType},
@@ -259,9 +260,10 @@ pub(crate) fn set_crafting_emitter(
                 let recipe = recipe_manifest.get(*recipe_id);
                 if workers_present.needs_more() && recipe.needs_workers() {
                     let signal_strength = SignalStrength::new(100.);
-                    emitter
-                        .signals
-                        .push((SignalType::Work(structure_id), signal_strength));
+                    emitter.signals.push((
+                        SignalType::Work(WorkplaceId::structure(structure_id)),
+                        signal_strength,
+                    ));
                 }
             }
         }

--- a/emergence_lib/src/graphics/structures.rs
+++ b/emergence_lib/src/graphics/structures.rs
@@ -5,7 +5,7 @@ use bevy::{
     prelude::*,
 };
 
-use crate::structures::construction::{Ghost, Preview};
+use crate::construction::ghosts::{Ghost, Preview};
 
 /// Adds [`NotShadowCaster`] and [`NotShadowReceiver`] to all ghosts and previews
 pub(super) fn remove_ghostly_shadows(

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod asset_management;
+pub mod construction;
 pub mod crafting;
 pub mod curves;
 pub mod enum_iter;

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -327,7 +327,7 @@ fn set_camera_focus(
         || settings.camera_mode == CameraMode::FollowUnit
     {
         let tile_to_snap_to = match &*selection {
-            CurrentSelection::Ghost(entity)
+            CurrentSelection::GhostStructure(entity)
             | CurrentSelection::Unit(entity)
             | CurrentSelection::Structure(entity) => Some(*tile_pos_query.get(*entity).unwrap()),
             CurrentSelection::Terrain(selected_tiles) => Some(selected_tiles.center()),

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -81,8 +81,7 @@ fn setup_camera(mut commands: Commands) {
         .insert(RaycastSource::<Terrain>::new())
         .insert(RaycastSource::<Structure>::new())
         .insert(RaycastSource::<Unit>::new())
-        .insert(RaycastSource::<(Ghost, Structure)>::new())
-        .insert(RaycastSource::<(Ghost, Terrain)>::new());
+        .insert(RaycastSource::<(Ghost, Structure)>::new());
 }
 
 /// The position that the camera is looking at.
@@ -328,7 +327,6 @@ fn set_camera_focus(
     {
         let tile_to_snap_to = match &*selection {
             CurrentSelection::GhostStructure(entity)
-            | CurrentSelection::GhostTerrain(entity)
             | CurrentSelection::Unit(entity)
             | CurrentSelection::Structure(entity) => Some(*tile_pos_query.get(*entity).unwrap()),
             CurrentSelection::Terrain(selected_tiles) => Some(selected_tiles.center()),

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -13,9 +13,9 @@ use leafwing_input_manager::orientation::Rotation;
 use leafwing_input_manager::prelude::ActionState;
 
 use crate::asset_management::manifest::Id;
+use crate::construction::ghosts::Ghost;
 use crate::simulation::geometry::MapGeometry;
 use crate::simulation::geometry::TilePos;
-use crate::structures::construction::Ghost;
 use crate::structures::structure_manifest::Structure;
 use crate::terrain::terrain_manifest::Terrain;
 use crate::units::unit_manifest::Unit;

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -12,7 +12,6 @@ use bevy_mod_raycast::RaycastSource;
 use leafwing_input_manager::orientation::Rotation;
 use leafwing_input_manager::prelude::ActionState;
 
-use crate::asset_management::manifest::Id;
 use crate::construction::ghosts::Ghost;
 use crate::simulation::geometry::MapGeometry;
 use crate::simulation::geometry::TilePos;
@@ -80,9 +79,9 @@ fn setup_camera(mut commands: Commands) {
         .insert(settings)
         .insert(focus)
         .insert(RaycastSource::<Terrain>::new())
-        .insert(RaycastSource::<Id<Structure>>::new())
-        .insert(RaycastSource::<Id<Unit>>::new())
-        .insert(RaycastSource::<Ghost>::new());
+        .insert(RaycastSource::<Structure>::new())
+        .insert(RaycastSource::<Unit>::new())
+        .insert(RaycastSource::<(Ghost, Structure)>::new());
 }
 
 /// The position that the camera is looking at.

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -81,7 +81,8 @@ fn setup_camera(mut commands: Commands) {
         .insert(RaycastSource::<Terrain>::new())
         .insert(RaycastSource::<Structure>::new())
         .insert(RaycastSource::<Unit>::new())
-        .insert(RaycastSource::<(Ghost, Structure)>::new());
+        .insert(RaycastSource::<(Ghost, Structure)>::new())
+        .insert(RaycastSource::<(Ghost, Terrain)>::new());
 }
 
 /// The position that the camera is looking at.
@@ -327,6 +328,7 @@ fn set_camera_focus(
     {
         let tile_to_snap_to = match &*selection {
             CurrentSelection::GhostStructure(entity)
+            | CurrentSelection::GhostTerrain(entity)
             | CurrentSelection::Unit(entity)
             | CurrentSelection::Structure(entity) => Some(*tile_pos_query.get(*entity).unwrap()),
             CurrentSelection::Terrain(selected_tiles) => Some(selected_tiles.center()),

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -194,7 +194,7 @@ fn copy_selection(
         let mut map = HashMap::new();
 
         match &*current_selection {
-            CurrentSelection::Structure(entity) | CurrentSelection::Ghost(entity) => {
+            CurrentSelection::Structure(entity) | CurrentSelection::GhostStructure(entity) => {
                 let query_item = structure_query.get(*entity).unwrap();
                 let tile_pos = query_item.tile_pos;
                 let clipboard_data = query_item.into();

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -6,15 +6,13 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     asset_management::manifest::Id,
+    construction::{ghosts::Preview, terraform::TerraformingChoice},
     crafting::components::ActiveRecipe,
     simulation::geometry::{Facing, MapGeometry, TilePos},
-    structures::{construction::Preview, structure_manifest::Structure},
+    structures::structure_manifest::Structure,
 };
 
-use super::{
-    cursor::CursorPos, selection::CurrentSelection, terraform::TerraformingChoice,
-    InteractionSystem, PlayerAction,
-};
+use super::{cursor::CursorPos, selection::CurrentSelection, InteractionSystem, PlayerAction};
 
 /// Code and data for working with the clipboard
 pub(super) struct ClipboardPlugin;
@@ -111,7 +109,7 @@ impl Clipboard {
     /// Apply a tile-position shift to the items on the clipboard.
     ///
     /// Used to place items in the correct location relative to the cursor.
-    pub(super) fn offset_positions(&self, origin: TilePos) -> Vec<(TilePos, ClipboardData)> {
+    pub(crate) fn offset_positions(&self, origin: TilePos) -> Vec<(TilePos, ClipboardData)> {
         if let Clipboard::Structures(map) = self {
             map.iter()
                 .map(|(k, v)| ((*k + origin), v.clone()))

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -6,7 +6,10 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     asset_management::manifest::Id,
-    construction::{ghosts::Preview, terraform::TerraformingTool},
+    construction::{
+        ghosts::Preview,
+        terraform::{TerraformingAction, TerraformingTool},
+    },
     crafting::components::ActiveRecipe,
     simulation::geometry::{Facing, MapGeometry, TilePos},
     structures::structure_manifest::Structure,
@@ -187,6 +190,7 @@ fn copy_selection(
     cursor_pos: Res<CursorPos>,
     current_selection: Res<CurrentSelection>,
     structure_query: Query<ClipboardQuery, Without<Preview>>,
+    ghost_terrain_query: Query<&TerraformingAction>,
     map_geometry: Res<MapGeometry>,
 ) {
     if actions.just_pressed(PlayerAction::Copy) {
@@ -224,7 +228,8 @@ fn copy_selection(
                 }
             }
             CurrentSelection::GhostTerrain(entity) => {
-                todo!()
+                let terraforming_action = ghost_terrain_query.get(*entity).unwrap();
+                *clipboard = Clipboard::Terraform(terraforming_action.clone().into());
             }
             // Otherwise, just grab whatever's under the cursor
             CurrentSelection::None | CurrentSelection::Unit(_) => {

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -6,10 +6,7 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     asset_management::manifest::Id,
-    construction::{
-        ghosts::Preview,
-        terraform::{TerraformingAction, TerraformingTool},
-    },
+    construction::{ghosts::Preview, terraform::TerraformingTool},
     crafting::components::ActiveRecipe,
     simulation::geometry::{Facing, MapGeometry, TilePos},
     structures::structure_manifest::Structure,
@@ -190,7 +187,6 @@ fn copy_selection(
     cursor_pos: Res<CursorPos>,
     current_selection: Res<CurrentSelection>,
     structure_query: Query<ClipboardQuery, Without<Preview>>,
-    ghost_terrain_query: Query<&TerraformingAction>,
     map_geometry: Res<MapGeometry>,
 ) {
     if actions.just_pressed(PlayerAction::Copy) {
@@ -226,10 +222,6 @@ fn copy_selection(
                     *clipboard = Clipboard::Structures(map);
                     clipboard.normalize_positions();
                 }
-            }
-            CurrentSelection::GhostTerrain(entity) => {
-                let terraforming_action = ghost_terrain_query.get(*entity).unwrap();
-                *clipboard = Clipboard::Terraform(terraforming_action.clone().into());
             }
             // Otherwise, just grab whatever's under the cursor
             CurrentSelection::None | CurrentSelection::Unit(_) => {

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -6,7 +6,7 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     asset_management::manifest::Id,
-    construction::{ghosts::Preview, terraform::TerraformingChoice},
+    construction::{ghosts::Preview, terraform::TerraformingTool},
     crafting::components::ActiveRecipe,
     simulation::geometry::{Facing, MapGeometry, TilePos},
     structures::structure_manifest::Structure,
@@ -41,7 +41,7 @@ impl Plugin for ClipboardPlugin {
 #[derive(Default, Resource, Debug)]
 pub(crate) enum Clipboard {
     /// The clipboard is set to terraform terrain.
-    Terraform(TerraformingChoice),
+    Terraform(TerraformingTool),
     /// The clipboard contains a structure.
     Structures(HashMap<TilePos, ClipboardData>),
     /// The clipboard is empty.

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -223,6 +223,9 @@ fn copy_selection(
                     clipboard.normalize_positions();
                 }
             }
+            CurrentSelection::GhostTerrain(entity) => {
+                todo!()
+            }
             // Otherwise, just grab whatever's under the cursor
             CurrentSelection::None | CurrentSelection::Unit(_) => {
                 if let Some(cursor_tile_pos) = cursor_pos.maybe_tile_pos() {

--- a/emergence_lib/src/player_interaction/cursor.rs
+++ b/emergence_lib/src/player_interaction/cursor.rs
@@ -18,9 +18,9 @@ impl Plugin for CursorPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CursorPos>()
             .add_plugin(DefaultRaycastingPlugin::<Terrain>::default())
-            .add_plugin(DefaultRaycastingPlugin::<Id<Structure>>::default())
-            .add_plugin(DefaultRaycastingPlugin::<Id<Unit>>::default())
-            .add_plugin(DefaultRaycastingPlugin::<Ghost>::default())
+            .add_plugin(DefaultRaycastingPlugin::<Structure>::default())
+            .add_plugin(DefaultRaycastingPlugin::<Unit>::default())
+            .add_plugin(DefaultRaycastingPlugin::<(Ghost, Structure)>::default())
             .add_system(
                 update_raycast_with_cursor
                     .before(RaycastSystem::BuildRays::<Terrain>)
@@ -99,9 +99,9 @@ fn update_raycast_with_cursor(
     mut query: Query<
         (
             &mut RaycastSource<Terrain>,
-            &mut RaycastSource<Id<Structure>>,
-            &mut RaycastSource<Id<Unit>>,
-            &mut RaycastSource<Ghost>,
+            &mut RaycastSource<Structure>,
+            &mut RaycastSource<Unit>,
+            &mut RaycastSource<(Ghost, Structure)>,
         ),
         With<Camera>,
     >,
@@ -128,9 +128,9 @@ fn update_cursor_pos(
     camera_query: Query<
         (
             &mut RaycastSource<Terrain>,
-            &mut RaycastSource<Id<Structure>>,
-            &mut RaycastSource<Id<Unit>>,
-            &mut RaycastSource<Ghost>,
+            &mut RaycastSource<Structure>,
+            &mut RaycastSource<Unit>,
+            &mut RaycastSource<(Ghost, Structure)>,
         ),
         With<Camera>,
     >,

--- a/emergence_lib/src/player_interaction/cursor.rs
+++ b/emergence_lib/src/player_interaction/cursor.rs
@@ -6,10 +6,8 @@ use leafwing_input_manager::prelude::ActionState;
 
 use super::{InteractionSystem, PlayerAction};
 use crate::{
-    asset_management::manifest::Id,
-    simulation::geometry::TilePos,
-    structures::{construction::Ghost, structure_manifest::Structure},
-    terrain::terrain_manifest::Terrain,
+    asset_management::manifest::Id, construction::ghosts::Ghost, simulation::geometry::TilePos,
+    structures::structure_manifest::Structure, terrain::terrain_manifest::Terrain,
     units::unit_manifest::Unit,
 };
 

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -90,11 +90,11 @@ pub(crate) enum PlayerAction {
     Copy,
     /// Sets the zoning of all currently selected tiles to the currently selected structure.
     ///
-    /// If no structure is selected to build, zoning will be set to [`Zoning::None`](zoning::Zoning::None).
+    /// If no structure is selected to build, zoning will be set to [`Zoning::None`](crate::construction::zoning::Zoning::None).
     Paste,
-    /// Sets the zoning of all currently selected tiles to [`Zoning::None`](zoning::Zoning::None).
+    /// Sets the zoning of all currently selected tiles to [`Zoning::None`](crate::construction::zoning::Zoning::None).
     ClearZoning,
-    /// Sets the zoning of all currently selected tiles to [`Zoning::KeepClear`](zoning::Zoning::KeepClear).
+    /// Sets the zoning of all currently selected tiles to [`Zoning::KeepClear`](crate::construction::zoning::Zoning::KeepClear).
     KeepClear,
     /// Rotates the conents of the clipboard counterclockwise.
     RotateClipboardLeft,

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -13,8 +13,6 @@ pub(crate) mod clipboard;
 pub(crate) mod cursor;
 pub(crate) mod intent;
 pub(crate) mod selection;
-pub(crate) mod terraform;
-pub(crate) mod zoning;
 
 /// All of the code needed for users to interact with the simulation.
 pub struct InteractionPlugin;
@@ -29,9 +27,7 @@ impl Plugin for InteractionPlugin {
             .add_plugin(cursor::CursorPlugin)
             .add_plugin(intent::IntentPlugin)
             .add_plugin(selection::SelectionPlugin)
-            .add_plugin(terraform::TerraformingPlugin)
-            .add_plugin(clipboard::ClipboardPlugin)
-            .add_plugin(zoning::ZoningPlugin);
+            .add_plugin(clipboard::ClipboardPlugin);
 
         #[cfg(feature = "debug_tools")]
         app.add_plugin(debug_tools::DebugToolsPlugin);

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -49,8 +49,6 @@ pub(crate) enum InteractionSystem {
     ReplenishIntent,
     /// Apply zoning to tiles
     ApplyZoning,
-    /// Apply terraforming to tiles
-    ApplyTerraforming,
     /// Use intent-spending abilities
     UseAbilities,
     /// Spawn and despawn ghosts

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -282,11 +282,11 @@ fn update_selection_radius(
 pub(crate) enum CurrentSelection {
     /// A ghost structure is selected
     GhostStructure(Entity),
-    /// A ghost terrain (used to indicate planned terraforming) is selected
-    GhostTerrain(Entity),
     /// A structure is selected
     Structure(Entity),
-    /// One or more tile is selected
+    /// One or more tile is selected.
+    ///
+    /// Note that terraforming details are also displayed on the basis of the selected terrain.
     Terrain(SelectedTiles),
     /// A unit is selected
     Unit(Entity),
@@ -402,9 +402,6 @@ impl CurrentSelection {
             SelectionVariant::Unit => cursor_pos
                 .maybe_unit()
                 .map(|unit_entity| CurrentSelection::Unit(unit_entity)),
-            SelectionVariant::GhostTerrain => cursor_pos
-                .maybe_ghost_terrain()
-                .map(|ghost_terrain_entity| CurrentSelection::GhostTerrain(ghost_terrain_entity)),
             SelectionVariant::GhostStructure => {
                 cursor_pos
                     .maybe_ghost_structure()
@@ -429,11 +426,17 @@ impl CurrentSelection {
 /// The dataless enum that tracks the variety of [`CurrentSelection`].
 #[derive(IterableEnum, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum SelectionVariant {
+    /// A unit.
     Unit,
-    GhostTerrain,
+    /// A ghost structure.
     GhostStructure,
+    /// A structure.
     Structure,
+    /// Terrain.
+    ///
+    /// Note that terraforming details are also stored in the [`CurrentSelection::Terrain`] variant.
     Terrain,
+    /// No selection.
     None,
 }
 
@@ -445,8 +448,7 @@ impl SelectionVariant {
     fn next(&self) -> Self {
         match self {
             Self::None => Self::Unit,
-            Self::Unit => Self::GhostTerrain,
-            Self::GhostTerrain => Self::GhostStructure,
+            Self::Unit => Self::GhostStructure,
             Self::GhostStructure => Self::Structure,
             Self::Structure => Self::Terrain,
             Self::Terrain => Self::Unit,
@@ -476,7 +478,6 @@ impl SelectionVariant {
 impl From<&CurrentSelection> for SelectionVariant {
     fn from(selection: &CurrentSelection) -> Self {
         match selection {
-            CurrentSelection::GhostTerrain(_) => Self::GhostTerrain,
             CurrentSelection::GhostStructure(_) => Self::GhostStructure,
             CurrentSelection::Structure(_) => Self::Structure,
             CurrentSelection::Terrain(_) => Self::Terrain,

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -295,7 +295,7 @@ pub(crate) enum CurrentSelection {
 
 impl CurrentSelection {
     /// Returns the set of terrain tiles that should be affected by actions.
-    pub(super) fn relevant_tiles(&self, cursor_pos: &CursorPos) -> SelectedTiles {
+    pub(crate) fn relevant_tiles(&self, cursor_pos: &CursorPos) -> SelectedTiles {
         match self {
             CurrentSelection::Terrain(selected_tiles) => match selected_tiles.is_empty() {
                 true => {

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -280,8 +280,8 @@ fn update_selection_radius(
 /// The game object(s) currently selected for inspection.
 #[derive(Resource, Debug, Default)]
 pub(crate) enum CurrentSelection {
-    /// A ghost is selected
-    Ghost(Entity),
+    /// A ghost structure is selected
+    GhostStructure(Entity),
     /// A structure is selected
     Structure(Entity),
     /// One or more tile is selected
@@ -374,7 +374,7 @@ impl CurrentSelection {
                 if let Some(unit_entity) = cursor_pos.maybe_unit() {
                     CurrentSelection::Unit(unit_entity)
                 } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::Ghost(ghost_entity)
+                    CurrentSelection::GhostStructure(ghost_entity)
                 } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
                     CurrentSelection::Structure(structure_entity)
                 } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
@@ -385,7 +385,7 @@ impl CurrentSelection {
                     CurrentSelection::None
                 }
             }
-            CurrentSelection::Ghost(_) => {
+            CurrentSelection::GhostStructure(_) => {
                 if let Some(structure_entity) = cursor_pos.maybe_structure() {
                     CurrentSelection::Structure(structure_entity)
                 } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
@@ -395,7 +395,7 @@ impl CurrentSelection {
                 } else if let Some(unit_entity) = cursor_pos.maybe_unit() {
                     CurrentSelection::Unit(unit_entity)
                 } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::Ghost(ghost_entity)
+                    CurrentSelection::GhostStructure(ghost_entity)
                 } else {
                     CurrentSelection::None
                 }
@@ -408,7 +408,7 @@ impl CurrentSelection {
                 } else if let Some(unit_entity) = cursor_pos.maybe_unit() {
                     CurrentSelection::Unit(unit_entity)
                 } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::Ghost(ghost_entity)
+                    CurrentSelection::GhostStructure(ghost_entity)
                 } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
                     CurrentSelection::Structure(structure_entity)
                 } else {
@@ -419,7 +419,7 @@ impl CurrentSelection {
                 if let Some(unit_entity) = cursor_pos.maybe_unit() {
                     CurrentSelection::Unit(unit_entity)
                 } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::Ghost(ghost_entity)
+                    CurrentSelection::GhostStructure(ghost_entity)
                 } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
                     CurrentSelection::Structure(structure_entity)
                 } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
@@ -435,7 +435,7 @@ impl CurrentSelection {
             }
             CurrentSelection::Unit(_) => {
                 if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::Ghost(ghost_entity)
+                    CurrentSelection::GhostStructure(ghost_entity)
                 } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
                     CurrentSelection::Structure(structure_entity)
                 } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -399,9 +399,7 @@ impl CurrentSelection {
         map_geometry: &MapGeometry,
     ) -> Option<Self> {
         match selection_variant {
-            SelectionVariant::Unit => cursor_pos
-                .maybe_unit()
-                .map(|unit_entity| CurrentSelection::Unit(unit_entity)),
+            SelectionVariant::Unit => cursor_pos.maybe_unit().map(CurrentSelection::Unit),
             SelectionVariant::GhostStructure => {
                 cursor_pos
                     .maybe_ghost_structure()
@@ -411,7 +409,7 @@ impl CurrentSelection {
             }
             SelectionVariant::Structure => cursor_pos
                 .maybe_structure()
-                .map(|structure_entity| CurrentSelection::Structure(structure_entity)),
+                .map(CurrentSelection::Structure),
             SelectionVariant::Terrain => {
                 let hovered_tile = cursor_pos.maybe_tile_pos()?;
                 let mut selected_tiles = SelectedTiles::default();
@@ -469,7 +467,7 @@ impl SelectionVariant {
         }
 
         // Fallback to self if nothing else is found
-        cycle.push(self.clone());
+        cycle.push(*self);
 
         cycle
     }
@@ -839,13 +837,15 @@ mod tests {
     #[test]
     fn cycle_end_with_self() {
         for variant in SelectionVariant::variants() {
+            if variant == SelectionVariant::None {
+                continue;
+            }
+
             let cycle = variant.cycle();
             assert_eq!(
                 cycle.iter().last().copied().unwrap(),
                 variant,
-                "{:?}'s cycle was {:?}",
-                variant,
-                cycle
+                "{variant:?}'s cycle was {cycle:?}"
             );
         }
     }

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -282,6 +282,8 @@ fn update_selection_radius(
 pub(crate) enum CurrentSelection {
     /// A ghost structure is selected
     GhostStructure(Entity),
+    /// A ghost terrain (used to indicate planned terraforming) is selected
+    GhostTerrain(Entity),
     /// A structure is selected
     Structure(Entity),
     /// One or more tile is selected
@@ -360,7 +362,7 @@ impl CurrentSelection {
 
     /// Cycles through game objects on the same tile.
     ///
-    /// The order is units -> ghosts -> structures -> terrain -> units.
+    /// The order is units -> ghost structure -> ghost terrain -> structures -> terrain -> units.
     /// If a higher priority option is missing, later options in the chain are searched.
     /// If none of the options can be found, the selection is cleared completely.
     fn cycle_selection(
@@ -369,86 +371,7 @@ impl CurrentSelection {
         selection_state: &SelectionState,
         map_geometry: &MapGeometry,
     ) {
-        *self = match self {
-            CurrentSelection::None => {
-                if let Some(unit_entity) = cursor_pos.maybe_unit() {
-                    CurrentSelection::Unit(unit_entity)
-                } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::GhostStructure(ghost_entity)
-                } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
-                    CurrentSelection::Structure(structure_entity)
-                } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
-                    let mut selected_tiles = SelectedTiles::default();
-                    selected_tiles.add_to_selection(hovered_tile, selection_state, map_geometry);
-                    CurrentSelection::Terrain(selected_tiles)
-                } else {
-                    CurrentSelection::None
-                }
-            }
-            CurrentSelection::GhostStructure(_) => {
-                if let Some(structure_entity) = cursor_pos.maybe_structure() {
-                    CurrentSelection::Structure(structure_entity)
-                } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
-                    let mut selected_tiles = SelectedTiles::default();
-                    selected_tiles.add_to_selection(hovered_tile, selection_state, map_geometry);
-                    CurrentSelection::Terrain(selected_tiles)
-                } else if let Some(unit_entity) = cursor_pos.maybe_unit() {
-                    CurrentSelection::Unit(unit_entity)
-                } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::GhostStructure(ghost_entity)
-                } else {
-                    CurrentSelection::None
-                }
-            }
-            CurrentSelection::Structure(_) => {
-                if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
-                    let mut selected_tiles = SelectedTiles::default();
-                    selected_tiles.add_to_selection(hovered_tile, selection_state, map_geometry);
-                    CurrentSelection::Terrain(selected_tiles)
-                } else if let Some(unit_entity) = cursor_pos.maybe_unit() {
-                    CurrentSelection::Unit(unit_entity)
-                } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::GhostStructure(ghost_entity)
-                } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
-                    CurrentSelection::Structure(structure_entity)
-                } else {
-                    CurrentSelection::None
-                }
-            }
-            CurrentSelection::Terrain(existing_selection) => {
-                if let Some(unit_entity) = cursor_pos.maybe_unit() {
-                    CurrentSelection::Unit(unit_entity)
-                } else if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::GhostStructure(ghost_entity)
-                } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
-                    CurrentSelection::Structure(structure_entity)
-                } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
-                    existing_selection.add_to_selection(
-                        hovered_tile,
-                        selection_state,
-                        map_geometry,
-                    );
-                    CurrentSelection::Terrain(existing_selection.clone())
-                } else {
-                    CurrentSelection::None
-                }
-            }
-            CurrentSelection::Unit(_) => {
-                if let Some(ghost_entity) = cursor_pos.maybe_ghost() {
-                    CurrentSelection::GhostStructure(ghost_entity)
-                } else if let Some(structure_entity) = cursor_pos.maybe_structure() {
-                    CurrentSelection::Structure(structure_entity)
-                } else if let Some(hovered_tile) = cursor_pos.maybe_tile_pos() {
-                    let mut selected_tiles = SelectedTiles::default();
-                    selected_tiles.add_to_selection(hovered_tile, selection_state, map_geometry);
-                    CurrentSelection::Terrain(selected_tiles)
-                } else if let Some(unit_entity) = cursor_pos.maybe_unit() {
-                    CurrentSelection::Unit(unit_entity)
-                } else {
-                    CurrentSelection::None
-                }
-            }
-        }
+        todo!()
     }
 }
 

--- a/emergence_lib/src/simulation/generation.rs
+++ b/emergence_lib/src/simulation/generation.rs
@@ -5,8 +5,8 @@ use crate::player_interaction::clipboard::ClipboardData;
 use crate::simulation::geometry::{Facing, Height, TilePos};
 use crate::structures::commands::StructureCommandsExt;
 use crate::structures::structure_manifest::StructureManifest;
+use crate::terrain::commands::TerrainCommandsExt;
 use crate::terrain::terrain_manifest::Terrain;
-use crate::terrain::SpawnTerrainCommand;
 use crate::units::unit_assets::UnitHandles;
 use crate::units::unit_manifest::UnitManifest;
 use crate::units::UnitBundle;
@@ -152,11 +152,9 @@ pub(crate) fn generate_terrain(
                 * AMPLITUDE_SCALE)
                 .abs();
 
-        commands.add(SpawnTerrainCommand {
-            tile_pos,
-            height: Height::from_world_pos(hex_height),
-            terrain_id,
-        })
+        let height = Height::from_world_pos(hex_height);
+
+        commands.spawn_terrain(tile_pos, height, terrain_id);
     }
 }
 

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 use crate::{
-    asset_management::manifest::Id, filtered_array_iter::FilteredArrayIter,
-    structures::construction::Footprint, terrain::terrain_manifest::Terrain,
+    asset_management::manifest::Id, filtered_array_iter::FilteredArrayIter, structures::Footprint,
+    terrain::terrain_manifest::Terrain,
 };
 
 /// A hex-based coordinate, that represents exactly one tile.

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -510,11 +510,6 @@ impl MapGeometry {
         removed
     }
 
-    /// Gets the ghost terrain [`Entity`] at the provided `tile_pos`, if any.
-    pub(crate) fn get_ghost_terrain(&self, tile_pos: TilePos) -> Option<Entity> {
-        self.ghost_terrain_index.get(&tile_pos).copied()
-    }
-
     /// Adds the provided `ghost_terrain_entity` to the ghost terrain index at the provided `tile_pos`.
     pub(crate) fn add_ghost_terrain(&mut self, ghost_terrain_entity: Entity, tile_pos: TilePos) {
         self.ghost_terrain_index

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -539,6 +539,11 @@ impl MapGeometry {
 
         removed
     }
+
+    /// Gets the ghost terrain [`Entity`] at the provided `tile_pos`, if any.
+    pub(crate) fn get_ghost_terrain(&self, tile_pos: TilePos) -> Option<Entity> {
+        self.ghost_structure_index.get(&tile_pos).copied()
+    }
 }
 
 /// The hex direction that this entity is facing.

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -542,7 +542,7 @@ impl MapGeometry {
 
     /// Gets the ghost terrain [`Entity`] at the provided `tile_pos`, if any.
     pub(crate) fn get_ghost_terrain(&self, tile_pos: TilePos) -> Option<Entity> {
-        self.ghost_structure_index.get(&tile_pos).copied()
+        self.ghost_terrain_index.get(&tile_pos).copied()
     }
 }
 

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -431,7 +431,9 @@ impl MapGeometry {
     /// - ghost structure
     /// - structure
     pub(crate) fn get_ghost_or_structure(&self, tile_pos: TilePos) -> Option<Entity> {
-        if let Some(&ghost_entity) = self.ghost_structure_index.get(&tile_pos) {
+        if let Some(&ghost_terrain_entity) = self.ghost_terrain_index.get(&tile_pos) {
+            Some(ghost_terrain_entity)
+        } else if let Some(&ghost_entity) = self.ghost_structure_index.get(&tile_pos) {
             Some(ghost_entity)
         } else if let Some(&structure_entity) = self.structure_index.get(&tile_pos) {
             Some(structure_entity)

--- a/emergence_lib/src/simulation/mod.rs
+++ b/emergence_lib/src/simulation/mod.rs
@@ -3,6 +3,7 @@
 //! All plugins in this module should work without rendering.
 
 use crate::asset_management::AssetState;
+use crate::construction::ConstructionPlugin;
 use crate::crafting::CraftingPlugin;
 use crate::organisms::OrganismPlugin;
 use crate::signals::SignalsPlugin;
@@ -55,6 +56,7 @@ impl Plugin for SimulationPlugin {
                 config: self.gen_config.clone(),
             })
             .add_plugin(CraftingPlugin)
+            .add_plugin(ConstructionPlugin)
             .add_plugin(StructuresPlugin)
             .add_plugin(TerrainPlugin)
             .add_plugin(OrganismPlugin)

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -55,17 +55,17 @@ pub(crate) trait StructureCommandsExt {
     /// Spawns a ghost with data defined by `data` at `tile_pos`.
     ///
     /// Replaces any existing ghost.
-    fn spawn_ghost(&mut self, tile_pos: TilePos, data: ClipboardData);
+    fn spawn_ghost_structure(&mut self, tile_pos: TilePos, data: ClipboardData);
 
     /// Despawns any ghost at the provided `tile_pos`.
     ///
     /// Has no effect if the tile position is already empty.
-    fn despawn_ghost(&mut self, tile_pos: TilePos);
+    fn despawn_ghost_structure(&mut self, tile_pos: TilePos);
 
     /// Spawns a preview with data defined by `item` at `tile_pos`.
     ///
     /// Replaces any existing preview.
-    fn spawn_preview(&mut self, tile_pos: TilePos, data: ClipboardData);
+    fn spawn_preview_structure(&mut self, tile_pos: TilePos, data: ClipboardData);
 }
 
 impl<'w, 's> StructureCommandsExt for Commands<'w, 's> {
@@ -97,15 +97,15 @@ impl<'w, 's> StructureCommandsExt for Commands<'w, 's> {
         self.add(DespawnStructureCommand { tile_pos });
     }
 
-    fn spawn_ghost(&mut self, tile_pos: TilePos, data: ClipboardData) {
+    fn spawn_ghost_structure(&mut self, tile_pos: TilePos, data: ClipboardData) {
         self.add(SpawnGhostCommand { tile_pos, data });
     }
 
-    fn despawn_ghost(&mut self, tile_pos: TilePos) {
+    fn despawn_ghost_structure(&mut self, tile_pos: TilePos) {
         self.add(DespawnGhostCommand { tile_pos });
     }
 
-    fn spawn_preview(&mut self, tile_pos: TilePos, data: ClipboardData) {
+    fn spawn_preview_structure(&mut self, tile_pos: TilePos, data: ClipboardData) {
         self.add(SpawnPreviewCommand { tile_pos, data });
     }
 }

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -279,14 +279,14 @@ impl Command for SpawnStructureGhostCommand {
         )> = SystemState::new(world);
 
         let (terrain_query, geometry, manifest) = system_state.get(world);
-        let structure_variety = manifest.get(structure_id).clone();
         let construction_data = manifest.construction_data(structure_id);
         let allowed_terrain_types = &construction_data.allowed_terrain_types;
+        let construction_footprint = manifest.construction_footprint(structure_id);
 
         // Check that the tiles needed are appropriate.
         if !geometry.can_build(
             self.tile_pos,
-            structure_variety.footprint.rotated(self.data.facing),
+            construction_footprint.rotated(self.data.facing),
             &terrain_query,
             allowed_terrain_types,
         ) {

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -9,6 +9,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom, thread_rng};
 
 use crate::{
     asset_management::manifest::Id,
+    construction::ghosts::{GhostBundle, GhostKind, PreviewBundle},
     crafting::{
         components::{CraftingBundle, StorageInventory},
         recipe::RecipeManifest,
@@ -23,7 +24,6 @@ use crate::{
 };
 
 use super::{
-    construction::{GhostBundle, GhostKind, PreviewBundle},
     structure_assets::StructureHandles,
     structure_manifest::{StructureKind, StructureManifest},
     StructureBundle,

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -9,7 +9,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom, thread_rng};
 
 use crate::{
     asset_management::manifest::Id,
-    construction::ghosts::{GhostBundle, GhostKind, PreviewBundle},
+    construction::ghosts::{GhostKind, GhostStructureBundle, StructurePreviewBundle},
     crafting::{
         components::{CraftingBundle, StorageInventory},
         recipe::RecipeManifest,
@@ -321,7 +321,7 @@ impl Command for SpawnGhostCommand {
         let world_pos = self.tile_pos.top_of_tile(world.resource::<MapGeometry>());
 
         let ghost_entity = world
-            .spawn(GhostBundle::new(
+            .spawn(GhostStructureBundle::new(
                 self.tile_pos,
                 self.data,
                 structure_manifest,
@@ -423,7 +423,7 @@ impl Command for SpawnPreviewCommand {
         let inherited_material = InheritedMaterial(preview_handle.clone_weak());
 
         // Spawn a preview
-        world.spawn(PreviewBundle::new(
+        world.spawn(StructurePreviewBundle::new(
             self.tile_pos,
             self.data,
             scene_handle,

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -295,7 +295,7 @@ impl Command for SpawnGhostCommand {
 
         // Remove any existing ghosts
         let mut geometry = world.resource_mut::<MapGeometry>();
-        let maybe_existing_ghost = geometry.remove_ghost(self.tile_pos);
+        let maybe_existing_ghost = geometry.remove_ghost_structure(self.tile_pos);
 
         if let Some(existing_ghost) = maybe_existing_ghost {
             world.entity_mut(existing_ghost).despawn_recursive();
@@ -338,7 +338,7 @@ impl Command for SpawnGhostCommand {
             let structure_variety = structure_manifest.get(structure_id);
             let footprint = &structure_variety.footprint;
 
-            map_geometry.add_ghost(self.tile_pos, footprint, ghost_entity);
+            map_geometry.add_ghost_structure(self.tile_pos, footprint, ghost_entity);
         });
     }
 }
@@ -352,7 +352,7 @@ struct DespawnGhostCommand {
 impl Command for DespawnGhostCommand {
     fn write(self, world: &mut World) {
         let mut geometry = world.resource_mut::<MapGeometry>();
-        let maybe_entity = geometry.remove_ghost(self.tile_pos);
+        let maybe_entity = geometry.remove_ghost_structure(self.tile_pos);
 
         // Check that there's something there to despawn
         if maybe_entity.is_none() {

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -313,7 +313,7 @@ impl Command for SpawnStructureGhostCommand {
             .get(&structure_id)
             .unwrap()
             .clone_weak();
-        let ghostly_handle = ghost_handles.get(GhostKind::Ghost);
+        let ghostly_handle = ghost_handles.get_material(GhostKind::Ghost);
         let inherited_material = InheritedMaterial(ghostly_handle.clone_weak());
 
         let world_pos = self.tile_pos.top_of_tile(world.resource::<MapGeometry>());
@@ -419,7 +419,7 @@ impl Command for SpawnStructurePreviewCommand {
 
         let ghost_handles = world.resource::<GhostHandles>();
 
-        let preview_handle = ghost_handles.get(ghost_kind);
+        let preview_handle = ghost_handles.get_material(ghost_kind);
         let inherited_material = InheritedMaterial(preview_handle.clone_weak());
 
         // Spawn a preview

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -46,7 +46,7 @@ struct StructureBundle {
     /// The location of this structure
     tile_pos: TilePos,
     /// Makes structures pickable
-    raycast_mesh: RaycastMesh<Id<Structure>>,
+    raycast_mesh: RaycastMesh<Structure>,
     /// How is this structure being interacted with
     object_interaction: ObjectInteraction,
     /// The mesh used for raycasting

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -3,8 +3,10 @@
 //! Typically, these will produce and transform resources (much like machines in other factory builders),
 //! but they can also be used for defense, research, reproduction, storage and more exotic effects.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashSet};
 use bevy_mod_raycast::RaycastMesh;
+use hexx::{shapes::hexagon, Hex};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     asset_management::{
@@ -12,20 +14,15 @@ use crate::{
         AssetCollectionExt,
     },
     player_interaction::{clipboard::ClipboardData, selection::ObjectInteraction},
-    simulation::{
-        geometry::{Facing, TilePos},
-        SimulationSet,
-    },
+    simulation::geometry::{Facing, TilePos},
 };
 
 use self::{
-    construction::{ghost_lifecycle, ghost_signals, validate_ghosts},
     structure_assets::StructureHandles,
     structure_manifest::{RawStructureManifest, Structure},
 };
 
 pub(crate) mod commands;
-pub mod construction;
 mod structure_assets;
 pub mod structure_manifest;
 
@@ -35,16 +32,7 @@ pub(super) struct StructuresPlugin;
 impl Plugin for StructuresPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(ManifestPlugin::<RawStructureManifest>::new())
-            .add_asset_collection::<StructureHandles>()
-            .add_systems(
-                (
-                    validate_ghosts,
-                    ghost_signals.after(validate_ghosts),
-                    ghost_lifecycle.after(validate_ghosts),
-                )
-                    .in_set(SimulationSet)
-                    .in_schedule(CoreSchedule::FixedUpdate),
-            );
+            .add_asset_collection::<StructureHandles>();
     }
 }
 
@@ -89,5 +77,57 @@ impl StructureBundle {
                 ..Default::default()
             },
         }
+    }
+}
+
+/// The set of tiles taken up by a structure.
+///
+/// Structures are always "centered" on 0, 0, so these coordinates are relative to that.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Footprint {
+    /// The set of tiles is taken up by this structure.
+    pub(crate) set: HashSet<TilePos>,
+}
+
+impl Default for Footprint {
+    fn default() -> Self {
+        Self::single()
+    }
+}
+
+impl Footprint {
+    /// A footprint that occupies a single tile.
+    pub fn single() -> Self {
+        Self {
+            set: HashSet::from_iter(vec![TilePos::ZERO]),
+        }
+    }
+
+    /// A footprint that occupies a set of tiles in a solid hexagon.
+    pub fn hexagon(radius: u32) -> Self {
+        let mut set = HashSet::new();
+        for hex in hexagon(Hex::ZERO, radius) {
+            set.insert(TilePos { hex });
+        }
+
+        Footprint { set }
+    }
+
+    /// Computes the set of tiles that this footprint occupies in world space, when centered at `center`.
+    pub(crate) fn in_world_space(&self, center: TilePos) -> HashSet<TilePos> {
+        self.set
+            .iter()
+            .map(|&offset| center + offset)
+            .collect::<HashSet<_>>()
+    }
+
+    /// Rotates the footprint by the provided [`Facing`].
+    pub(crate) fn rotated(&self, facing: Facing) -> Self {
+        let mut set = HashSet::new();
+        for &tile_pos in self.set.iter() {
+            set.insert(tile_pos.rotated(facing));
+        }
+
+        Footprint { set }
     }
 }

--- a/emergence_lib/src/structures/structure_assets.rs
+++ b/emergence_lib/src/structures/structure_assets.rs
@@ -2,13 +2,11 @@
 
 use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
+    construction::ghosts::GhostKind,
     enum_iter::IterableEnum,
     player_interaction::selection::ObjectInteraction,
     simulation::geometry::{hexagonal_column, MapGeometry},
-    structures::{
-        construction::GhostKind,
-        structure_manifest::{Structure, StructureManifest},
-    },
+    structures::structure_manifest::{Structure, StructureManifest},
 };
 use bevy::{asset::LoadState, prelude::*, utils::HashMap};
 

--- a/emergence_lib/src/structures/structure_assets.rs
+++ b/emergence_lib/src/structures/structure_assets.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
-    construction::ghosts::GhostKind,
     enum_iter::IterableEnum,
     player_interaction::selection::ObjectInteraction,
     simulation::geometry::{hexagonal_column, MapGeometry},
@@ -15,8 +14,6 @@ use bevy::{asset::LoadState, prelude::*, utils::HashMap};
 pub(crate) struct StructureHandles {
     /// The scene for each type of structure
     pub(crate) scenes: HashMap<Id<Structure>, Handle<Scene>>,
-    /// The materials used for tiles when they are selected or otherwise interacted with
-    pub(crate) ghost_materials: HashMap<GhostKind, Handle<StandardMaterial>>,
     /// The raycasting mesh used to select structures
     pub(crate) picking_mesh: Handle<Mesh>,
 }
@@ -45,15 +42,8 @@ impl Loadable for StructureHandles {
             }
         }
 
-        let mut ghost_materials = HashMap::new();
-        for variant in GhostKind::variants() {
-            let material_handle = material_assets.add(variant.material());
-            ghost_materials.insert(variant, material_handle);
-        }
-
         let mut handles = StructureHandles {
             scenes: HashMap::default(),
-            ghost_materials,
             picking_mesh,
         };
 

--- a/emergence_lib/src/structures/structure_manifest.rs
+++ b/emergence_lib/src/structures/structure_manifest.rs
@@ -90,7 +90,7 @@ pub enum ConstructionStrategy {
 }
 
 /// The data contained in a [`ConstructionStrategy::Direct`] variant.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConstructionData {
     /// The amount of work by units required to complete the construction of this building.
     ///

--- a/emergence_lib/src/structures/structure_manifest.rs
+++ b/emergence_lib/src/structures/structure_manifest.rs
@@ -30,6 +30,17 @@ impl StructureManifest {
             ConstructionStrategy::Direct(data) => data,
         }
     }
+
+    /// Fetches the [`Footprint`] for the initial form of a given structure type.
+    pub fn construction_footprint(&self, structure_id: Id<Structure>) -> &Footprint {
+        let strategy = &self.get(structure_id).construction_strategy;
+        match strategy {
+            ConstructionStrategy::Seedling(seedling_id) => {
+                self.construction_footprint(*seedling_id)
+            }
+            ConstructionStrategy::Direct(_data) => &self.get(structure_id).footprint,
+        }
+    }
 }
 
 /// Information about a single [`Id<Structure>`] variety of structure.

--- a/emergence_lib/src/structures/structure_manifest.rs
+++ b/emergence_lib/src/structures/structure_manifest.rs
@@ -5,7 +5,6 @@ use crate::{
     crafting::components::{ActiveRecipe, InputInventory, RawActiveRecipe},
     items::{item_manifest::Item, slot::ItemSlot},
     organisms::{OrganismId, OrganismVariety, RawOrganismVariety},
-    structures::construction::Footprint,
     terrain::terrain_manifest::Terrain,
 };
 use bevy::{
@@ -13,6 +12,8 @@ use bevy::{
     utils::{Duration, HashMap, HashSet},
 };
 use serde::{Deserialize, Serialize};
+
+use super::Footprint;
 
 /// The marker type for [`Id<Structure>`](super::Id).
 #[derive(Reflect, FromReflect, Clone, Copy, PartialEq, Eq)]

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -11,7 +11,7 @@ use bevy::{
 use crate::{
     asset_management::manifest::Id,
     construction::{
-        ghosts::{GhostHandles, GhostKind, GhostTerrainBundle},
+        ghosts::{GhostHandles, GhostKind, GhostTerrainBundle, TerrainPreviewBundle},
         terraform::TerraformingAction,
     },
     graphics::InheritedMaterial,
@@ -232,7 +232,15 @@ impl Command for SpawnTerrainGhostCommand {
                 map_geometry.add_ghost_terrain(ghost_entity, self.tile_pos);
             }
             GhostKind::Preview => {
-                todo!("Spawn preview ghost");
+                // Previews are not indexed, and are instead just spawned and despawned as needed
+                world.spawn(TerrainPreviewBundle::new(
+                    self.tile_pos,
+                    self.terrain_id,
+                    self.terraforming_action,
+                    scene_handle,
+                    inherited_material,
+                    world_pos,
+                ));
             }
             _ => unreachable!("Invalid ghost kind provided."),
         }

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -217,7 +217,6 @@ impl Command for SpawnTerrainGhostCommand {
             GhostKind::Ghost => {
                 let ghost_entity = world
                     .spawn(GhostTerrainBundle::new(
-                        self.terrain_id,
                         self.terraforming_action,
                         self.tile_pos,
                         picking_mesh,
@@ -235,7 +234,6 @@ impl Command for SpawnTerrainGhostCommand {
                 // Previews are not indexed, and are instead just spawned and despawned as needed
                 world.spawn(TerrainPreviewBundle::new(
                     self.tile_pos,
-                    self.terrain_id,
                     self.terraforming_action,
                     scene_handle,
                     inherited_material,

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -207,6 +207,12 @@ impl Command for SpawnTerrainGhostCommand {
             return;
         }
 
+        // Remove any existing ghost terrain
+        if let Some(ghost_entity) = map_geometry.get_ghost_terrain(self.tile_pos) {
+            world.entity_mut(ghost_entity).despawn_recursive();
+        }
+
+        let map_geometry = world.resource::<MapGeometry>();
         let picking_mesh = world.resource::<TerrainHandles>().topper_mesh.clone_weak();
         let scene_handle = world
             .resource::<TerrainHandles>()

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -217,7 +217,6 @@ impl Command for SpawnTerrainGhostCommand {
         }
 
         let map_geometry = world.resource::<MapGeometry>();
-        let picking_mesh = world.resource::<TerrainHandles>().topper_mesh.clone_weak();
         let scene_handle = world
             .resource::<TerrainHandles>()
             .scenes
@@ -245,7 +244,6 @@ impl Command for SpawnTerrainGhostCommand {
                     .spawn(GhostTerrainBundle::new(
                         self.terraforming_action,
                         self.tile_pos,
-                        picking_mesh,
                         scene_handle,
                         inherited_material,
                         world_pos,

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -1,0 +1,261 @@
+//! Methods to use [`Commands`] to manipulate terrain.
+
+use bevy::{
+    ecs::system::Command,
+    prelude::{
+        BuildWorldChildren, Commands, DespawnRecursiveExt, PbrBundle, Transform, Vec3, Visibility,
+        World,
+    },
+};
+
+use crate::{
+    asset_management::manifest::Id,
+    construction::{
+        ghosts::{GhostHandles, GhostKind, GhostTerrainBundle},
+        terraform::TerraformingAction,
+    },
+    graphics::InheritedMaterial,
+    simulation::geometry::{Height, MapGeometry, TilePos},
+    terrain::{terrain_assets::TerrainHandles, terrain_manifest::Terrain},
+};
+
+use super::TerrainBundle;
+
+/// An extension trait for [`Commands`] for working with terrain.
+pub(crate) trait TerrainCommandsExt {
+    /// Spawns a new terrain tile.
+    ///
+    /// Overwrites existing terrain.
+    fn spawn_terrain(&mut self, tile_pos: TilePos, height: Height, terrain_id: Id<Terrain>);
+
+    /// Spawns a ghost that previews the action given by `terraforming_action` at `tile_pos`.
+    ///
+    /// Replaces any existing ghost.
+    fn spawn_ghost_terrain(
+        &mut self,
+        tile_pos: TilePos,
+        terrain_id: Id<Terrain>,
+        terraforming_action: TerraformingAction,
+    );
+
+    /// Despawns any ghost at the provided `tile_pos`.
+    ///
+    /// Has no effect if the tile position is already empty.
+    fn despawn_ghost_terrain(&mut self, tile_pos: TilePos);
+
+    /// Spawns a preview that previews the action given by `terraforming_action` at `tile_pos`.
+    fn spawn_preview_terrain(
+        &mut self,
+        tile_pos: TilePos,
+        terrain_id: Id<Terrain>,
+        terraforming_action: TerraformingAction,
+    );
+}
+
+impl<'w, 's> TerrainCommandsExt for Commands<'w, 's> {
+    fn spawn_terrain(&mut self, tile_pos: TilePos, height: Height, terrain_id: Id<Terrain>) {
+        self.add(SpawnTerrainCommand {
+            tile_pos,
+            height,
+            terrain_id,
+        });
+    }
+
+    fn spawn_ghost_terrain(
+        &mut self,
+        tile_pos: TilePos,
+        terrain_id: Id<Terrain>,
+        terraforming_action: TerraformingAction,
+    ) {
+        self.add(SpawnTerrainGhostCommand {
+            tile_pos,
+            terrain_id,
+            terraforming_action,
+            ghost_kind: GhostKind::Ghost,
+        });
+    }
+
+    fn despawn_ghost_terrain(&mut self, tile_pos: TilePos) {
+        self.add(DespawnGhostCommand { tile_pos });
+    }
+
+    fn spawn_preview_terrain(
+        &mut self,
+        tile_pos: TilePos,
+        terrain_id: Id<Terrain>,
+        terraforming_action: TerraformingAction,
+    ) {
+        self.add(SpawnTerrainGhostCommand {
+            tile_pos,
+            terrain_id,
+            terraforming_action,
+            ghost_kind: GhostKind::Preview,
+        });
+    }
+}
+
+/// Constructs a new [`Terrain`] entity.
+///
+/// The order of the chidlren *must* be:
+/// 0: column
+/// 1: overlay
+/// 2: scene root
+pub(crate) struct SpawnTerrainCommand {
+    /// The position to spawn the tile
+    pub(crate) tile_pos: TilePos,
+    /// The height of the tile
+    pub(crate) height: Height,
+    /// The type of tile
+    pub(crate) terrain_id: Id<Terrain>,
+}
+
+impl Command for SpawnTerrainCommand {
+    fn write(self, world: &mut World) {
+        let handles = world.resource::<TerrainHandles>();
+        let scene_handle = handles.scenes.get(&self.terrain_id).unwrap().clone_weak();
+        let mesh = handles.topper_mesh.clone_weak();
+        let mut map_geometry = world.resource_mut::<MapGeometry>();
+
+        // Store the height, so it can be used below
+        map_geometry.update_height(self.tile_pos, self.height);
+
+        // Drop the borrow so the borrow checker is happy
+        let map_geometry = world.resource::<MapGeometry>();
+
+        // Spawn the terrain entity
+        let terrain_entity = world
+            .spawn(TerrainBundle::new(
+                self.terrain_id,
+                self.tile_pos,
+                scene_handle,
+                mesh,
+                map_geometry,
+            ))
+            .id();
+
+        // Spawn the column as the 0th child of the tile entity
+        // The scene bundle will be added as the first child
+        let handles = world.resource::<TerrainHandles>();
+        let column_bundle = PbrBundle {
+            mesh: handles.column_mesh.clone_weak(),
+            material: handles.column_material.clone_weak(),
+            ..Default::default()
+        };
+
+        let hex_column = world.spawn(column_bundle).id();
+        world.entity_mut(terrain_entity).add_child(hex_column);
+
+        let handles = world.resource::<TerrainHandles>();
+        /// Makes the overlays ever so slightly larger than their base to avoid z-fighting.
+        ///
+        /// This value should be very slightly larger than 1.0
+        const OVERLAY_OVERSIZE_SCALE: f32 = 1.001;
+
+        let overlay_bundle = PbrBundle {
+            mesh: handles.topper_mesh.clone_weak(),
+            visibility: Visibility::Hidden,
+            transform: Transform::from_scale(Vec3 {
+                x: OVERLAY_OVERSIZE_SCALE,
+                y: OVERLAY_OVERSIZE_SCALE,
+                z: OVERLAY_OVERSIZE_SCALE,
+            }),
+            ..Default::default()
+        };
+        let overlay = world.spawn(overlay_bundle).id();
+        world.entity_mut(terrain_entity).add_child(overlay);
+
+        // Update the index of what terrain is where
+        let mut map_geometry = world.resource_mut::<MapGeometry>();
+        map_geometry.add_terrain(self.tile_pos, terrain_entity);
+    }
+}
+
+/// A [`Command`] used to spawn a ghost via [`TerrainCommandsExt`].
+struct SpawnTerrainGhostCommand {
+    /// The tile position at which the ghost should be spawned.
+    tile_pos: TilePos,
+    /// The terrain type that the ghost represents.
+    terrain_id: Id<Terrain>,
+    /// The action that the ghost represents.
+    terraforming_action: TerraformingAction,
+    /// What kind of ghost this is.
+    ghost_kind: GhostKind,
+}
+
+impl Command for SpawnTerrainGhostCommand {
+    fn write(self, world: &mut World) {
+        let map_geometry = world.resource::<MapGeometry>();
+
+        // Check that the tile is within the bounds of the map
+        if !map_geometry.is_valid(self.tile_pos) {
+            return;
+        }
+
+        let picking_mesh = world.resource::<TerrainHandles>().topper_mesh.clone_weak();
+        let scene_handle = world
+            .resource::<TerrainHandles>()
+            .scenes
+            .get(&self.terrain_id)
+            .unwrap()
+            .clone_weak();
+
+        let ghost_handles = world.resource::<GhostHandles>();
+        let ghost_material = ghost_handles.get(self.ghost_kind);
+
+        let inherited_material = InheritedMaterial(ghost_material);
+        let current_height = map_geometry.get_height(self.tile_pos).unwrap();
+        let new_height = match self.terraforming_action {
+            TerraformingAction::Raise => current_height + Height(1),
+            TerraformingAction::Lower => current_height - Height(1),
+            _ => current_height,
+        };
+
+        let mut world_pos = self.tile_pos.into_world_pos(map_geometry);
+        world_pos.y = new_height.into_world_pos();
+
+        match self.ghost_kind {
+            GhostKind::Ghost => {
+                let ghost_entity = world
+                    .spawn(GhostTerrainBundle::new(
+                        self.terrain_id,
+                        self.terraforming_action,
+                        self.tile_pos,
+                        picking_mesh,
+                        scene_handle,
+                        inherited_material,
+                        world_pos,
+                    ))
+                    .id();
+
+                // Update the index to reflect the new state
+                let mut map_geometry = world.resource_mut::<MapGeometry>();
+                map_geometry.add_ghost_terrain(ghost_entity, self.tile_pos);
+            }
+            GhostKind::Preview => {
+                todo!("Spawn preview ghost");
+            }
+            _ => unreachable!("Invalid ghost kind provided."),
+        }
+    }
+}
+
+/// A [`Command`] used to despawn a ghost via [`TerrainCommandsExt`].
+struct DespawnGhostCommand {
+    /// The tile position at which the terrain to be despawned is found.
+    tile_pos: TilePos,
+}
+
+impl Command for DespawnGhostCommand {
+    fn write(self, world: &mut World) {
+        let mut geometry = world.resource_mut::<MapGeometry>();
+        let maybe_entity = geometry.remove_ghost_terrain(self.tile_pos);
+
+        // Check that there's something there to despawn
+        let Some(ghost_entity) = maybe_entity else {
+            return;
+        };
+
+        // Make sure to despawn all children, which represent the meshes stored in the loaded gltf scene.
+        world.entity_mut(ghost_entity).despawn_recursive();
+    }
+}

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -225,7 +225,7 @@ impl Command for SpawnTerrainGhostCommand {
             .clone_weak();
 
         let ghost_handles = world.resource::<GhostHandles>();
-        let ghost_material = ghost_handles.get(self.ghost_kind);
+        let ghost_material = ghost_handles.get_material(self.ghost_kind);
 
         let inherited_material = InheritedMaterial(ghost_material);
         let current_height = map_geometry.get_height(self.tile_pos).unwrap();

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -209,7 +209,11 @@ impl Command for SpawnTerrainGhostCommand {
 
         // Remove any existing ghost terrain
         if let Some(ghost_entity) = map_geometry.get_ghost_terrain(self.tile_pos) {
-            world.entity_mut(ghost_entity).despawn_recursive();
+            if world.entities().contains(ghost_entity) && self.ghost_kind == GhostKind::Ghost {
+                world.entity_mut(ghost_entity).despawn_recursive();
+                let mut map_geometry = world.resource_mut::<MapGeometry>();
+                map_geometry.remove_ghost_terrain(self.tile_pos);
+            }
         }
 
         let map_geometry = world.resource::<MapGeometry>();

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -7,8 +7,8 @@ use bevy_mod_raycast::RaycastMesh;
 use crate::asset_management::manifest::plugin::ManifestPlugin;
 use crate::asset_management::manifest::Id;
 use crate::asset_management::AssetCollectionExt;
+use crate::construction::zoning::Zoning;
 use crate::player_interaction::selection::ObjectInteraction;
-use crate::player_interaction::zoning::Zoning;
 use crate::simulation::geometry::{Height, MapGeometry, TilePos};
 use crate::simulation::SimulationSet;
 

--- a/emergence_lib/src/ui/mod.rs
+++ b/emergence_lib/src/ui/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asset_management::{manifest::Id, AssetCollectionExt},
-    construction::terraform::TerraformingChoice,
+    construction::terraform::TerraformingTool,
     structures::structure_manifest::Structure,
     ui::{
         overlay::OverlayMenuPlugin,
@@ -50,7 +50,7 @@ impl Plugin for UiPlugin {
         })
         .add_asset_collection::<UiElements>()
         .add_asset_collection::<Icons<Id<Structure>>>()
-        .add_asset_collection::<Icons<TerraformingChoice>>()
+        .add_asset_collection::<Icons<TerraformingTool>>()
         .add_startup_system(setup_ui.in_base_set(StartupSet::PreStartup))
         .add_plugin(ScreenDiagnosticsPlugin::default())
         .add_plugin(ScreenFrameDiagnosticsPlugin)

--- a/emergence_lib/src/ui/mod.rs
+++ b/emergence_lib/src/ui/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asset_management::{manifest::Id, AssetCollectionExt},
-    player_interaction::terraform::TerraformingChoice,
+    construction::terraform::TerraformingChoice,
     structures::structure_manifest::Structure,
     ui::{
         overlay::OverlayMenuPlugin,

--- a/emergence_lib/src/ui/overlay.rs
+++ b/emergence_lib/src/ui/overlay.rs
@@ -7,6 +7,7 @@ use crate::{
     player_interaction::PlayerAction,
     signals::{SignalKind, Signals},
     structures::structure_manifest::StructureManifest,
+    terrain::terrain_manifest::TerrainManifest,
     units::unit_manifest::UnitManifest,
 };
 use bevy::prelude::*;
@@ -112,6 +113,7 @@ fn update_signal_type_display(
     tile_overlay: Res<TileOverlay>,
     item_manifest: Res<ItemManifest>,
     structure_manifest: Res<StructureManifest>,
+    terrain_manifest: Res<TerrainManifest>,
     unit_manifest: Res<UnitManifest>,
 ) {
     let mut text = text_query.get_mut(overlay_menu.signal_type_entity).unwrap();
@@ -135,7 +137,12 @@ fn update_signal_type_display(
             let signal_kind: SignalKind = (*signal_type).into();
 
             text.sections = vec![TextSection {
-                value: signal_type.display(&item_manifest, &structure_manifest, &unit_manifest),
+                value: signal_type.display(
+                    &item_manifest,
+                    &structure_manifest,
+                    &terrain_manifest,
+                    &unit_manifest,
+                ),
                 style: TextStyle {
                     font: fonts.regular.clone_weak(),
                     font_size,

--- a/emergence_lib/src/ui/select_terraforming.rs
+++ b/emergence_lib/src/ui/select_terraforming.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     asset_management::AssetState,
+    construction::terraform::TerraformingChoice,
     graphics::palette::ui::{MENU_HIGHLIGHT_COLOR, MENU_NEUTRAL_COLOR},
-    player_interaction::{clipboard::Clipboard, terraform::TerraformingChoice, PlayerAction},
+    player_interaction::{clipboard::Clipboard, PlayerAction},
     terrain::terrain_manifest::TerrainManifest,
 };
 

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -555,6 +555,7 @@ mod structure_details {
     use super::organism_details::OrganismDetails;
     use crate::{
         asset_management::manifest::Id,
+        construction::demolition::MarkedForDemolition,
         crafting::{
             components::{
                 ActiveRecipe, CraftingState, InputInventory, OutputInventory, StorageInventory,
@@ -564,10 +565,7 @@ mod structure_details {
         },
         items::{inventory::Inventory, item_manifest::ItemManifest},
         simulation::geometry::TilePos,
-        structures::{
-            construction::MarkedForDemolition,
-            structure_manifest::{Structure, StructureManifest},
-        },
+        structures::structure_manifest::{Structure, StructureManifest},
         units::unit_manifest::UnitManifest,
     };
 
@@ -701,8 +699,8 @@ mod terrain_details {
 
     use crate::{
         asset_management::manifest::Id,
+        construction::zoning::Zoning,
         items::item_manifest::ItemManifest,
-        player_interaction::zoning::Zoning,
         signals::LocalSignals,
         simulation::geometry::{Height, TilePos},
         structures::structure_manifest::StructureManifest,

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -299,7 +299,7 @@ fn get_details(
     signals: Res<Signals>,
 ) -> Result<(), QueryEntityError> {
     *selection_details = match &*selection_type {
-        CurrentSelection::Ghost(ghost_entity) => {
+        CurrentSelection::GhostStructure(ghost_entity) => {
             let ghost_query_item = ghost_query.get(*ghost_entity)?;
             SelectionDetails::GhostStructure(GhostStructureDetails {
                 entity: *ghost_entity,

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use self::{
-    ghost_details::{GhostDetails, GhostDetailsQuery},
+    ghost_structure_details::{GhostDetailsQuery, GhostStructureDetails},
     organism_details::{OrganismDetails, OrganismDetailsQuery},
     structure_details::{CraftingDetails, StructureDetails, StructureDetailsQuery},
     terrain_details::{TerrainDetails, TerrainDetailsQuery},
@@ -181,7 +181,7 @@ fn update_selection_details(
     let (mut terrain_style, mut terrain_text) = terrain_details_query.single_mut();
 
     match *selection_details {
-        SelectionDetails::Ghost(_) => {
+        SelectionDetails::GhostStructure(_) => {
             *parent_visibility = Visibility::Visible;
             ghost_style.display = Display::Flex;
             structure_style.display = Display::None;
@@ -216,7 +216,7 @@ fn update_selection_details(
     }
 
     match &*selection_details {
-        SelectionDetails::Ghost(details) => {
+        SelectionDetails::GhostStructure(details) => {
             ghost_text.sections[0].value =
                 details.display(&item_manifest, &structure_manifest, &recipe_manifest);
         }
@@ -270,8 +270,8 @@ fn populate_details<T: Component + Default>(
 /// Detailed info about the selected organism.
 #[derive(Debug, Resource, Default)]
 pub(crate) enum SelectionDetails {
-    /// A ghost is selected
-    Ghost(GhostDetails),
+    /// A ghost of a structure is selected
+    GhostStructure(GhostStructureDetails),
     /// A structure is selected
     Structure(StructureDetails),
     /// A tile is selected.
@@ -301,7 +301,7 @@ fn get_details(
     *selection_details = match &*selection_type {
         CurrentSelection::Ghost(ghost_entity) => {
             let ghost_query_item = ghost_query.get(*ghost_entity)?;
-            SelectionDetails::Ghost(GhostDetails {
+            SelectionDetails::GhostStructure(GhostStructureDetails {
                 entity: *ghost_entity,
                 tile_pos: *ghost_query_item.tile_pos,
                 structure_id: *ghost_query_item.structure_id,
@@ -420,8 +420,8 @@ pub(crate) fn clear_details_on_error(
     }
 }
 
-/// Details for ghosts
-mod ghost_details {
+/// Details for ghost structures
+mod ghost_structure_details {
     use bevy::ecs::{prelude::*, query::WorldQuery};
 
     use crate::{
@@ -457,7 +457,7 @@ mod ghost_details {
 
     /// Detailed info about a given ghost.
     #[derive(Debug)]
-    pub(crate) struct GhostDetails {
+    pub(crate) struct GhostStructureDetails {
         /// The root entity
         pub(super) entity: Entity,
         /// The tile position of this structure
@@ -472,7 +472,7 @@ mod ghost_details {
         pub(super) active_recipe: ActiveRecipe,
     }
 
-    impl GhostDetails {
+    impl GhostStructureDetails {
         /// The pretty formatting for this type
         pub(crate) fn display(
             &self,

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -233,8 +233,12 @@ fn update_selection_details(
             );
         }
         SelectionDetails::Unit(details) => {
-            unit_text.sections[0].value =
-                details.display(&unit_manifest, &item_manifest, &structure_manifest);
+            unit_text.sections[0].value = details.display(
+                &unit_manifest,
+                &item_manifest,
+                &structure_manifest,
+                &terrain_manifest,
+            );
         }
         SelectionDetails::None => (),
     };
@@ -751,9 +755,12 @@ mod terrain_details {
             let terrain_type = terrain_manifest.name(self.terrain_id);
             let tile_pos = &self.tile_pos;
             let height = &self.height;
-            let signals = self
-                .signals
-                .display(item_manifest, structure_manifest, unit_manifest);
+            let signals = self.signals.display(
+                item_manifest,
+                structure_manifest,
+                terrain_manifest,
+                unit_manifest,
+            );
             let zoning = self.zoning.display(structure_manifest, terrain_manifest);
 
             format!(
@@ -778,6 +785,7 @@ mod unit_details {
         items::item_manifest::ItemManifest,
         simulation::geometry::TilePos,
         structures::structure_manifest::StructureManifest,
+        terrain::terrain_manifest::TerrainManifest,
         units::{
             actions::CurrentAction,
             goals::Goal,
@@ -839,13 +847,16 @@ mod unit_details {
             unit_manifest: &UnitManifest,
             item_manifest: &ItemManifest,
             structure_manifest: &StructureManifest,
+            terrain_manifest: &TerrainManifest,
         ) -> String {
             let entity = self.entity;
             let unit_name = unit_manifest.name(self.unit_id);
             let diet = self.diet.display(item_manifest);
             let tile_pos = &self.tile_pos;
             let held_item = self.held_item.display(item_manifest);
-            let goal = self.goal.display(item_manifest, structure_manifest);
+            let goal = self
+                .goal
+                .display(item_manifest, structure_manifest, terrain_manifest);
             let action = &self.action.display(item_manifest);
             let impatience_pool = &self.impatience_pool;
             let organism_details = self

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -20,10 +20,11 @@ use crate::{
 
 use self::{
     ghost_structure_details::{GhostStructureDetails, GhostStructureDetailsQuery},
-    ghost_terrain_details::{GhostTerrainDetails, GhostTerrainDetailsQuery},
     organism_details::{OrganismDetails, OrganismDetailsQuery},
     structure_details::{CraftingDetails, StructureDetails, StructureDetailsQuery},
-    terrain_details::{TerrainDetails, TerrainDetailsQuery},
+    terrain_details::{
+        GhostTerrainDetailsQuery, TerraformingDetails, TerrainDetails, TerrainDetailsQuery,
+    },
     unit_details::{UnitDetails, UnitDetailsQuery},
 };
 
@@ -55,10 +56,6 @@ struct SelectionPanel;
 /// The UI node that stores all ghost structure details.
 #[derive(Component, Default)]
 struct GhostStructureDetailsMarker;
-
-/// The UI node that stores all ghost terrain details.
-#[derive(Component, Default)]
-struct GhostTerrainDetailsMarker;
 
 /// The UI node that stores all structure details.
 #[derive(Component, Default)]
@@ -105,8 +102,6 @@ fn populate_selection_panel(
 
     let ghost_structure_details =
         populate_details::<GhostStructureDetailsMarker>(&mut commands, &key_text_style);
-    let ghost_terrain_details =
-        populate_details::<GhostTerrainDetailsMarker>(&mut commands, &key_text_style);
     let structure_details =
         populate_details::<StructureDetailsMarker>(&mut commands, &key_text_style);
     let terrain_details = populate_details::<TerrainDetailsMarker>(&mut commands, &key_text_style);
@@ -116,7 +111,6 @@ fn populate_selection_panel(
     commands
         .entity(selection)
         .add_child(ghost_structure_details)
-        .add_child(ghost_terrain_details)
         .add_child(structure_details)
         .add_child(terrain_details)
         .add_child(unit_details);
@@ -145,17 +139,6 @@ fn update_selection_details(
         (&mut Style, &mut Text),
         (
             With<GhostStructureDetailsMarker>,
-            Without<GhostTerrainDetailsMarker>,
-            Without<StructureDetailsMarker>,
-            Without<TerrainDetailsMarker>,
-            Without<UnitDetailsMarker>,
-        ),
-    >,
-    mut ghost_terrain_details_query: Query<
-        (&mut Style, &mut Text),
-        (
-            With<GhostTerrainDetailsMarker>,
-            Without<GhostStructureDetailsMarker>,
             Without<StructureDetailsMarker>,
             Without<TerrainDetailsMarker>,
             Without<UnitDetailsMarker>,
@@ -166,7 +149,6 @@ fn update_selection_details(
         (
             With<StructureDetailsMarker>,
             Without<GhostStructureDetailsMarker>,
-            Without<GhostTerrainDetailsMarker>,
             Without<TerrainDetailsMarker>,
             Without<UnitDetailsMarker>,
         ),
@@ -176,7 +158,6 @@ fn update_selection_details(
         (
             With<UnitDetailsMarker>,
             Without<GhostStructureDetailsMarker>,
-            Without<GhostTerrainDetailsMarker>,
             Without<StructureDetailsMarker>,
             Without<TerrainDetailsMarker>,
         ),
@@ -186,7 +167,6 @@ fn update_selection_details(
         (
             With<TerrainDetailsMarker>,
             Without<GhostStructureDetailsMarker>,
-            Without<GhostTerrainDetailsMarker>,
             Without<StructureDetailsMarker>,
             Without<UnitDetailsMarker>,
         ),
@@ -200,8 +180,6 @@ fn update_selection_details(
     let mut parent_visibility = selection_panel_query.single_mut();
     let (mut ghost_structure_style, mut ghost_structure_text) =
         ghost_structures_details_query.single_mut();
-    let (mut ghost_terrain_style, mut ghost_terrain_text) =
-        ghost_terrain_details_query.single_mut();
     let (mut structure_style, mut structure_text) = structure_details_query.single_mut();
     let (mut unit_style, mut unit_text) = unit_details_query.single_mut();
     let (mut terrain_style, mut terrain_text) = terrain_details_query.single_mut();
@@ -210,15 +188,6 @@ fn update_selection_details(
         SelectionDetails::GhostStructure(_) => {
             *parent_visibility = Visibility::Visible;
             ghost_structure_style.display = Display::Flex;
-            ghost_terrain_style.display = Display::None;
-            structure_style.display = Display::None;
-            terrain_style.display = Display::None;
-            unit_style.display = Display::None;
-        }
-        SelectionDetails::GhostTerrain(_) => {
-            *parent_visibility = Visibility::Visible;
-            ghost_terrain_style.display = Display::Flex;
-            ghost_structure_style.display = Display::None;
             structure_style.display = Display::None;
             terrain_style.display = Display::None;
             unit_style.display = Display::None;
@@ -226,7 +195,6 @@ fn update_selection_details(
         SelectionDetails::Structure(_) => {
             *parent_visibility = Visibility::Visible;
             ghost_structure_style.display = Display::None;
-            ghost_terrain_style.display = Display::None;
             structure_style.display = Display::Flex;
             terrain_style.display = Display::None;
             unit_style.display = Display::None;
@@ -234,7 +202,6 @@ fn update_selection_details(
         SelectionDetails::Terrain(_) => {
             *parent_visibility = Visibility::Visible;
             ghost_structure_style.display = Display::None;
-            ghost_terrain_style.display = Display::None;
             structure_style.display = Display::None;
             terrain_style.display = Display::Flex;
             unit_style.display = Display::None;
@@ -242,7 +209,6 @@ fn update_selection_details(
         SelectionDetails::Unit(_) => {
             *parent_visibility = Visibility::Visible;
             ghost_structure_style.display = Display::None;
-            ghost_terrain_style.display = Display::None;
             structure_style.display = Display::None;
             terrain_style.display = Display::None;
             unit_style.display = Display::Flex;
@@ -257,10 +223,6 @@ fn update_selection_details(
         SelectionDetails::GhostStructure(details) => {
             ghost_structure_text.sections[0].value =
                 details.display(&item_manifest, &structure_manifest, &recipe_manifest);
-        }
-        SelectionDetails::GhostTerrain(details) => {
-            ghost_terrain_text.sections[0].value =
-                details.display(&item_manifest, &terrain_manifest);
         }
         SelectionDetails::Structure(details) => {
             structure_text.sections[0].value =
@@ -314,8 +276,6 @@ fn populate_details<T: Component + Default>(
 pub(crate) enum SelectionDetails {
     /// A ghost of a structure is selected
     GhostStructure(GhostStructureDetails),
-    /// A ghost of a terraforming action is selected
-    GhostTerrain(GhostTerrainDetails),
     /// A structure is selected
     Structure(StructureDetails),
     /// A tile is selected.
@@ -353,16 +313,6 @@ fn get_details(
                 input_inventory: ghost_query_item.input_inventory.clone(),
                 crafting_state: ghost_query_item.crafting_state.clone(),
                 active_recipe: ghost_query_item.active_recipe.clone(),
-            })
-        }
-        CurrentSelection::GhostTerrain(ghost_terrain_entity) => {
-            let ghost_query_item = ghost_terrain_query.get(*ghost_terrain_entity)?;
-            SelectionDetails::GhostTerrain(GhostTerrainDetails {
-                entity: *ghost_terrain_entity,
-                tile_pos: *ghost_query_item.tile_pos,
-                terraforming_action: *ghost_query_item.terraforming_action,
-                input_inventory: ghost_query_item.input_inventory.clone(),
-                crafting_state: ghost_query_item.crafting_state.clone(),
             })
         }
         CurrentSelection::Structure(structure_entity) => {
@@ -418,6 +368,19 @@ fn get_details(
                 let terrain_entity = map_geometry.get_terrain(*tile_pos).unwrap();
                 let terrain_query_item = terrain_query.get(terrain_entity)?;
 
+                let maybe_terraforming_details = if let Some(ghost_terrain_entity) =
+                    map_geometry.get_ghost_terrain(*tile_pos)
+                {
+                    let ghost_terrain_query_item = ghost_terrain_query.get(ghost_terrain_entity)?;
+                    Some(TerraformingDetails {
+                        terraforming_action: ghost_terrain_query_item.terraforming_action.clone(),
+                        input_inventory: ghost_terrain_query_item.input_inventory.clone(),
+                        crafting_state: ghost_terrain_query_item.crafting_state.clone(),
+                    })
+                } else {
+                    None
+                };
+
                 SelectionDetails::Terrain(TerrainDetails {
                     entity: terrain_entity,
                     terrain_id: *terrain_query_item.terrain_id,
@@ -425,6 +388,7 @@ fn get_details(
                     height: *terrain_query_item.height,
                     signals: signals.all_signals_at_position(*tile_pos),
                     zoning: terrain_query_item.zoning.clone(),
+                    maybe_terraforming_details,
                 })
             } else {
                 SelectionDetails::None
@@ -547,72 +511,6 @@ mod ghost_structure_details {
 Tile: {tile_pos}
 Ghost structure type: {structure_id}
 Recipe: {recipe}
-Construction materials: {construction_materials}
-{crafting_state}"
-            )
-        }
-    }
-}
-
-/// Details for ghost terrain
-mod ghost_terrain_details {
-    use bevy::ecs::{prelude::*, query::WorldQuery};
-
-    use crate::{
-        construction::terraform::TerraformingAction,
-        crafting::components::{CraftingState, InputInventory},
-        items::item_manifest::ItemManifest,
-        simulation::geometry::TilePos,
-        terrain::terrain_manifest::TerrainManifest,
-    };
-
-    /// Data needed to populate [`GhostStructureDetails`].
-    #[derive(WorldQuery)]
-    pub(super) struct GhostTerrainDetailsQuery {
-        /// The root entity
-        pub(super) entity: Entity,
-        /// The terraforming action being performed
-        pub(super) terraforming_action: &'static TerraformingAction,
-        /// The tile position of this ghost
-        pub(crate) tile_pos: &'static TilePos,
-        /// The inputs that must be added to construct this ghost
-        pub(super) input_inventory: &'static InputInventory,
-        /// The ghost's progress through construction
-        pub(crate) crafting_state: &'static CraftingState,
-    }
-
-    /// Detailed info about a given ghost.
-    #[derive(Debug)]
-    pub(crate) struct GhostTerrainDetails {
-        /// The root entity
-        pub(super) entity: Entity,
-        /// The terraforming action being performed
-        pub(super) terraforming_action: TerraformingAction,
-        /// The tile position of this ghost
-        pub(crate) tile_pos: TilePos,
-        /// The inputs that must be added to construct this ghost
-        pub(super) input_inventory: InputInventory,
-        /// The ghost's progress through construction
-        pub(crate) crafting_state: CraftingState,
-    }
-
-    impl GhostTerrainDetails {
-        /// The pretty formatting for this type
-        pub(crate) fn display(
-            &self,
-            item_manifest: &ItemManifest,
-            terrain_manifest: &TerrainManifest,
-        ) -> String {
-            let entity = self.entity;
-            let terraforming_action = self.terraforming_action.display(terrain_manifest);
-            let tile_pos = &self.tile_pos;
-            let crafting_state = &self.crafting_state;
-            let construction_materials = self.input_inventory.display(item_manifest);
-
-            format!(
-                "Entity: {entity:?}
-Tile: {tile_pos}
-Terraforming: {terraforming_action}
 Construction materials: {construction_materials}
 {crafting_state}"
             )
@@ -824,7 +722,8 @@ mod terrain_details {
 
     use crate::{
         asset_management::manifest::Id,
-        construction::zoning::Zoning,
+        construction::{terraform::TerraformingAction, zoning::Zoning},
+        crafting::components::{CraftingState, InputInventory},
         items::item_manifest::ItemManifest,
         signals::LocalSignals,
         simulation::geometry::{Height, TilePos},
@@ -846,6 +745,47 @@ mod terrain_details {
         pub(super) zoning: &'static Zoning,
     }
 
+    /// Data needed to populate [`TerraformingDetails`].
+    #[derive(WorldQuery)]
+    pub(super) struct GhostTerrainDetailsQuery {
+        /// The terraforming action being performed
+        pub(super) terraforming_action: &'static TerraformingAction,
+        /// The inputs that must be added to construct this ghost
+        pub(super) input_inventory: &'static InputInventory,
+        /// The ghost's progress through construction
+        pub(crate) crafting_state: &'static CraftingState,
+    }
+
+    /// Detailed info about a given terraforming ghost.
+    #[derive(Debug)]
+    pub(crate) struct TerraformingDetails {
+        /// The terraforming action being performed
+        pub(super) terraforming_action: TerraformingAction,
+        /// The inputs that must be added to construct this ghost
+        pub(super) input_inventory: InputInventory,
+        /// The ghost's progress through construction
+        pub(crate) crafting_state: CraftingState,
+    }
+
+    impl TerraformingDetails {
+        /// The pretty formatting for this type
+        pub(crate) fn display(
+            &self,
+            item_manifest: &ItemManifest,
+            terrain_manifest: &TerrainManifest,
+        ) -> String {
+            let terraforming_action = self.terraforming_action.display(terrain_manifest);
+            let crafting_state = &self.crafting_state;
+            let construction_materials = self.input_inventory.display(item_manifest);
+
+            format!(
+                "Terraforming: {terraforming_action}
+Construction materials: {construction_materials}
+{crafting_state}"
+            )
+        }
+    }
+
     /// Detailed info about a given piece of terrain.
     #[derive(Debug)]
     pub(crate) struct TerrainDetails {
@@ -861,6 +801,8 @@ mod terrain_details {
         pub(super) signals: LocalSignals,
         /// The zoning of this tile
         pub(super) zoning: Zoning,
+        /// The details about the terraforming process, if any
+        pub(super) maybe_terraforming_details: Option<TerraformingDetails>,
     }
 
     impl TerrainDetails {
@@ -884,15 +826,21 @@ mod terrain_details {
             );
             let zoning = self.zoning.display(structure_manifest, terrain_manifest);
 
-            format!(
+            let base_string = format!(
                 "Entity: {entity:?}
 Terrain type: {terrain_type}
 Tile: {tile_pos}
 Height: {height}
-Zoning: {zoning}
-Signals:
-{signals}"
-            )
+Zoning: {zoning}"
+            );
+
+            if let Some(terraforming_details) = &self.maybe_terraforming_details {
+                let terraforming_details =
+                    terraforming_details.display(item_manifest, terrain_manifest);
+                format!("{base_string}\n\n{terraforming_details}\n\nSignals:\n{signals}")
+            } else {
+                format!("{base_string}\n\nSignals:\n{signals}")
+            }
         }
     }
 }

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -287,7 +287,7 @@ pub(crate) enum SelectionDetails {
 fn get_details(
     selection_type: Res<CurrentSelection>,
     mut selection_details: ResMut<SelectionDetails>,
-    ghost_query: Query<GhostDetailsQuery>,
+    ghost_structure_query: Query<GhostDetailsQuery>,
     organism_query: Query<OrganismDetailsQuery>,
     structure_query: Query<StructureDetailsQuery>,
     terrain_query: Query<TerrainDetailsQuery>,
@@ -299,10 +299,21 @@ fn get_details(
     signals: Res<Signals>,
 ) -> Result<(), QueryEntityError> {
     *selection_details = match &*selection_type {
-        CurrentSelection::GhostStructure(ghost_entity) => {
-            let ghost_query_item = ghost_query.get(*ghost_entity)?;
+        CurrentSelection::GhostStructure(ghost_structure_entity) => {
+            let ghost_query_item = ghost_structure_query.get(*ghost_structure_entity)?;
             SelectionDetails::GhostStructure(GhostStructureDetails {
-                entity: *ghost_entity,
+                entity: *ghost_structure_entity,
+                tile_pos: *ghost_query_item.tile_pos,
+                structure_id: *ghost_query_item.structure_id,
+                input_inventory: ghost_query_item.input_inventory.clone(),
+                crafting_state: ghost_query_item.crafting_state.clone(),
+                active_recipe: ghost_query_item.active_recipe.clone(),
+            })
+        }
+        CurrentSelection::GhostTerrain(ghost_terrain_entity) => {
+            let ghost_query_item = ghost_terrain_query.get(*ghost_terrain_entity)?;
+            SelectionDetails::GhostTerrain(GhostTerrainDetails {
+                entity: *ghost_structure_entity,
                 tile_pos: *ghost_query_item.tile_pos,
                 structure_id: *ghost_query_item.structure_id,
                 input_inventory: ghost_query_item.input_inventory.clone(),

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -373,7 +373,7 @@ fn get_details(
                 {
                     let ghost_terrain_query_item = ghost_terrain_query.get(ghost_terrain_entity)?;
                     Some(TerraformingDetails {
-                        terraforming_action: ghost_terrain_query_item.terraforming_action.clone(),
+                        terraforming_action: *ghost_terrain_query_item.terraforming_action,
                         input_inventory: ghost_terrain_query_item.input_inventory.clone(),
                         crafting_state: ghost_terrain_query_item.crafting_state.clone(),
                     })

--- a/emergence_lib/src/ui/status.rs
+++ b/emergence_lib/src/ui/status.rs
@@ -7,7 +7,8 @@ use leafwing_input_manager::prelude::ActionState;
 use crate::{
     asset_management::AssetState, crafting::components::CraftingState,
     items::item_manifest::ItemManifest, player_interaction::PlayerAction,
-    structures::structure_manifest::StructureManifest, units::goals::Goal,
+    structures::structure_manifest::StructureManifest, terrain::terrain_manifest::TerrainManifest,
+    units::goals::Goal,
 };
 
 use super::FiraSansFontFamily;
@@ -93,6 +94,7 @@ fn display_status(
     fonts: Res<FiraSansFontFamily>,
     item_manifest: Res<ItemManifest>,
     structure_manifest: Res<StructureManifest>,
+    terrain_manifest: Res<TerrainManifest>,
     mut commands: Commands,
 ) {
     // PERF: immediate mode for now
@@ -147,7 +149,7 @@ fn display_status(
                 .spawn(BillboardTextBundle {
                     transform,
                     text: Text::from_section(
-                        goal.display(&item_manifest, &structure_manifest),
+                        goal.display(&item_manifest, &structure_manifest, &terrain_manifest),
                         TextStyle {
                             font_size: 60.0,
                             font: fonts.regular.clone_weak(),

--- a/emergence_lib/src/ui/ui_assets.rs
+++ b/emergence_lib/src/ui/ui_assets.rs
@@ -6,7 +6,7 @@ use core::hash::Hash;
 
 use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
-    player_interaction::terraform::TerraformingChoice,
+    construction::terraform::TerraformingChoice,
     structures::structure_manifest::{Structure, StructureManifest},
     terrain::terrain_manifest::TerrainManifest,
 };

--- a/emergence_lib/src/ui/ui_assets.rs
+++ b/emergence_lib/src/ui/ui_assets.rs
@@ -6,7 +6,7 @@ use core::hash::Hash;
 
 use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
-    construction::terraform::TerraformingChoice,
+    construction::terraform::TerraformingTool,
     structures::structure_manifest::{Structure, StructureManifest},
     terrain::terrain_manifest::TerrainManifest,
 };
@@ -66,7 +66,7 @@ impl FromWorld for Icons<Id<Structure>> {
     }
 }
 
-impl FromWorld for Icons<TerraformingChoice> {
+impl FromWorld for Icons<TerraformingTool> {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
         let mut map = HashMap::new();
@@ -78,17 +78,17 @@ impl FromWorld for Icons<TerraformingChoice> {
             let terrain_path = format!("icons/terrain/{id}.png");
             let icon = asset_server.load(terrain_path);
 
-            let choice = TerraformingChoice::Change(terrain_id);
+            let choice = TerraformingTool::Change(terrain_id);
             map.insert(choice, icon);
         }
 
         map.insert(
-            TerraformingChoice::Lower,
+            TerraformingTool::Lower,
             asset_server.load("icons/terraforming/lower.png"),
         );
 
         map.insert(
-            TerraformingChoice::Raise,
+            TerraformingTool::Raise,
             asset_server.load("icons/terraforming/raise.png"),
         );
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -12,6 +12,7 @@ use crate::{
     construction::{
         demolition::{DemolitionQuery, MarkedForDemolition},
         ghosts::WorkplaceId,
+        terraform::TerraformingAction,
     },
     crafting::{
         components::{
@@ -1124,7 +1125,7 @@ pub(crate) struct WorkplaceQuery<'w, 's> {
         's,
         (
             &'static CraftingState,
-            AnyOf<(&'static Id<Structure>, &'static Id<Terrain>)>,
+            AnyOf<(&'static Id<Structure>, &'static TerraformingAction)>,
             &'static WorkersPresent,
         ),
     >,

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -254,8 +254,6 @@ pub(super) fn finish_actions(
                     let (.., mut workers_present) = workplace;
                     // FIXME: this isn't robust to units dying
                     workers_present.remove_worker();
-                } else {
-                    warn!("Unit was working at an entity that is not a workplace!");
                 }
             }
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -1147,9 +1147,7 @@ impl<'w, 's> WorkplaceQuery<'w, 's> {
 
         let (found_crafting_state, ids, workers_present) = self.query.get(entity).ok()?;
 
-        let found_id = WorkplaceId::new(ids);
-
-        if found_id != workplace_id {
+        if workplace_id != WorkplaceId::new(ids) {
             return None;
         }
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -9,6 +9,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom, thread_rng};
 
 use crate::{
     asset_management::manifest::Id,
+    construction::demolition::{DemolitionQuery, MarkedForDemolition},
     crafting::{
         components::{
             AddToInputError, CraftingState, InputInventory, OutputInventory, StorageInventory,
@@ -20,11 +21,7 @@ use crate::{
     organisms::{energy::EnergyPool, lifecycle::Lifecycle},
     signals::{SignalType, Signals},
     simulation::geometry::{Facing, MapGeometry, RotationDirection, TilePos},
-    structures::{
-        commands::StructureCommandsExt,
-        construction::{DemolitionQuery, MarkedForDemolition},
-        structure_manifest::Structure,
-    },
+    structures::{commands::StructureCommandsExt, structure_manifest::Structure},
     terrain::terrain_manifest::{Terrain, TerrainManifest},
 };
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -681,7 +681,7 @@ impl CurrentAction {
 
         for tile_pos in neighboring_tiles {
             // Ghosts
-            if let Some(ghost_entity) = map_geometry.get_ghost(tile_pos) {
+            if let Some(ghost_entity) = map_geometry.get_ghost_structure(tile_pos) {
                 if let Ok((maybe_input_inventory, ..)) = input_inventory_query.get(ghost_entity) {
                     if let Some(input_inventory) = maybe_input_inventory {
                         if input_inventory.currently_accepts(item_kind, item_manifest) {
@@ -758,7 +758,7 @@ impl CurrentAction {
 
         for tile_pos in neighboring_tiles {
             // Ghosts
-            if let Some(ghost_entity) = map_geometry.get_ghost(tile_pos) {
+            if let Some(ghost_entity) = map_geometry.get_ghost_structure(tile_pos) {
                 if let Ok((maybe_input_inventory, ..)) = input_inventory_query.get(ghost_entity) {
                     if let Some(input_inventory) = maybe_input_inventory {
                         if input_inventory.currently_accepts(item_kind, item_manifest) {
@@ -1142,7 +1142,7 @@ impl<'w, 's> WorkplaceQuery<'w, 's> {
         map_geometry: &MapGeometry,
     ) -> Option<Entity> {
         // Prioritize ghosts over structures to allow for replacing structures by building
-        let entity = if let Some(ghost_entity) = map_geometry.get_ghost(structure_pos) {
+        let entity = if let Some(ghost_entity) = map_geometry.get_ghost_structure(structure_pos) {
             ghost_entity
         } else {
             map_geometry.get_structure(structure_pos)?

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -1137,16 +1137,13 @@ impl<'w, 's> WorkplaceQuery<'w, 's> {
     /// If so, returns `Some(matching_structure_entity_that_needs_work)`.
     pub(crate) fn needs_work(
         &self,
-        structure_pos: TilePos,
+        tile_pos: TilePos,
         workplace_id: WorkplaceId,
         map_geometry: &MapGeometry,
     ) -> Option<Entity> {
         // Prioritize ghosts over structures to allow for replacing structures by building
-        let entity = if let Some(ghost_entity) = map_geometry.get_ghost_structure(structure_pos) {
-            ghost_entity
-        } else {
-            map_geometry.get_structure(structure_pos)?
-        };
+        // Prioritize terrain ghosts over structure ghosts to encourage terraforming to complete before structures are built on top
+        let entity = map_geometry.get_ghost_or_structure(tile_pos)?;
 
         let (found_crafting_state, ids, workers_present) = self.query.get(entity).ok()?;
 

--- a/emergence_lib/src/units/goals.rs
+++ b/emergence_lib/src/units/goals.rs
@@ -7,11 +7,13 @@ use rand::rngs::ThreadRng;
 use rand::thread_rng;
 
 use crate::asset_management::manifest::Id;
+use crate::construction::ghosts::WorkplaceId;
 use crate::crafting::item_tags::ItemKind;
 use crate::items::item_manifest::ItemManifest;
 use crate::signals::{SignalType, Signals};
 use crate::simulation::geometry::TilePos;
 use crate::structures::structure_manifest::{Structure, StructureManifest};
+use crate::terrain::terrain_manifest::TerrainManifest;
 
 use super::impatience::ImpatiencePool;
 use super::item_interaction::UnitInventory;
@@ -42,7 +44,7 @@ pub(crate) enum Goal {
     /// Attempting to drop off an object to a structure that actively needs it.
     Deliver(ItemKind),
     /// Attempting to perform work at a structure
-    Work(Id<Structure>),
+    Work(WorkplaceId),
     /// Attempt to feed self
     Eat(ItemKind),
     /// Attempting to destroy a structure
@@ -82,6 +84,7 @@ impl Goal {
         &self,
         item_manifest: &ItemManifest,
         structure_manifest: &StructureManifest,
+        terrain_manifest: &TerrainManifest,
     ) -> String {
         match self {
             Goal::Wander { remaining_actions } => format!(
@@ -93,7 +96,10 @@ impl Goal {
             Goal::Deliver(item_kind) => {
                 format!("Deliver {}", item_manifest.name_of_kind(*item_kind))
             }
-            Goal::Work(structure) => format!("Work at {}", structure_manifest.name(*structure)),
+            Goal::Work(workplace) => format!(
+                "Work at {}",
+                workplace.name(structure_manifest, terrain_manifest)
+            ),
             Goal::Demolish(structure) => {
                 format!("Demolish {}", structure_manifest.name(*structure))
             }

--- a/emergence_lib/src/units/mod.rs
+++ b/emergence_lib/src/units/mod.rs
@@ -88,7 +88,7 @@ pub(crate) struct UnitBundle {
     /// Organism data
     organism_bundle: OrganismBundle,
     /// Makes units pickable
-    raycast_mesh: RaycastMesh<Id<Unit>>,
+    raycast_mesh: RaycastMesh<Unit>,
     /// The mesh used for raycasting
     mesh: Handle<Mesh>,
     /// The child scene that contains the gltF model used

--- a/emergence_lib/tests/serde_manifests.rs
+++ b/emergence_lib/tests/serde_manifests.rs
@@ -13,10 +13,10 @@ use emergence_lib::{
     },
     simulation::light::Illuminance,
     structures::{
-        construction::Footprint,
         structure_manifest::{
             RawConstructionStrategy, RawStructureData, RawStructureKind, RawStructureManifest,
         },
+        Footprint,
     },
     terrain::terrain_manifest::{RawTerrainManifest, TerrainData},
     units::{

--- a/emergence_lib/tests/serde_manifests.rs
+++ b/emergence_lib/tests/serde_manifests.rs
@@ -1,5 +1,6 @@
 use bevy::utils::{HashMap, HashSet};
 use emergence_lib::{
+    construction::RawConstructionStrategy,
     crafting::components::RawActiveRecipe,
     crafting::{
         item_tags::ItemTag,
@@ -13,9 +14,7 @@ use emergence_lib::{
     },
     simulation::light::Illuminance,
     structures::{
-        structure_manifest::{
-            RawConstructionStrategy, RawStructureData, RawStructureKind, RawStructureManifest,
-        },
+        structure_manifest::{RawStructureData, RawStructureKind, RawStructureManifest},
         Footprint,
     },
     terrain::terrain_manifest::{RawTerrainManifest, TerrainData},


### PR DESCRIPTION
- Fixes #558 
- Fixes #563
- Fixes #564

To do:
- [x] add commands for spawning and despawning terrain ghosts
- [x] add visual indicators for terrain ghosts
- [x] ensure terrain ghosts actually produce signals
- [x] allow selection of terrain ghosts: cycling appears to be broken, and cannot select any kind of ghosts. Done by displaying terraforming info on terrain!
- [x] ensure ghosts despawn when terraforming completes
- [x] add previews for terraforming
- [x] don't spawn multiple ghost terrain entities in the same spot

Follow-up:
- add soil items created / used for terraforming (#673)
- make the visual indicators less jank: the floating topper is cute, but not good enough (#674)
- make sure visual indicators work for "lower" ghosts (#674)
- fix interactions between structures and terraforming (#675)
