### PR TITLE
Faster diffusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
 dependencies = [
  "async-lock",
  "async-task",
@@ -307,7 +307,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "bevy-inspector-egui"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f7ebaedaa0083df7c3679094e25eccebbaa9c4c60c3a5e74337f6402af2291"
+checksum = "7bda61dd72f879e8d4b0f57e94b86bd163bf558ac2e7ddea9ea075a47bdcd9af"
 dependencies = [
  "bevy-inspector-egui-derive",
  "bevy_app",
@@ -357,13 +357,13 @@ dependencies = [
 
 [[package]]
 name = "bevy-inspector-egui-derive"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc47dfcdcb52182af97741c1582cc9b3bb4e82f0adacf4c3e78909d438cbfc8b"
+checksum = "7556c913daacbec7aa213eda82517673bf6c6b25e0d827a56efe17421ebaca35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_framepace"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ceed91c013a62e38ff4975d027504c23fc44df3554f96e4098ff303f585bfae"
+checksum = "a1825c5a485aa2a2ffd91cc1faa1f4d621c804a893ead88cafedbe1ed6c51d34"
 dependencies = [
  "bevy",
  "spin_sleep",
@@ -1191,7 +1191,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1395,7 +1395,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -1407,9 +1407,9 @@ checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
@@ -1463,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d959d90e938c5493000514b446987c07aed46c668faaa7d34d6c7a67b1a578c"
 dependencies = [
  "alsa",
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.19.0",
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1813,15 +1813,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.20"
+name = "fdeflate"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1837,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -1893,9 +1902,9 @@ checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1927,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1953,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2244818258229abc01fe5a7817664e8b82af29eb70e67ab39d49018ae679912"
+checksum = "373b55d596e5a84fff61c559de54351a69f9ff481593ac78c35d9dc625df8d8f"
 dependencies = [
  "core-foundation",
  "io-kit-sys",
@@ -1963,12 +1972,12 @@ dependencies = [
  "libc",
  "libudev-sys",
  "log",
- "nix 0.25.1",
+ "nix 0.26.2",
  "uuid",
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.44.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -2266,12 +2275,12 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7789f7f3c9686f96164f5109d69152de759e76e284f736bd57661c6df5091919"
+checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
 dependencies = [
- "core-foundation-sys 0.8.3",
- "mach",
+ "core-foundation-sys 0.8.4",
+ "mach2",
 ]
 
 [[package]]
@@ -2482,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"
@@ -2523,15 +2532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2615,6 +2615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,14 +2701,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2864,9 +2874,9 @@ checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.3.patch-leaks.2"
+version = "0.3.0-beta.3.patch-leaks.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d9bb2ee6b71d02b1b3554ed600d267ee9a2796acc9fa43fb7748e13fe072dd"
+checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
 dependencies = [
  "block2",
  "objc-sys",
@@ -2955,9 +2965,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "orbclient"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974465c5e83cf9df05c1e4137b271d29035c902e39e5ad4c1939837e22160af8"
+checksum = "0e9829e16c5e112e94efb5e2ad1fe17f8c1c99bb0fcdc8c65c44e935d904767d"
 dependencies = [
  "cfg-if",
  "redox_syscall 0.2.16",
@@ -2988,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -3094,14 +3104,15 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
 dependencies = [
  "bitflags",
  "crc32fast",
+ "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -3137,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -3377,29 +3388,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.14",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -3420,6 +3431,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "slab"
@@ -3499,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3515,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "libc",
  "ntapi",
  "once_cell",
@@ -3524,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b26705069936de5f8a8b52e2873a76a6e0e35f08ae8dd34832804e4b6fa840"
+checksum = "fab62c50c3d17993e7f0c72932e51ceeac5ec2b51c225fda8529d606159c99d8"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -3565,7 +3582,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -3772,9 +3789,9 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom",
  "serde",
@@ -3909,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
+checksum = "b692165700260bbd40fbc5ff23766c03e339fbaca907aeea5cb77bf0a553ca83"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -4084,7 +4101,7 @@ checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -4093,7 +4110,16 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4124,13 +4150,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4139,7 +4165,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4148,13 +4183,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4164,10 +4214,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4176,10 +4238,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4188,16 +4262,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
  "debug_tools",
  "derive_more",
  "emergence_macros",
+ "hashbrown",
  "hexx",
  "indexmap",
  "itertools",
@@ -1705,6 +1706,7 @@ dependencies = [
  "noisy_bevy",
  "petitset",
  "rand",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -2125,6 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+ "rayon",
  "serde",
 ]
 

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -30,6 +30,8 @@ itertools = "0.10.5"
 bevy_screen_diagnostics = "0.2"
 anyhow = "1.0.69"
 serde_json = "1.0.94"
+hashbrown = { version = "0.12", features = ["rayon"] }
+rayon = "1.7.0"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -19,6 +19,7 @@ use emergence_macros::IterableEnum;
 use itertools::Itertools;
 use leafwing_abilities::prelude::Pool;
 use rand::seq::SliceRandom;
+use rayon::prelude::*;
 use std::ops::{Div, DivAssign, MulAssign};
 
 use crate::asset_management::manifest::Id;
@@ -769,7 +770,7 @@ fn degrade_signals(mut signals: ResMut<Signals>) {
     ///  - increase the amount of time units will wait around for more production
     const EPSILON_STRENGTH: SignalStrength = SignalStrength(1e-8);
 
-    for signal_map in signals.maps.values_mut() {
+    signals.maps.par_iter_mut().for_each(|(_, signal_map)| {
         let mut tiles_to_clear: Vec<TilePos> = Vec::with_capacity(signal_map.map.len());
 
         for (tile_pos, signal_strength) in signal_map.map.iter_mut() {
@@ -785,7 +786,7 @@ fn degrade_signals(mut signals: ResMut<Signals>) {
         for tile_to_clear in tiles_to_clear {
             signal_map.map.remove(&tile_to_clear);
         }
-    }
+    });
 }
 
 #[cfg(test)]

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -269,43 +269,45 @@ impl Signals {
 
     /// Diffuses signals from one cell into the next
     pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
-        for original_map in self.maps.values_mut() {
-            let num_elements = original_map.map.len();
-            let size_hint = num_elements * 6;
-            let mut addition_map = Vec::with_capacity(size_hint);
-            let mut removal_map = Vec::with_capacity(size_hint);
+        self.maps
+            .par_iter_mut()
+            .for_each(|(_signal_type, original_map)| {
+                let num_elements = original_map.map.len();
+                let size_hint = num_elements * 6;
+                let mut addition_map = Vec::with_capacity(size_hint);
+                let mut removal_map = Vec::with_capacity(size_hint);
 
-            for (&occupied_tile, original_strength) in original_map
-                .map
-                .iter()
-                .filter(|(_, signal_strength)| SignalStrength::ZERO.ne(signal_strength))
-            {
-                let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
+                for (&occupied_tile, original_strength) in original_map
+                    .map
+                    .iter()
+                    .filter(|(_, signal_strength)| SignalStrength::ZERO.ne(signal_strength))
+                {
+                    let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
 
-                // Signal that goes out of bounds is lost
-                let mut num_neighbors = occupied_tile
-                    .out_of_bounds_neighbors(map_geometry)
-                    .into_iter()
-                    .count() as f32;
-                for neighboring_tile in occupied_tile.passable_neighbors(map_geometry) {
-                    num_neighbors += 1.0;
-                    addition_map.push((neighboring_tile, amount_to_send_to_each_neighbor));
+                    // Signal that goes out of bounds is lost
+                    let mut num_neighbors = occupied_tile
+                        .out_of_bounds_neighbors(map_geometry)
+                        .into_iter()
+                        .count() as f32;
+                    for neighboring_tile in occupied_tile.passable_neighbors(map_geometry) {
+                        num_neighbors += 1.0;
+                        addition_map.push((neighboring_tile, amount_to_send_to_each_neighbor));
+                    }
+                    removal_map.push((
+                        occupied_tile,
+                        amount_to_send_to_each_neighbor * num_neighbors,
+                    ));
                 }
-                removal_map.push((
-                    occupied_tile,
-                    amount_to_send_to_each_neighbor * num_neighbors,
-                ));
-            }
 
-            // We cannot do this in one step, as we need to avoid bizarre iteration order dependencies
-            for (removal_pos, removal_strength) in removal_map.into_iter() {
-                original_map.subtract_signal(removal_pos, removal_strength)
-            }
+                // We cannot do this in one step, as we need to avoid bizarre iteration order dependencies
+                for (removal_pos, removal_strength) in removal_map.into_iter() {
+                    original_map.subtract_signal(removal_pos, removal_strength)
+                }
 
-            for (addition_pos, addition_strength) in addition_map.into_iter() {
-                original_map.add_signal(addition_pos, addition_strength)
-            }
-        }
+                for (addition_pos, addition_strength) in addition_map.into_iter() {
+                    original_map.add_signal(addition_pos, addition_strength)
+                }
+            });
     }
 
     /// Returns a random signal type present in the map.
@@ -709,6 +711,7 @@ fn emit_signals(
         }
     }
 
+    // PERF: this could be parallelized, but requires some thought due to the intent pool.
     for (&center, emitter, maybe_structure_id, maybe_facing) in emitter_query.iter() {
         match maybe_structure_id {
             // Signals should be emitted from all tiles in the footprint of a structure.

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -66,12 +66,14 @@ impl TilePos {
 
     /// Generates a new [`TilePos`] from axial coordinates.
     #[inline]
+    #[must_use]
     pub fn new(x: i32, y: i32) -> Self {
         TilePos { hex: Hex { x, y } }
     }
 
     /// Generates a random [`TilePos`], sampled uniformly from the valid positions in `map_geometry`
     #[inline]
+    #[must_use]
     pub fn random(map_geometry: &MapGeometry, rng: &mut ThreadRng) -> TilePos {
         let range = -(map_geometry.radius as i32)..(map_geometry.radius as i32);
 
@@ -94,6 +96,7 @@ impl TilePos {
     /// Returns the world position (in [`Transform`] units) associated with this tile.
     ///
     /// The `y` value returned corresponds to the top of the tile column at this location.
+    #[inline]
     #[must_use]
     pub(crate) fn into_world_pos(self, map_geometry: &MapGeometry) -> Vec3 {
         let xz = map_geometry.layout.hex_to_world_pos(self.hex);
@@ -112,6 +115,7 @@ impl TilePos {
     /// Returns the world position (in [`Transform`] units) associated with the top of this tile.
     ///
     /// The `y` value returned corresponds to the top of the tile topper at this location.
+    #[inline]
     #[must_use]
     pub(crate) fn top_of_tile(self, map_geometry: &MapGeometry) -> Vec3 {
         self.into_world_pos(map_geometry)
@@ -125,6 +129,7 @@ impl TilePos {
     /// Returns the nearest tile position to the provided `world_pos`
     ///
     /// `world_pos` generally corresponds to the `translation` of a [`Transform`].
+    #[inline]
     #[must_use]
     pub(crate) fn from_world_pos(world_pos: Vec3, map_geometry: &MapGeometry) -> Self {
         TilePos {
@@ -136,6 +141,8 @@ impl TilePos {
     }
 
     /// Returns the [`TilePos`] in the provided `direction` from `self`.
+    #[inline]
+    #[must_use]
     pub(crate) fn neighbor(&self, direction: Direction) -> Self {
         TilePos {
             hex: self.hex.neighbor(direction),
@@ -143,6 +150,8 @@ impl TilePos {
     }
 
     /// All adjacent tiles that are on the map.
+    #[inline]
+    #[must_use]
     pub fn all_neighbors(&self, map_geometry: &MapGeometry) -> impl IntoIterator<Item = TilePos> {
         let neighbors = self.hex.all_neighbors().map(|hex| TilePos { hex });
         let mut iter = FilteredArrayIter::from(neighbors);
@@ -151,6 +160,8 @@ impl TilePos {
     }
 
     /// All adjacent tiles that are at most [`Height::MAX_STEP`] higher or lower than `self`.
+    #[inline]
+    #[must_use]
     pub(crate) fn reachable_neighbors(
         &self,
         map_geometry: &MapGeometry,
@@ -174,6 +185,8 @@ impl TilePos {
     /// All adjacent tiles that are passable.
     ///
     /// This is distinct from [`reachable_neighbors`](Self::reachable_neighbors), which includes tiles filled with litter.
+    #[inline]
+    #[must_use]
     pub(crate) fn passable_neighbors(
         &self,
         map_geometry: &MapGeometry,
@@ -194,6 +207,8 @@ impl TilePos {
     }
 
     /// All adjacent tiles that are out of bounds.
+    #[inline]
+    #[must_use]
     pub(crate) fn out_of_bounds_neighbors(
         &self,
         map_geometry: &MapGeometry,
@@ -205,6 +220,8 @@ impl TilePos {
     }
 
     /// Returns the [`TilePos`] rotated to match the `facing` around the origin.
+    #[inline]
+    #[must_use]
     pub(crate) fn rotated(&self, facing: Facing) -> Self {
         let n_rotations = facing.rotation_count();
 
@@ -216,6 +233,8 @@ impl TilePos {
     /// Computes the flat distance between the centers of self and `other` in world coordinates.
     ///
     /// Note that this is not the same as the distance between tiles in tile coordinates!
+    #[inline]
+    #[must_use]
     #[allow(dead_code)]
     pub(crate) fn world_space_distance(&self, other: TilePos, map_geometry: &MapGeometry) -> f32 {
         let self_pos = self.into_world_pos(map_geometry).xz();
@@ -227,12 +246,16 @@ impl TilePos {
     /// Computes the length of the shortest path between the centers of self and `other` in tile coordinates.
     ///
     /// Note that this is not the same as the distance between tiles in world coordinates!
+    #[inline]
+    #[must_use]
     #[allow(dead_code)]
     pub(crate) fn manhattan_tile_distance(&self, other: TilePos) -> f32 {
         (self.hex - other.hex).length() as f32
     }
 
     /// Computes the Euclidean distance between the centers of self and `other` in tile coordinates.
+    #[inline]
+    #[must_use]
     pub(crate) fn euclidean_tile_distance(&self, other: TilePos) -> f32 {
         let [a_x, a_y, a_z] = self.hex.to_cubic_array();
         let [b_x, b_y, b_z] = other.hex.to_cubic_array();
@@ -268,6 +291,8 @@ impl Height {
     pub(crate) const STEP_HEIGHT: f32 = 1.0;
 
     /// Computes the `y` coordinate of a `Transform` that corresponds to this height.
+    #[inline]
+    #[must_use]
     pub(crate) fn into_world_pos(self) -> f32 {
         self.0 as f32 * Self::STEP_HEIGHT
     }
@@ -275,6 +300,8 @@ impl Height {
     /// Constructs a new height from the `y` coordinate of a `Transform`.
     ///
     /// Any values outside of the allowable range will be clamped to [`Height::MIN`] and [`Height::MAX`] appropriately.
+    #[inline]
+    #[must_use]
     pub(crate) fn from_world_pos(world_y: f32) -> Self {
         let f32_height = (world_y / Self::STEP_HEIGHT).round();
         if f32_height < 0. {
@@ -290,6 +317,8 @@ impl Height {
     }
 
     /// Computes the correct [`Transform`] of the column underneath a tile of this height at this position
+    #[inline]
+    #[must_use]
     pub(crate) fn column_transform(&self) -> Transform {
         let y_scale = self.into_world_pos();
         let scale = Vec3 {
@@ -394,18 +423,24 @@ impl MapGeometry {
     }
 
     /// Returns the list of valid tile positions.
+    #[inline]
+    #[must_use]
     #[cfg(test)]
     pub fn valid_tile_positions(&self) -> impl Iterator<Item = TilePos> + '_ {
         hexagon(Hex::ZERO, self.radius).map(|hex| TilePos { hex })
     }
 
     /// Is the provided `tile_pos` in the map?
+    #[inline]
+    #[must_use]
     pub(crate) fn is_valid(&self, tile_pos: TilePos) -> bool {
         let distance = Hex::ZERO.distance_to(tile_pos.hex);
         distance <= self.radius as i32
     }
 
     /// Are all of the tiles in the `footprint` centered around `center` valid?
+    #[inline]
+    #[must_use]
     pub(crate) fn is_footprint_valid(&self, tile_pos: TilePos, footprint: &Footprint) -> bool {
         footprint
             .in_world_space(tile_pos)
@@ -419,6 +454,8 @@ impl MapGeometry {
     /// Tiles that have a structure will return `false`.
     /// Tiles that are more than [`Height::MAX_STEP`] above or below the current tile will return `false`.
     /// Tiles that are completely full of litter will return `false`.
+    #[inline]
+    #[must_use]
     pub(crate) fn is_passable(&self, starting_pos: TilePos, ending_pos: TilePos) -> bool {
         if !self.is_valid(starting_pos) {
             return false;
@@ -444,6 +481,8 @@ impl MapGeometry {
     }
 
     /// Is there enough space for a structure with the provided `footprint` located at the `center` tile?
+    #[inline]
+    #[must_use]
     fn is_space_available(&self, center: TilePos, footprint: &Footprint) -> bool {
         footprint
             .in_world_space(center)
@@ -454,6 +493,8 @@ impl MapGeometry {
     /// Is there enough space for `existing_entity` to transform into a structure with the provided `footprint` located at the `center` tile?
     ///
     /// The `existing_entity` will be ignored when checking for space.
+    #[inline]
+    #[must_use]
     fn is_space_available_to_transform(
         &self,
         existing_entity: Entity,
@@ -467,6 +508,8 @@ impl MapGeometry {
     }
 
     /// Are all of the terrain tiles in the provided `footprint` appropriate?
+    #[inline]
+    #[must_use]
     fn is_terrain_valid(
         &self,
         center: TilePos,
@@ -487,6 +530,8 @@ impl MapGeometry {
     }
 
     /// Are all of the terrain tiles in the provided `footprint` flat?
+    #[inline]
+    #[must_use]
     fn is_terrain_flat(&self, center: TilePos, footprint: &Footprint) -> bool {
         let height = self.get_height(center).unwrap();
 
@@ -506,6 +551,8 @@ impl MapGeometry {
     /// - the area is flat
     /// - the area is free of structures
     /// - all tiles match the provided allowable terrain list
+    #[inline]
+    #[must_use]
     pub(crate) fn can_build(
         &self,
         center: TilePos,
@@ -529,6 +576,8 @@ impl MapGeometry {
     /// - the area is flat
     /// - the area is free of structures
     /// - all tiles match the provided allowable terrain list
+    #[inline]
+    #[must_use]
     pub(crate) fn can_transform(
         &self,
         existing_entity: Entity,
@@ -544,6 +593,7 @@ impl MapGeometry {
     }
 
     /// Updates the height of the tile at `tile_pos`
+    #[inline]
     pub(crate) fn update_height(&mut self, tile_pos: TilePos, height: Height) {
         self.height_index.insert(tile_pos, height);
     }
@@ -559,6 +609,8 @@ impl MapGeometry {
     }
 
     /// Returns the average height (in world units) of tiles around `tile_pos` within `radius`
+    #[inline]
+    #[must_use]
     pub(crate) fn average_height(&self, tile_pos: TilePos, radius: u32) -> f32 {
         let hex_iter = hexagon(tile_pos.hex, radius);
         let heights = hex_iter
@@ -573,6 +625,8 @@ impl MapGeometry {
     }
 
     /// Returns the absolute difference in height between the tile at `starting_pos` and the tile at `ending_pos`.
+    #[inline]
+    #[must_use]
     pub(crate) fn height_difference(
         &self,
         starting_pos: TilePos,
@@ -587,6 +641,8 @@ impl MapGeometry {
     ///
     /// If the `delivery_mode` is [`DeliveryMode::PickUp`], looks for litter, ghost terrain, or structures.
     /// If the `delivery_mode` is [`DeliveryMode::DropOff`], looks for ghost structures, ghost terrain or structures.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_candidates(
         &self,
         tile_pos: TilePos,
@@ -629,6 +685,8 @@ impl MapGeometry {
     /// Gets entities that units might work at, at the provided `tile_pos`.
     ///
     /// Prioritizes ghosts over structures if both are present to allow for replacing structures.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_workplaces(&self, tile_pos: TilePos) -> Vec<Entity> {
         let mut entities = Vec::new();
 
@@ -644,21 +702,27 @@ impl MapGeometry {
     }
 
     /// Gets the terrain [`Entity`] at the provided `tile_pos`, if any.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_terrain(&self, tile_pos: TilePos) -> Option<Entity> {
         self.terrain_index.get(&tile_pos).copied()
     }
 
     /// Adds the provided `terrain_entity` to the terrain index at the provided `tile_pos`.
+    #[inline]
     pub(crate) fn add_terrain(&mut self, tile_pos: TilePos, terrain_entity: Entity) {
         self.terrain_index.insert(tile_pos, terrain_entity);
     }
 
     /// Gets the structure [`Entity`] at the provided `tile_pos`, if any.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_structure(&self, tile_pos: TilePos) -> Option<Entity> {
         self.structure_index.get(&tile_pos).copied()
     }
 
     /// Adds the provided `structure_entity` to the structure index at the provided `center`.
+    #[inline]
     pub(crate) fn add_structure(
         &mut self,
         center: TilePos,
@@ -673,6 +737,7 @@ impl MapGeometry {
     /// Removes any structure entity found at the provided `tile_pos` from the structure index.
     ///
     /// Returns the removed entity, if any.
+    #[inline]
     pub(crate) fn remove_structure(&mut self, tile_pos: TilePos) -> Option<Entity> {
         let removed = self.structure_index.remove(&tile_pos);
 
@@ -686,11 +751,14 @@ impl MapGeometry {
     }
 
     /// Gets the ghost structure [`Entity`] at the provided `tile_pos`, if any.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_ghost_structure(&self, tile_pos: TilePos) -> Option<Entity> {
         self.ghost_structure_index.get(&tile_pos).copied()
     }
 
     /// Adds the provided `ghost_structure_entity` to the ghost structure index at the provided `center`.
+    #[inline]
     pub(crate) fn add_ghost_structure(
         &mut self,
         center: TilePos,
@@ -706,6 +774,7 @@ impl MapGeometry {
     /// Removes any ghost structure entity found at the provided `tile_pos` from the ghost structure index.
     ///
     /// Returns the removed entity, if any.
+    #[inline]
     pub(crate) fn remove_ghost_structure(&mut self, tile_pos: TilePos) -> Option<Entity> {
         let removed = self.ghost_structure_index.remove(&tile_pos);
 
@@ -720,6 +789,7 @@ impl MapGeometry {
     }
 
     /// Adds the provided `ghost_terrain_entity` to the ghost terrain index at the provided `tile_pos`.
+    #[inline]
     pub(crate) fn add_ghost_terrain(&mut self, ghost_terrain_entity: Entity, tile_pos: TilePos) {
         self.ghost_terrain_index
             .insert(tile_pos, ghost_terrain_entity);
@@ -728,6 +798,7 @@ impl MapGeometry {
     /// Removes any ghost terrain entity found at the provided `tile_pos` from the ghost terrain index.
     ///
     /// Returns the removed entity, if any.
+    #[inline]
     pub(crate) fn remove_ghost_terrain(&mut self, tile_pos: TilePos) -> Option<Entity> {
         let removed = self.ghost_terrain_index.remove(&tile_pos);
 
@@ -742,16 +813,21 @@ impl MapGeometry {
     }
 
     /// Gets the ghost terrain [`Entity`] at the provided `tile_pos`, if any.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_ghost_terrain(&self, tile_pos: TilePos) -> Option<Entity> {
         self.ghost_terrain_index.get(&tile_pos).copied()
     }
 
     /// Sets the amount of litter at the provided `tile_pos`.
+    #[inline]
     pub(crate) fn set_litter_state(&mut self, tile_pos: TilePos, litter_state: InventoryState) {
         self.litter_index.insert(tile_pos, litter_state);
     }
 
     /// Gets the amount of litter at the provided `tile_pos`.
+    #[inline]
+    #[must_use]
     pub(crate) fn get_litter_state(&self, tile_pos: TilePos) -> InventoryState {
         self.litter_index
             .get(&tile_pos)
@@ -773,6 +849,8 @@ pub(crate) struct Facing {
 
 impl Facing {
     /// Generates a random facing.
+    #[inline]
+    #[must_use]
     pub(crate) fn random(rng: &mut ThreadRng) -> Self {
         let direction = *Direction::ALL_DIRECTIONS.choose(rng).unwrap();
 
@@ -780,11 +858,13 @@ impl Facing {
     }
 
     /// Rotates this facing one 60 degree step clockwise.
+    #[inline]
     pub(crate) fn rotate_left(&mut self) {
         self.direction = self.direction.left();
     }
 
     /// Rotates this facing one 60 degree step counterclockwise.
+    #[inline]
     pub(crate) fn rotate_right(&mut self) {
         self.direction = self.direction.right();
     }
@@ -792,6 +872,7 @@ impl Facing {
     /// Returns the number of clockwise 60 degree rotations needed to face this direction, starting from [`Direction::Top`].
     ///
     /// This is intended to be paired with [`Hex::rotate_right`](hexx::Hex) to rotate a hex to face this direction.
+    #[inline]
     pub(crate) const fn rotation_count(&self) -> u32 {
         match self.direction {
             Direction::Top => 0,
@@ -838,6 +919,8 @@ pub(crate) enum RotationDirection {
 
 impl RotationDirection {
     /// Picks a direction to rotate in at random
+    #[inline]
+    #[must_use]
     pub(crate) fn random(rng: &mut ThreadRng) -> Self {
         match rng.gen::<bool>() {
             true => RotationDirection::Left,
@@ -847,6 +930,7 @@ impl RotationDirection {
 }
 
 /// Constructs the mesh for a single hexagonal column with the specified height.
+#[must_use]
 pub(crate) fn hexagonal_column(hex_layout: &HexLayout, hex_height: f32) -> Mesh {
     let mesh_info = MeshInfo::hexagonal_column(hex_layout, Hex::ZERO, hex_height);
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -626,7 +626,6 @@ impl MapGeometry {
 
     /// Returns the absolute difference in height between the tile at `starting_pos` and the tile at `ending_pos`.
     #[inline]
-    #[must_use]
     pub(crate) fn height_difference(
         &self,
         starting_pos: TilePos,

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -409,9 +409,19 @@ mod tests {
             let height = hill(tile_pos, &settings);
 
             if distance_from_center >= settings.radius as i32 {
-                assert_eq!(height, height_at_edge);
+                assert_eq!(
+                    height, height_at_edge,
+                    "height at {} is {}, but should be at most {}",
+                    tile_pos, height, height_at_edge
+                );
             } else {
-                assert!(height > height_at_edge);
+                assert!(
+                    height >= height_at_edge,
+                    "height at {} is {}, but should be at most {}",
+                    tile_pos,
+                    height,
+                    height_at_edge
+                );
             }
         }
     }


### PR DESCRIPTION
Fixes #718, at least so far.

> signal_diffusion_modest time:   [26.909 ms 27.052 ms 27.205 ms]
                        change: [-64.437% -64.238% -64.017%] (p = 0.00 < 0.05)
                        Performance has improved.

For the rayon step.

> signal_diffusion_modest time:   [26.345 ms 26.508 ms 26.684 ms]
                        change: [-2.8006% -2.0121% -1.1968%] (p = 0.00 < 0.05)
                        Performance has improved.

For inlining.

We still need to improve performance dramatically, but it appears that shadows are the big offender currently.