### PR TITLE
Store dropped items on the ground

### DIFF
--- a/emergence_game/assets/manifests/base_game.item_manifest.json
+++ b/emergence_game/assets/manifests/base_game.item_manifest.json
@@ -18,7 +18,7 @@
       "compostable": true
     },
     "soil": {
-      "stack_size": 10,
+      "stack_size": 3,
       "compostable": false
     }
   }

--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -35,6 +35,9 @@ pub enum TerraformingAction {
 }
 
 impl TerraformingAction {
+    /// The number of items needed to perform each action.
+    const N_ITEMS: u32 = 3;
+
     /// The items needed to perform this action.
     pub(crate) fn input_inventory(&self) -> InputInventory {
         // TODO: vary these inventories based on the terrain type
@@ -42,11 +45,11 @@ impl TerraformingAction {
 
         match self {
             Self::Raise => InputInventory::Exact {
-                inventory: Inventory::new_from_item(soil_id, 10),
+                inventory: Inventory::new_from_item(soil_id, Self::N_ITEMS),
             },
             Self::Lower => InputInventory::default(),
             Self::Change(_terrain) => InputInventory::Exact {
-                inventory: Inventory::new_from_item(soil_id, 10),
+                inventory: Inventory::new_from_item(soil_id, Self::N_ITEMS),
             },
         }
     }
@@ -59,10 +62,10 @@ impl TerraformingAction {
         match self {
             Self::Raise => OutputInventory::default(),
             Self::Lower => OutputInventory {
-                inventory: Inventory::full_from_item(soil_id, 10),
+                inventory: Inventory::full_from_item(soil_id, Self::N_ITEMS),
             },
             Self::Change(_terrain) => OutputInventory {
-                inventory: Inventory::full_from_item(soil_id, 10),
+                inventory: Inventory::full_from_item(soil_id, Self::N_ITEMS),
             },
         }
     }

--- a/emergence_lib/src/crafting/components.rs
+++ b/emergence_lib/src/crafting/components.rs
@@ -372,7 +372,9 @@ impl StorageInventory {
                 ItemKind::Tag(_) => false,
             },
             None => match item_kind {
-                ItemKind::Single(item_id) => self.remaining_reserved_space_for_item(item_id) > 0,
+                ItemKind::Single(item_id) => {
+                    self.remaining_space_for_item(item_id, item_manifest) > 0
+                }
                 ItemKind::Tag(tag) => {
                     !self.is_full() && item_kind.is_compatible_with(tag, item_manifest)
                 }

--- a/emergence_lib/src/crafting/mod.rs
+++ b/emergence_lib/src/crafting/mod.rs
@@ -272,7 +272,7 @@ pub(crate) fn set_crafting_emitter(
 
 /// Causes storage structures to emit signals based on the items they have and accept.
 pub(crate) fn set_storage_emitter(
-    mut crafting_query: Query<(&mut Emitter, &StorageInventory)>,
+    mut crafting_query: Query<(&mut Emitter, &StorageInventory), With<Id<Structure>>>,
     item_manifest: Res<ItemManifest>,
 ) {
     for (mut emitter, storage_inventory) in crafting_query.iter_mut() {

--- a/emergence_lib/src/graphics/palette.rs
+++ b/emergence_lib/src/graphics/palette.rs
@@ -146,8 +146,14 @@ pub(crate) mod infovis {
                     lightness: 0.9,
                     alpha: 1.0,
                 },
-                Goal::Pickup(_) => Color::Hsla {
+                Goal::Fetch(_) => Color::Hsla {
                     hue: SignalKind::Pull.hue(),
+                    saturation: 0.7,
+                    lightness: 0.7,
+                    alpha: 1.0,
+                },
+                Goal::Remove(_) => Color::Hsla {
+                    hue: SignalKind::Push.hue(),
                     saturation: 0.7,
                     lightness: 0.7,
                     alpha: 1.0,

--- a/emergence_lib/src/player_interaction/selection.rs
+++ b/emergence_lib/src/player_interaction/selection.rs
@@ -374,12 +374,8 @@ impl CurrentSelection {
         let start = SelectionVariant::from(&*self);
         let cycle = start.cycle();
 
-        info!("Starting with {:?}", start);
-
         for variant in cycle {
-            info!("Trying {:?}", variant);
             if let Some(selection) = self.get(variant, selection_state, cursor_pos, map_geometry) {
-                info!("Found {:?}", selection);
                 *self = selection;
                 return;
             }
@@ -650,7 +646,6 @@ fn set_selection(
                 && !selection_state.multiple
                 && actions.just_pressed(PlayerAction::Select)
             {
-                info!("Cycling selection");
                 current_selection.cycle_selection(cursor_pos, &selection_state, map_geometry)
             } else if !same_tile_as_last_time {
                 current_selection.update_from_cursor_pos(

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -364,7 +364,7 @@ impl SignalType {
     ///
     /// If `delivery_mode` is [`DeliveryMode::PickUp`], this will return [`SignalType::Push`] and [`SignalType::Contains`].
     /// If `delivery_mode` is [`DeliveryMode::DropOff`], this will return [`SignalType::Pull`] and [`SignalType::Stores`].
-    /// If `purpose` is [`Purpose::Primary`], [`SignalType::Stores`] and [`SignalType::Contains`] are excluded.
+    /// If `purpose` is [`Purpose::Intrinsic`], [`SignalType::Stores`] and [`SignalType::Contains`] are excluded.
     pub(crate) fn item_signal_types(
         item_kind: ItemKind,
         item_manifest: &ItemManifest,

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -201,7 +201,7 @@ impl Signals {
         let mut signal_strength_map = HashMap::with_capacity(7);
 
         signal_strength_map.insert(tile_pos, self.get(signal_type, tile_pos));
-        for neighbor in tile_pos.reachable_neighbors(map_geometry) {
+        for neighbor in tile_pos.passable_neighbors(map_geometry) {
             signal_strength_map.insert(neighbor, self.get(signal_type, neighbor));
         }
 
@@ -224,7 +224,7 @@ impl Signals {
                 let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
 
                 let mut num_neighbors = 0.0;
-                for neighboring_tile in occupied_tile.reachable_neighbors(map_geometry) {
+                for neighboring_tile in occupied_tile.passable_neighbors(map_geometry) {
                     num_neighbors += 1.0;
                     addition_map.push((neighboring_tile, amount_to_send_to_each_neighbor));
                 }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -823,4 +823,47 @@ mod tests {
             )
             .is_some());
     }
+
+    #[test]
+    fn item_signal_types_are_correct() {
+        let item_kind = test_item();
+        let item_manifest = test_manifest();
+
+        assert_eq!(
+            SignalType::item_signal_types(
+                item_kind,
+                &item_manifest,
+                DeliveryMode::PickUp,
+                Purpose::Intrinsic
+            ),
+            vec![SignalType::Push(item_kind)]
+        );
+        assert_eq!(
+            SignalType::item_signal_types(
+                item_kind,
+                &item_manifest,
+                DeliveryMode::PickUp,
+                Purpose::Instrumental
+            ),
+            vec![SignalType::Push(item_kind), SignalType::Contains(item_kind)]
+        );
+        assert_eq!(
+            SignalType::item_signal_types(
+                item_kind,
+                &item_manifest,
+                DeliveryMode::DropOff,
+                Purpose::Intrinsic
+            ),
+            vec![SignalType::Pull(item_kind)]
+        );
+        assert_eq!(
+            SignalType::item_signal_types(
+                item_kind,
+                &item_manifest,
+                DeliveryMode::DropOff,
+                Purpose::Instrumental
+            ),
+            vec![SignalType::Pull(item_kind), SignalType::Stores(item_kind)]
+        );
+    }
 }

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -492,13 +492,13 @@ impl MapGeometry {
         Ok(Height(starting_height.abs_diff(ending_height.0)))
     }
 
-    /// Gets the list of ghost or structure [`Entity`]s at the provided `tile_pos`.
+    /// Gets the list of [`Entity`]s at the provided `tile_pos` that might want an item.
     ///
     /// Priority:
     /// - ghost terrain
     /// - ghost structure
     /// - structure
-    pub(crate) fn ghosts_or_structures(&self, tile_pos: TilePos) -> Vec<Entity> {
+    pub(crate) fn might_want_items(&self, tile_pos: TilePos) -> Vec<Entity> {
         let mut entities = Vec::new();
         if let Some(&ghost_terrain_entity) = self.ghost_terrain_index.get(&tile_pos) {
             entities.push(ghost_terrain_entity)
@@ -506,6 +506,29 @@ impl MapGeometry {
 
         if let Some(&ghost_structure_entity) = self.ghost_structure_index.get(&tile_pos) {
             entities.push(ghost_structure_entity)
+        }
+
+        if let Some(&structure_entity) = self.structure_index.get(&tile_pos) {
+            entities.push(structure_entity)
+        }
+
+        entities
+    }
+
+    /// Gets the list of [`Entity`]s at the provided `tile_pos` that might have an item.
+    ///
+    /// Priority:
+    /// - ghost terrain (terraforming)
+    /// - terrain (litter)
+    /// - structure
+    pub(crate) fn might_have_items(&self, tile_pos: TilePos) -> Vec<Entity> {
+        let mut entities = Vec::new();
+        if let Some(&ghost_terrain_entity) = self.ghost_terrain_index.get(&tile_pos) {
+            entities.push(ghost_terrain_entity)
+        }
+
+        if let Some(&terrain_entity) = self.terrain_index.get(&tile_pos) {
+            entities.push(terrain_entity)
         }
 
         if let Some(&structure_entity) = self.structure_index.get(&tile_pos) {

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -167,6 +167,28 @@ impl TilePos {
         iter
     }
 
+    /// All adjacent tiles that are passable.
+    ///
+    /// This is distinct from [`reachable_neighbors`](Self::reachable_neighbors), which includes tiles filled with litter.
+    pub(crate) fn passable_neighbors(
+        &self,
+        map_geometry: &MapGeometry,
+    ) -> impl IntoIterator<Item = TilePos> {
+        if !map_geometry.is_valid(*self) {
+            let null_array = [TilePos::ZERO; 6];
+            let mut null_iter = FilteredArrayIter::from(null_array);
+            null_iter.filter(|_| false);
+            return null_iter;
+        }
+
+        let neighbors = self.hex.all_neighbors().map(|hex| TilePos { hex });
+        let mut iter = FilteredArrayIter::from(neighbors);
+        iter.filter(|&target_pos| {
+            map_geometry.is_valid(target_pos) && map_geometry.is_passable(*self, target_pos)
+        });
+        iter
+    }
+
     /// All adjacent tiles that are on the map and free of structures.
     pub(crate) fn empty_neighbors(
         &self,

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -17,8 +17,8 @@ use std::{
 
 use crate::{
     asset_management::manifest::Id, construction::AllowedTerrainTypes,
-    crafting::components::StorageInventory, filtered_array_iter::FilteredArrayIter,
-    structures::Footprint, terrain::terrain_manifest::Terrain,
+    filtered_array_iter::FilteredArrayIter, structures::Footprint,
+    terrain::terrain_manifest::Terrain,
 };
 
 /// A hex-based coordinate, that represents exactly one tile.
@@ -357,13 +357,7 @@ impl MapGeometry {
     /// Tiles that are not part of the map will return `false`.
     /// Tiles that have a structure will return `false`.
     /// Tiles that are more than [`Height::MAX_STEP`] above or below the current tile will return `false`.
-    /// Tiles that are full on liter will return `false`.
-    pub(crate) fn is_passable(
-        &self,
-        starting_pos: TilePos,
-        ending_pos: TilePos,
-        litter_query: &Query<&StorageInventory>,
-    ) -> bool {
+    pub(crate) fn is_passable(&self, starting_pos: TilePos, ending_pos: TilePos) -> bool {
         if !self.is_valid(starting_pos) {
             return false;
         }
@@ -373,14 +367,6 @@ impl MapGeometry {
         }
 
         if self.get_structure(ending_pos).is_some() {
-            return false;
-        }
-
-        let storage_inventory = litter_query
-            .get(self.get_terrain(ending_pos).unwrap())
-            .unwrap();
-
-        if storage_inventory.is_full() {
             return false;
         }
 

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -17,8 +17,8 @@ use std::{
 
 use crate::{
     asset_management::manifest::Id, construction::AllowedTerrainTypes,
-    filtered_array_iter::FilteredArrayIter, structures::Footprint,
-    terrain::terrain_manifest::Terrain,
+    crafting::components::StorageInventory, filtered_array_iter::FilteredArrayIter,
+    structures::Footprint, terrain::terrain_manifest::Terrain,
 };
 
 /// A hex-based coordinate, that represents exactly one tile.
@@ -357,7 +357,13 @@ impl MapGeometry {
     /// Tiles that are not part of the map will return `false`.
     /// Tiles that have a structure will return `false`.
     /// Tiles that are more than [`Height::MAX_STEP`] above or below the current tile will return `false`.
-    pub(crate) fn is_passable(&self, starting_pos: TilePos, ending_pos: TilePos) -> bool {
+    /// Tiles that are full on liter will return `false`.
+    pub(crate) fn is_passable(
+        &self,
+        starting_pos: TilePos,
+        ending_pos: TilePos,
+        litter_query: &Query<&StorageInventory>,
+    ) -> bool {
         if !self.is_valid(starting_pos) {
             return false;
         }
@@ -367,6 +373,14 @@ impl MapGeometry {
         }
 
         if self.get_structure(ending_pos).is_some() {
+            return false;
+        }
+
+        let storage_inventory = litter_query
+            .get(self.get_terrain(ending_pos).unwrap())
+            .unwrap();
+
+        if storage_inventory.is_full() {
             return false;
         }
 

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -116,6 +116,7 @@ fn respond_to_height_changes(
     }
 }
 
+/// Updates the signals produced by terrain tiles.
 fn set_terrain_emitters(
     mut query: Query<(&mut Emitter, Ref<StorageInventory>), With<Id<Terrain>>>,
 ) {

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -89,7 +89,7 @@ impl TerrainBundle {
             zoning: Zoning::None,
             scene_bundle,
             emitter: Emitter::default(),
-            storage_inventory: StorageInventory::new(3, None),
+            storage_inventory: StorageInventory::new(1, None),
         }
     }
 }

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -57,7 +57,7 @@ struct TerrainBundle {
     scene_bundle: SceneBundle,
     /// Controls the signals produced by this terrain tile.
     emitter: Emitter,
-    /// Stores dropped items
+    /// Stores littered items
     storage_inventory: StorageInventory,
 }
 

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -29,7 +29,11 @@ impl Plugin for TerrainPlugin {
         app.add_plugin(ManifestPlugin::<RawTerrainManifest>::new())
             .add_asset_collection::<TerrainHandles>()
             .add_systems(
-                (respond_to_height_changes, set_terrain_emitters)
+                (
+                    respond_to_height_changes,
+                    set_terrain_emitters,
+                    update_litter_index,
+                )
                     .in_set(SimulationSet)
                     .in_schedule(CoreSchedule::FixedUpdate),
             );
@@ -130,5 +134,15 @@ fn set_terrain_emitters(
                 emitter.signals.push((signal_type, signal_strength));
             }
         }
+    }
+}
+
+/// Tracks how much litter is on the ground on each tile.
+fn update_litter_index(
+    query: Query<(&TilePos, &StorageInventory), (With<Id<Terrain>>, Changed<StorageInventory>)>,
+    mut map_geometry: ResMut<MapGeometry>,
+) {
+    for (&tile_pos, litter) in query.iter() {
+        map_geometry.set_litter_state(tile_pos, litter.state());
     }
 }

--- a/emergence_lib/src/terrain/mod.rs
+++ b/emergence_lib/src/terrain/mod.rs
@@ -119,7 +119,12 @@ fn set_terrain_emitters(
         if storage_inventory.is_changed() {
             emitter.signals.clear();
             for item_slot in storage_inventory.iter() {
-                let signal_type = SignalType::Contains(ItemKind::Single(item_slot.item_id()));
+                let item_kind = ItemKind::Single(item_slot.item_id());
+
+                let signal_type = match storage_inventory.is_full() {
+                    true => SignalType::Push(item_kind),
+                    false => SignalType::Contains(item_kind),
+                };
                 let signal_strength = SignalStrength::new(10.);
 
                 emitter.signals.push((signal_type, signal_strength));

--- a/emergence_lib/src/ui/selection_details.rs
+++ b/emergence_lib/src/ui/selection_details.rs
@@ -388,6 +388,7 @@ fn get_details(
                     height: *terrain_query_item.height,
                     signals: signals.all_signals_at_position(*tile_pos),
                     zoning: terrain_query_item.zoning.clone(),
+                    storage_inventory: terrain_query_item.storage_inventory.clone(),
                     maybe_terraforming_details,
                 })
             } else {
@@ -723,7 +724,7 @@ mod terrain_details {
     use crate::{
         asset_management::manifest::Id,
         construction::{terraform::TerraformingAction, zoning::Zoning},
-        crafting::components::{InputInventory, OutputInventory},
+        crafting::components::{InputInventory, OutputInventory, StorageInventory},
         items::item_manifest::ItemManifest,
         signals::LocalSignals,
         simulation::geometry::{Height, TilePos},
@@ -743,6 +744,8 @@ mod terrain_details {
         pub(super) terrain_id: &'static Id<Terrain>,
         /// The zoning applied to this terrain
         pub(super) zoning: &'static Zoning,
+        /// Any littered items on this tile
+        pub(super) storage_inventory: &'static StorageInventory,
     }
 
     /// Data needed to populate [`TerraformingDetails`].
@@ -801,6 +804,8 @@ Output: {output}"
         pub(super) signals: LocalSignals,
         /// The zoning of this tile
         pub(super) zoning: Zoning,
+        /// Any littered items on this tile
+        pub(super) storage_inventory: StorageInventory,
         /// The details about the terraforming process, if any
         pub(super) maybe_terraforming_details: Option<TerraformingDetails>,
     }
@@ -825,13 +830,15 @@ Output: {output}"
                 unit_manifest,
             );
             let zoning = self.zoning.display(structure_manifest, terrain_manifest);
+            let litter = self.storage_inventory.display(item_manifest);
 
             let base_string = format!(
                 "Entity: {entity:?}
 Terrain type: {terrain_type}
 Tile: {tile_pos}
 Height: {height}
-Zoning: {zoning}"
+Zoning: {zoning}
+Litter: {litter}"
             );
 
             if let Some(terraforming_details) = &self.maybe_terraforming_details {

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -365,6 +365,7 @@ pub(super) fn finish_actions(
                                         Err(..) => Goal::Pickup(*item_kind),
                                     }
                                 } else {
+                                    unit.impatience.increment();
                                     Goal::Pickup(*item_kind)
                                 }
                             }
@@ -414,7 +415,10 @@ pub(super) fn finish_actions(
                                             unit.unit_inventory.held_item = None;
                                             Goal::default()
                                         }
-                                        Err(..) => Goal::Store(ItemKind::Single(held_item_id)),
+                                        Err(..) => {
+                                            unit.impatience.increment();
+                                            Goal::Store(ItemKind::Single(held_item_id))
+                                        }
                                     }
                                 } else {
                                     // Somehow we're holding the wrong thing

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -683,7 +683,7 @@ impl CurrentAction {
         let mut sources: Vec<(Entity, TilePos)> = Vec::new();
 
         for tile_pos in neighboring_tiles {
-            for output_entity in map_geometry.ghosts_or_structures(tile_pos) {
+            for output_entity in map_geometry.might_have_items(tile_pos) {
                 if let Ok((maybe_output_inventory, maybe_storage_inventory)) =
                     output_inventory_query.get(output_entity)
                 {
@@ -696,7 +696,7 @@ impl CurrentAction {
                             sources.push((output_entity, tile_pos));
                         }
                     } else {
-                        error!("output_inventory_query contained an object with neither an output nor storage inventory.")
+                        unreachable!("output_inventory_query contained an object with neither an output nor storage inventory.")
                     }
                 }
             }
@@ -750,7 +750,7 @@ impl CurrentAction {
         let mut receptacles: Vec<(Entity, TilePos)> = Vec::new();
 
         for tile_pos in neighboring_tiles {
-            for entity in map_geometry.ghosts_or_structures(tile_pos) {
+            for entity in map_geometry.might_want_items(tile_pos) {
                 if let Ok((maybe_input_inventory, maybe_storage_inventory)) =
                     input_inventory_query.get(entity)
                 {
@@ -763,7 +763,7 @@ impl CurrentAction {
                             receptacles.push((entity, tile_pos));
                         }
                     } else {
-                        error!("input_inventory_query contained an object with neither an input nor storage inventory.")
+                        unreachable!("input_inventory_query contained an object with neither an input nor storage inventory.")
                     }
                 }
             }
@@ -1286,7 +1286,7 @@ impl<'w, 's> WorkplaceQuery<'w, 's> {
 
         // Prioritize ghosts over structures to allow for replacing structures by building
         // Prioritize terrain ghosts over structure ghosts to encourage terraforming to complete before structures are built on top
-        let entity = *map_geometry.ghosts_or_structures(target).first()?;
+        let entity = *map_geometry.might_want_items(target).first()?;
 
         let (found_crafting_state, ids, workers_present) = self.query.get(entity).ok()?;
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -612,7 +612,7 @@ impl CurrentAction {
 
     /// Atempts to find a place to pick up or drop off an item.
     ///
-    /// If the `purpose` is [`Purpose::Primary`], items will not be picked up from or dropped off at a [`StorageInventory`].
+    /// If the `purpose` is [`Purpose::Intrinsic`], items will not be picked up from or dropped off at a [`StorageInventory`].
     fn find(
         item_kind: ItemKind,
         delivery_mode: DeliveryMode,

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -66,7 +66,7 @@ pub(super) fn choose_actions(
     map_geometry: Res<MapGeometry>,
     signals: Res<Signals>,
     terrain_query: Query<&Id<Terrain>>,
-    terrain_storage_query: Query<&StorageInventory, With<Id<Terrain>>>,
+    litter_query: Query<&StorageInventory>,
     terrain_manifest: Res<TerrainManifest>,
     item_manifest: Res<ItemManifest>,
 ) {
@@ -86,6 +86,7 @@ pub(super) fn choose_actions(
                     facing,
                     map_geometry,
                     &terrain_query,
+                    &litter_query,
                     &terrain_manifest,
                     rng,
                 ),
@@ -99,7 +100,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &terrain_storage_query,
+                            &litter_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -112,6 +113,7 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &output_inventory_query,
+                            &litter_query,
                             &signals,
                             rng,
                             &item_manifest,
@@ -131,7 +133,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &terrain_storage_query,
+                            &litter_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -144,6 +146,7 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &input_inventory_query,
+                            &litter_query,
                             &signals,
                             rng,
                             &terrain_query,
@@ -163,7 +166,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &terrain_storage_query,
+                            &litter_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -180,6 +183,7 @@ pub(super) fn choose_actions(
                             rng,
                             &item_manifest,
                             &terrain_query,
+                            &litter_query,
                             &terrain_manifest,
                             map_geometry,
                         )
@@ -196,7 +200,7 @@ pub(super) fn choose_actions(
                                 unit_inventory,
                                 map_geometry,
                                 &item_manifest,
-                                &terrain_storage_query,
+                                &litter_query,
                                 &terrain_manifest,
                                 &terrain_query,
                                 facing,
@@ -210,6 +214,7 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &output_inventory_query,
+                            &litter_query,
                             &signals,
                             rng,
                             &item_manifest,
@@ -227,6 +232,7 @@ pub(super) fn choose_actions(
                     &signals,
                     rng,
                     &terrain_query,
+                    &litter_query,
                     &terrain_manifest,
                     &item_manifest,
                     map_geometry,
@@ -240,6 +246,7 @@ pub(super) fn choose_actions(
                     rng,
                     &item_manifest,
                     &terrain_query,
+                    &litter_query,
                     &terrain_manifest,
                     map_geometry,
                 ),
@@ -664,6 +671,7 @@ impl CurrentAction {
         facing: &Facing,
         goal: &Goal,
         output_inventory_query: &Query<AnyOf<(&OutputInventory, &StorageInventory)>>,
+        litter_query: &Query<&StorageInventory>,
         signals: &Signals,
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
@@ -710,6 +718,7 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
+                &litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -729,6 +738,7 @@ impl CurrentAction {
             AnyOf<(&InputInventory, &StorageInventory)>,
             Without<MarkedForDemolition>,
         >,
+        litter_query: &Query<&StorageInventory>,
         signals: &Signals,
         rng: &mut ThreadRng,
         terrain_query: &Query<&Id<Terrain>>,
@@ -775,6 +785,7 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
+                &litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -798,6 +809,7 @@ impl CurrentAction {
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> CurrentAction {
@@ -847,6 +859,7 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
+                litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -864,6 +877,7 @@ impl CurrentAction {
         signals: &Signals,
         rng: &mut ThreadRng,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         item_manifest: &ItemManifest,
         map_geometry: &MapGeometry,
@@ -897,6 +911,7 @@ impl CurrentAction {
                     chosen_workplace.1,
                     facing,
                     terrain_query,
+                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -911,6 +926,7 @@ impl CurrentAction {
                     upstream,
                     facing,
                     terrain_query,
+                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -930,6 +946,7 @@ impl CurrentAction {
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> CurrentAction {
@@ -966,6 +983,7 @@ impl CurrentAction {
                     chosen_demo_site.1,
                     facing,
                     terrain_query,
+                    litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -980,6 +998,7 @@ impl CurrentAction {
                     upstream,
                     facing,
                     terrain_query,
+                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -1032,6 +1051,7 @@ impl CurrentAction {
         facing: &Facing,
         map_geometry: &MapGeometry,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
     ) -> Self {
         /// The time in seconds that it takes a standard unit to walk to an adjacent tile.
@@ -1043,7 +1063,7 @@ impl CurrentAction {
         let walking_speed = terrain_manifest.get(*terrain_standing_on).walking_speed;
         let walking_duration = BASE_WALKING_DURATION / walking_speed;
 
-        if map_geometry.is_passable(current_tile, target_tile) {
+        if map_geometry.is_passable(current_tile, target_tile, &litter_query) {
             CurrentAction {
                 action: UnitAction::MoveForward,
                 timer: Timer::from_seconds(walking_duration, TimerMode::Once),
@@ -1060,6 +1080,7 @@ impl CurrentAction {
         target_tile_pos: TilePos,
         facing: &Facing,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> Self {
@@ -1071,6 +1092,7 @@ impl CurrentAction {
                 facing,
                 map_geometry,
                 terrain_query,
+                litter_query,
                 terrain_manifest,
             )
         } else {
@@ -1171,14 +1193,14 @@ impl CurrentAction {
         unit_inventory: &UnitInventory,
         map_geometry: &MapGeometry,
         item_manifest: &ItemManifest,
-        terrain_storage_query: &Query<&StorageInventory, With<Id<Terrain>>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         terrain_query: &Query<&Id<Terrain>>,
         facing: &Facing,
         rng: &mut ThreadRng,
     ) -> Self {
         let terrain_entity = map_geometry.get_terrain(unit_tile_pos).unwrap();
-        let terrain_storage_inventory = terrain_storage_query.get(terrain_entity).unwrap();
+        let terrain_storage_inventory = litter_query.get(terrain_entity).unwrap();
 
         if let Some(item_id) = unit_inventory.held_item {
             let item_kind = ItemKind::Single(item_id);
@@ -1197,6 +1219,7 @@ impl CurrentAction {
             facing,
             map_geometry,
             terrain_query,
+            &litter_query,
             terrain_manifest,
             rng,
         )
@@ -1211,6 +1234,7 @@ impl CurrentAction {
         facing: &Facing,
         map_geometry: &MapGeometry,
         terrain_query: &Query<&Id<Terrain>>,
+        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         rng: &mut ThreadRng,
     ) -> Self {
@@ -1220,6 +1244,7 @@ impl CurrentAction {
                 facing,
                 map_geometry,
                 &terrain_query,
+                &litter_query,
                 &terrain_manifest,
             ),
             _ => CurrentAction::random_spin(rng),

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -66,7 +66,7 @@ pub(super) fn choose_actions(
     map_geometry: Res<MapGeometry>,
     signals: Res<Signals>,
     terrain_query: Query<&Id<Terrain>>,
-    litter_query: Query<&StorageInventory>,
+    terrain_storage_query: Query<&StorageInventory, With<Id<Terrain>>>,
     terrain_manifest: Res<TerrainManifest>,
     item_manifest: Res<ItemManifest>,
 ) {
@@ -86,7 +86,6 @@ pub(super) fn choose_actions(
                     facing,
                     map_geometry,
                     &terrain_query,
-                    &litter_query,
                     &terrain_manifest,
                     rng,
                 ),
@@ -100,7 +99,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &litter_query,
+                            &terrain_storage_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -113,7 +112,6 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &output_inventory_query,
-                            &litter_query,
                             &signals,
                             rng,
                             &item_manifest,
@@ -133,7 +131,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &litter_query,
+                            &terrain_storage_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -146,7 +144,6 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &input_inventory_query,
-                            &litter_query,
                             &signals,
                             rng,
                             &terrain_query,
@@ -166,7 +163,7 @@ pub(super) fn choose_actions(
                             unit_inventory,
                             map_geometry,
                             &item_manifest,
-                            &litter_query,
+                            &terrain_storage_query,
                             &terrain_manifest,
                             &terrain_query,
                             facing,
@@ -183,7 +180,6 @@ pub(super) fn choose_actions(
                             rng,
                             &item_manifest,
                             &terrain_query,
-                            &litter_query,
                             &terrain_manifest,
                             map_geometry,
                         )
@@ -200,7 +196,7 @@ pub(super) fn choose_actions(
                                 unit_inventory,
                                 map_geometry,
                                 &item_manifest,
-                                &litter_query,
+                                &terrain_storage_query,
                                 &terrain_manifest,
                                 &terrain_query,
                                 facing,
@@ -214,7 +210,6 @@ pub(super) fn choose_actions(
                             facing,
                             goal,
                             &output_inventory_query,
-                            &litter_query,
                             &signals,
                             rng,
                             &item_manifest,
@@ -232,7 +227,6 @@ pub(super) fn choose_actions(
                     &signals,
                     rng,
                     &terrain_query,
-                    &litter_query,
                     &terrain_manifest,
                     &item_manifest,
                     map_geometry,
@@ -246,7 +240,6 @@ pub(super) fn choose_actions(
                     rng,
                     &item_manifest,
                     &terrain_query,
-                    &litter_query,
                     &terrain_manifest,
                     map_geometry,
                 ),
@@ -671,7 +664,6 @@ impl CurrentAction {
         facing: &Facing,
         goal: &Goal,
         output_inventory_query: &Query<AnyOf<(&OutputInventory, &StorageInventory)>>,
-        litter_query: &Query<&StorageInventory>,
         signals: &Signals,
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
@@ -718,7 +710,6 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
-                &litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -738,7 +729,6 @@ impl CurrentAction {
             AnyOf<(&InputInventory, &StorageInventory)>,
             Without<MarkedForDemolition>,
         >,
-        litter_query: &Query<&StorageInventory>,
         signals: &Signals,
         rng: &mut ThreadRng,
         terrain_query: &Query<&Id<Terrain>>,
@@ -785,7 +775,6 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
-                &litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -809,7 +798,6 @@ impl CurrentAction {
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> CurrentAction {
@@ -859,7 +847,6 @@ impl CurrentAction {
                 upstream,
                 facing,
                 terrain_query,
-                litter_query,
                 terrain_manifest,
                 map_geometry,
             )
@@ -877,7 +864,6 @@ impl CurrentAction {
         signals: &Signals,
         rng: &mut ThreadRng,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         item_manifest: &ItemManifest,
         map_geometry: &MapGeometry,
@@ -911,7 +897,6 @@ impl CurrentAction {
                     chosen_workplace.1,
                     facing,
                     terrain_query,
-                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -926,7 +911,6 @@ impl CurrentAction {
                     upstream,
                     facing,
                     terrain_query,
-                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -946,7 +930,6 @@ impl CurrentAction {
         rng: &mut ThreadRng,
         item_manifest: &ItemManifest,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> CurrentAction {
@@ -983,7 +966,6 @@ impl CurrentAction {
                     chosen_demo_site.1,
                     facing,
                     terrain_query,
-                    litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -998,7 +980,6 @@ impl CurrentAction {
                     upstream,
                     facing,
                     terrain_query,
-                    &litter_query,
                     terrain_manifest,
                     map_geometry,
                 )
@@ -1051,7 +1032,6 @@ impl CurrentAction {
         facing: &Facing,
         map_geometry: &MapGeometry,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
     ) -> Self {
         /// The time in seconds that it takes a standard unit to walk to an adjacent tile.
@@ -1063,7 +1043,7 @@ impl CurrentAction {
         let walking_speed = terrain_manifest.get(*terrain_standing_on).walking_speed;
         let walking_duration = BASE_WALKING_DURATION / walking_speed;
 
-        if map_geometry.is_passable(current_tile, target_tile, &litter_query) {
+        if map_geometry.is_passable(current_tile, target_tile) {
             CurrentAction {
                 action: UnitAction::MoveForward,
                 timer: Timer::from_seconds(walking_duration, TimerMode::Once),
@@ -1080,7 +1060,6 @@ impl CurrentAction {
         target_tile_pos: TilePos,
         facing: &Facing,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> Self {
@@ -1092,7 +1071,6 @@ impl CurrentAction {
                 facing,
                 map_geometry,
                 terrain_query,
-                litter_query,
                 terrain_manifest,
             )
         } else {
@@ -1193,14 +1171,14 @@ impl CurrentAction {
         unit_inventory: &UnitInventory,
         map_geometry: &MapGeometry,
         item_manifest: &ItemManifest,
-        litter_query: &Query<&StorageInventory>,
+        terrain_storage_query: &Query<&StorageInventory, With<Id<Terrain>>>,
         terrain_manifest: &TerrainManifest,
         terrain_query: &Query<&Id<Terrain>>,
         facing: &Facing,
         rng: &mut ThreadRng,
     ) -> Self {
         let terrain_entity = map_geometry.get_terrain(unit_tile_pos).unwrap();
-        let terrain_storage_inventory = litter_query.get(terrain_entity).unwrap();
+        let terrain_storage_inventory = terrain_storage_query.get(terrain_entity).unwrap();
 
         if let Some(item_id) = unit_inventory.held_item {
             let item_kind = ItemKind::Single(item_id);
@@ -1219,7 +1197,6 @@ impl CurrentAction {
             facing,
             map_geometry,
             terrain_query,
-            &litter_query,
             terrain_manifest,
             rng,
         )
@@ -1234,7 +1211,6 @@ impl CurrentAction {
         facing: &Facing,
         map_geometry: &MapGeometry,
         terrain_query: &Query<&Id<Terrain>>,
-        litter_query: &Query<&StorageInventory>,
         terrain_manifest: &TerrainManifest,
         rng: &mut ThreadRng,
     ) -> Self {
@@ -1244,7 +1220,6 @@ impl CurrentAction {
                 facing,
                 map_geometry,
                 &terrain_query,
-                &litter_query,
                 &terrain_manifest,
             ),
             _ => CurrentAction::random_spin(rng),

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -469,13 +469,13 @@ pub(super) fn finish_actions(
                         let diet = &unit_data.diet;
 
                         if diet.item_kind().matches(held_item, item_manifest) {
+                            unit.unit_inventory.held_item = None;
+
                             let proposed = unit.energy_pool.current() + diet.energy();
                             unit.energy_pool.set_current(proposed);
                             unit.lifecycle.record_energy_gained(diet.energy());
                         }
                     }
-
-                    unit.unit_inventory.held_item = None;
                 }
                 UnitAction::Abandon => {
                     let terrain_entity = map_geometry.get_terrain(*unit.tile_pos).unwrap();

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -1069,8 +1069,8 @@ impl CurrentAction {
                 unit_tile_pos,
                 facing,
                 map_geometry,
-                &terrain_query,
-                &terrain_manifest,
+                terrain_query,
+                terrain_manifest,
             ),
             _ => CurrentAction::random_spin(rng),
         }

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -108,7 +108,7 @@ pub(super) fn choose_actions(
                             rng,
                         )
                     } else {
-                        CurrentAction::find_place_for_item(
+                        CurrentAction::find(
                             *item_kind,
                             goal.delivery_mode().unwrap(),
                             goal.purpose(),
@@ -146,7 +146,7 @@ pub(super) fn choose_actions(
                             )
                         }
                     } else {
-                        CurrentAction::find_place_for_item(
+                        CurrentAction::find(
                             *item_kind,
                             DeliveryMode::PickUp,
                             Purpose::Instrumental,
@@ -613,7 +613,7 @@ impl CurrentAction {
     /// Atempts to find a place to pick up or drop off an item.
     ///
     /// If the `purpose` is [`Purpose::Primary`], items will not be picked up from or dropped off at a [`StorageInventory`].
-    fn find_place_for_item(
+    fn find(
         item_kind: ItemKind,
         delivery_mode: DeliveryMode,
         purpose: Purpose,

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -208,8 +208,6 @@ pub(super) fn start_actions(
                     if result.is_err() {
                         *action = CurrentAction::idle();
                     }
-                } else {
-                    warn!("Unit tried to start working at an entity that is not a workplace!");
                 }
             }
 


### PR DESCRIPTION
Fixes #366.

Fairly straightforward for now: each terrain tile gets a `StorageInventory` component, and an `Emitter` to track what's actually there.

Abanoned items are dropped there.

I had to refactor the goals and signal code a bit to make sure that units wouldn't take from storage when trying to solve SignalType::Pull