### PR TITLE
Add hills to world generation

### DIFF
--- a/emergence_game/src/main.rs
+++ b/emergence_game/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::window::{PresentMode, WindowMode, WindowPlugin};
 use bevy_framepace::{FramepacePlugin, FramepaceSettings, Limiter};
-use emergence_lib::simulation::generation::GenerationConfig;
+use emergence_lib::world_gen::GenerationConfig;
 
 fn main() {
     App::new()

--- a/emergence_lib/src/lib.rs
+++ b/emergence_lib/src/lib.rs
@@ -25,14 +25,14 @@ pub mod structures;
 pub mod terrain;
 pub mod ui;
 pub mod units;
+pub mod world_gen;
 
 /// Various app configurations, used for testing.
 ///
 /// Importing between files shared in the `tests` directory appears to be broken with this workspace config?
 /// Followed directions from <https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html>
 pub mod testing {
-    use crate::simulation::generation::GenerationConfig;
-    use crate::simulation::SimulationPlugin;
+    use crate::{simulation::SimulationPlugin, world_gen::GenerationConfig};
     use bevy::prelude::*;
 
     /// Just [`MinimalPlugins`].

--- a/emergence_lib/src/simulation/mod.rs
+++ b/emergence_lib/src/simulation/mod.rs
@@ -7,17 +7,16 @@ use crate::construction::ConstructionPlugin;
 use crate::crafting::CraftingPlugin;
 use crate::organisms::OrganismPlugin;
 use crate::signals::SignalsPlugin;
-use crate::simulation::generation::{GenerationConfig, GenerationPlugin};
 use crate::simulation::geometry::{sync_rotation_to_facing, MapGeometry};
 use crate::simulation::light::LightPlugin;
 use crate::simulation::time::TemporalPlugin;
 use crate::structures::StructuresPlugin;
 use crate::terrain::TerrainPlugin;
 use crate::units::UnitsPlugin;
+use crate::world_gen::{GenerationConfig, GenerationPlugin};
 use bevy::ecs::schedule::{LogLevel, ScheduleBuildSettings};
 use bevy::prelude::*;
 
-pub mod generation;
 pub mod geometry;
 pub mod light;
 pub mod time;

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -2,7 +2,7 @@
 use crate::asset_management::manifest::Id;
 use crate::asset_management::AssetState;
 use crate::player_interaction::clipboard::ClipboardData;
-use crate::simulation::geometry::{Facing, Height, TilePos};
+use crate::simulation::geometry::{Facing, Height, MapGeometry, TilePos};
 use crate::structures::commands::StructureCommandsExt;
 use crate::structures::structure_manifest::StructureManifest;
 use crate::terrain::commands::TerrainCommandsExt;
@@ -21,8 +21,6 @@ use hexx::Hex;
 use noisy_bevy::fbm_simplex_2d_seeded;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-
-use super::geometry::MapGeometry;
 
 /// Controls world generation strategy
 #[derive(Resource, Clone)]

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -52,16 +52,16 @@ impl Default for GenerationConfig {
         terrain_weights.insert(Id::from_name("rocky".to_string()), 0.2);
 
         GenerationConfig {
-            map_radius: 20,
-            n_ant: 12,
-            n_plant: 12,
-            n_fungi: 2,
+            map_radius: 40,
+            n_ant: 20,
+            n_plant: 150,
+            n_fungi: 30,
             n_hive: 1,
             terrain_weights,
             hill_settings: HillSettings {
                 center: TilePos::ZERO,
-                height: Height(10),
-                radius: 10,
+                height: Height(25),
+                radius: 40,
             },
             simplex_settings: SimplexSettings {
                 frequency: 0.07,

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -39,50 +39,20 @@ pub struct GenerationConfig {
     terrain_weights: HashMap<Id<Terrain>, f32>,
 }
 
-impl GenerationConfig {
-    /// The number of tiles from the center of the map to the edge
-    const MAP_RADIUS: u32 = 20;
-
-    /// The number of ants in the default generation config
-    const N_ANT: usize = 12;
-    /// The number of plants in the default generation config
-    const N_PLANT: usize = 12;
-    /// The number of fungi in the default generation config
-    const N_FUNGI: usize = 2;
-    /// The number of ant hives in the default generation config
-    const N_HIVE: usize = 1;
-
-    /// The choice weight for plain terrain in default generation config
-    const TERRAIN_WEIGHT_LOAM: f32 = 1.0;
-    /// The choice weight for high terrain in default generation config
-    const TERRAIN_WEIGHT_MUDDY: f32 = 0.3;
-    /// The choice weight for impassable terrain in default generation config
-    const TERRAIN_WEIGHT_ROCKY: f32 = 0.2;
-}
-
 impl Default for GenerationConfig {
     fn default() -> GenerationConfig {
         let mut terrain_weights: HashMap<Id<Terrain>, f32> = HashMap::new();
         // FIXME: load from file somehow
-        terrain_weights.insert(
-            Id::from_name("loam".to_string()),
-            GenerationConfig::TERRAIN_WEIGHT_LOAM,
-        );
-        terrain_weights.insert(
-            Id::from_name("muddy".to_string()),
-            GenerationConfig::TERRAIN_WEIGHT_MUDDY,
-        );
-        terrain_weights.insert(
-            Id::from_name("rocky".to_string()),
-            GenerationConfig::TERRAIN_WEIGHT_ROCKY,
-        );
+        terrain_weights.insert(Id::from_name("loam".to_string()), 1.0);
+        terrain_weights.insert(Id::from_name("muddy".to_string()), 0.3);
+        terrain_weights.insert(Id::from_name("rocky".to_string()), 0.2);
 
         GenerationConfig {
-            map_radius: GenerationConfig::MAP_RADIUS,
-            n_ant: GenerationConfig::N_ANT,
-            n_plant: GenerationConfig::N_PLANT,
-            n_fungi: GenerationConfig::N_FUNGI,
-            n_hive: GenerationConfig::N_HIVE,
+            map_radius: 20,
+            n_ant: 12,
+            n_plant: 12,
+            n_fungi: 2,
+            n_hive: 1,
             terrain_weights,
         }
     }

--- a/emergence_lib/tests/test_setup.rs
+++ b/emergence_lib/tests/test_setup.rs
@@ -1,7 +1,7 @@
 // use common::{bevy_app, interaction_app, minimal_app, simulation_app};
 
-use emergence_lib::simulation::generation::GenerationConfig;
 use emergence_lib::testing::{interaction_app, minimal_app, simulation_app};
+use emergence_lib::world_gen::GenerationConfig;
 
 #[test]
 fn minimal_app_can_update() {


### PR DESCRIPTION
Good foundations for more complex world generation strategies.

Fixes #634, as I think the current settings are big enough to test out water flow on.

![image](https://user-images.githubusercontent.com/3579909/231581211-102661ee-43b8-48e5-9e2c-14667a230286.png)

![image](https://user-images.githubusercontent.com/3579909/231581235-584d5086-1699-468a-bceb-3ce4a98bcf71.png)
