### PR TITLE
Add system to dynamically adjust camera background based on sun brightness

### DIFF
--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -2,13 +2,47 @@
 
 use bevy::prelude::*;
 
-use crate::graphics::palette::environment::SKY_SUNNY;
+use crate::graphics::palette::environment::{MIDDAY_LIGHTNESS, SKY_SUNNY};
+
+use super::lighting::{CelestialBody, Sun};
 
 /// Logic and resources to modify the sky and atmosphere.
 pub(super) struct AtmospherePlugin;
 
 impl Plugin for AtmospherePlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(ClearColor(SKY_SUNNY));
+        app.insert_resource(ClearColor(SKY_SUNNY))
+            .add_system(animate_sky_color);
+    }
+}
+
+/// Changes the ClearColor resource which drives the sky color based on the illuminance from the Sun.
+fn animate_sky_color(
+    mut clear_color: ResMut<ClearColor>,
+    query: Query<(&CelestialBody, &Sun), Changed<CelestialBody>>,
+) {
+    for (celestial_body, _) in query.iter() {
+        let max_illuminance = celestial_body.compute_max_light();
+        let current_illuminance = celestial_body.compute_light();
+
+        let [hue, saturation, _, alpha] = clear_color.0.as_hsla_f32();
+
+        // The midday lightness is the ideal lightness at noon.
+        //
+        // Scaling up the max illuminance by the midday lightness ensures
+        // we reach the max_illuminance at the same time we reach midday lightness.
+        let target_scaled_max_illuminance = max_illuminance.0 / MIDDAY_LIGHTNESS;
+
+        // Calculate a percentage of lightness of the given max illuminance
+        let lightness = current_illuminance.0 / target_scaled_max_illuminance;
+
+        let new_sky = Color::Hsla {
+            hue,
+            saturation,
+            lightness,
+            alpha,
+        };
+
+        clear_color.0 = new_sky;
     }
 }

--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -16,7 +16,7 @@ impl Plugin for AtmospherePlugin {
     }
 }
 
-/// Changes the ClearColor resource which drives the sky color based on the illuminance from the Sun.
+/// Changes the `ClearColor` resource which drives the sky color based on the illuminance from the Sun.
 fn animate_sky_color(
     mut clear_color: ResMut<ClearColor>,
     query: Query<(&CelestialBody, &PrimaryCelestialBody), Changed<CelestialBody>>,

--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 use crate::graphics::palette::environment::{MIDDAY_LIGHTNESS, SKY_SUNNY};
 
-use super::lighting::{CelestialBody, Sun};
+use super::lighting::{CelestialBody, PrimaryCelestialBody};
 
 /// Logic and resources to modify the sky and atmosphere.
 pub(super) struct AtmospherePlugin;
@@ -19,7 +19,7 @@ impl Plugin for AtmospherePlugin {
 /// Changes the ClearColor resource which drives the sky color based on the illuminance from the Sun.
 fn animate_sky_color(
     mut clear_color: ResMut<ClearColor>,
-    query: Query<(&CelestialBody, &Sun), Changed<CelestialBody>>,
+    query: Query<(&CelestialBody, &PrimaryCelestialBody), Changed<CelestialBody>>,
 ) {
     for (celestial_body, _) in query.iter() {
         let max_illuminance = celestial_body.compute_max_light();

--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -28,9 +28,7 @@ fn animate_sky_color(
         let [hue, saturation, _, alpha] = clear_color.0.as_hsla_f32();
 
         // The midday lightness is the ideal lightness at noon.
-        //
-        // Scaling up the max illuminance by the midday lightness ensures
-        // we reach the max_illuminance at the same time we reach midday lightness.
+        // Scaling up the max_illuminance by the midday lightness ensures we reach midday lightness.
         let target_scaled_max_illuminance = max_illuminance.0 / MIDDAY_LIGHTNESS;
 
         // Calculate a percentage of lightness of the given max illuminance

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -113,9 +113,6 @@ impl CelestialBody {
 #[derive(Component, Debug)]
 pub(crate) struct Sun;
 
-#[derive(Component, Debug)]
-pub(crate) struct Moon;
-
 /// Spawns a directional light source to illuminate the scene
 #[allow(dead_code)]
 fn spawn_celestial_bodies(mut commands: Commands) {
@@ -161,8 +158,7 @@ fn spawn_celestial_bodies(mut commands: Commands) {
             },
             ..default()
         })
-        .insert(moon)
-        .insert(Moon);
+        .insert(moon);
 }
 
 /// Moves celestial bodies to the correct position and orientation

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -64,8 +64,7 @@ impl CelestialBody {
         CelestialBody::compute_illuminance(self.hour_angle, self.declination, self.illuminance)
     }
 
-    /// Computes the maximum total irradiance produced by
-    /// this celestial body based on its brightest possible position in the sky.
+    /// Computes the maximum total irradiance produced by this celestial body based on its brightest possible position in the sky.
     pub(crate) fn compute_max_light(&self) -> Illuminance {
         CelestialBody::compute_illuminance(
             CelestialBody::DEFAULT_NOON_RADIANS,

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -68,7 +68,7 @@ impl CelestialBody {
     pub(crate) fn compute_max_light(&self) -> Illuminance {
         CelestialBody::compute_illuminance(
             CelestialBody::DEFAULT_NOON_RADIANS,
-            CelestialBody::DEFAULT_NOON_RADIANS,
+            self.declination,
             self.illuminance,
         )
     }

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -73,7 +73,7 @@ impl CelestialBody {
         )
     }
 
-    /// Computes the total irradiance produced by a celestial body given hour_angle, declination, and illuminance.
+    /// Computes the total irradiance produced by a celestial body given `hour_angle`, `declination`, and `illuminance`.
     fn compute_illuminance(hour_angle: f32, declination: f32, illuminance: f32) -> Illuminance {
         // Computes the total angle formed by the celestial body and the horizon
         //

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -56,16 +56,34 @@ pub(crate) struct CelestialBody {
 }
 
 impl CelestialBody {
+    /// The default angle that the sun is offset from the zenith in radians.
+    const DEFAULT_NOON_RADIANS: f32 = 23.5 / 360.;
+
     /// Computes the total irradiance produced by this celestial body based on its position in the sky.
     pub(crate) fn compute_light(&self) -> Illuminance {
+        CelestialBody::compute_illuminance(self.hour_angle, self.declination, self.illuminance)
+    }
+
+    /// Computes the maximum total irradiance produced by
+    /// this celestial body based on its brightest possible position in the sky.
+    pub(crate) fn compute_max_light(&self) -> Illuminance {
+        CelestialBody::compute_illuminance(
+            CelestialBody::DEFAULT_NOON_RADIANS,
+            CelestialBody::DEFAULT_NOON_RADIANS,
+            self.illuminance,
+        )
+    }
+
+    /// Computes the total irradiance produced by a celestial body given hour_angle, declination, and illuminance.
+    fn compute_illuminance(hour_angle: f32, declination: f32, illuminance: f32) -> Illuminance {
         // Computes the total angle formed by the celestial body and the horizon
         //
         // We cannot simply use the progress, as the inclination also needs to be taken into account.
         // See https://en.wikipedia.org/wiki/Solar_zenith_angle
         // We're treating the latitude here as equatorial.
-        let cos_solar_zenith_angle = self.hour_angle.cos() * self.declination.cos();
+        let cos_solar_zenith_angle = hour_angle.cos() * declination.cos();
         let solar_zenith_angle = cos_solar_zenith_angle.acos();
-        Illuminance(self.illuminance * solar_zenith_angle.cos().max(0.))
+        Illuminance(illuminance * solar_zenith_angle.cos().max(0.))
     }
 
     /// The starting settings for the sun
@@ -73,7 +91,7 @@ impl CelestialBody {
         CelestialBody {
             height: 2. * Height::MAX.into_world_pos(),
             hour_angle: -PI / 4.,
-            declination: 23.5 / 360. * PI / 2.,
+            declination: CelestialBody::DEFAULT_NOON_RADIANS * PI / 2.,
             travel_axis: 0.,
             illuminance: 8e4,
             days_per_cycle: 1.0,
@@ -85,13 +103,19 @@ impl CelestialBody {
         CelestialBody {
             height: 2. * Height::MAX.into_world_pos(),
             hour_angle: 0.,
-            declination: 23.5 / 360. * PI / 2.,
+            declination: CelestialBody::DEFAULT_NOON_RADIANS * PI / 2.,
             travel_axis: PI / 6.,
             illuminance: 3e4,
             days_per_cycle: 29.53,
         }
     }
 }
+
+#[derive(Component, Debug)]
+pub(crate) struct Sun;
+
+#[derive(Component, Debug)]
+pub(crate) struct Moon;
 
 /// Spawns a directional light source to illuminate the scene
 #[allow(dead_code)]
@@ -124,7 +148,8 @@ fn spawn_celestial_bodies(mut commands: Commands) {
             },
             ..default()
         })
-        .insert(sun);
+        .insert(sun)
+        .insert(Sun);
 
     let moon = CelestialBody::moon();
     commands
@@ -137,7 +162,8 @@ fn spawn_celestial_bodies(mut commands: Commands) {
             },
             ..default()
         })
-        .insert(moon);
+        .insert(moon)
+        .insert(Moon);
 }
 
 /// Moves celestial bodies to the correct position and orientation

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -110,8 +110,9 @@ impl CelestialBody {
     }
 }
 
+/// This component signals that this Entity is the primary celestial body for lighting.
 #[derive(Component, Debug)]
-pub(crate) struct Sun;
+pub(crate) struct PrimaryCelestialBody;
 
 /// Spawns a directional light source to illuminate the scene
 #[allow(dead_code)]
@@ -145,7 +146,7 @@ fn spawn_celestial_bodies(mut commands: Commands) {
             ..default()
         })
         .insert(sun)
-        .insert(Sun);
+        .insert(PrimaryCelestialBody);
 
     let moon = CelestialBody::moon();
     commands

--- a/emergence_lib/src/graphics/palette.rs
+++ b/emergence_lib/src/graphics/palette.rs
@@ -235,13 +235,17 @@ pub(crate) mod environment {
 
     /// The color used for columns of dirt underneath tiles
     pub(crate) const COLUMN_COLOR: Color = Color::hsl(21., 0.6, 0.15);
+
     /// The color of a clear and sunny sky.
     pub(crate) const SKY_SUNNY: Color = Color::Hsla {
         hue: 202.,
         saturation: 0.8,
-        lightness: 0.8,
+        lightness: MIDDAY_LIGHTNESS,
         alpha: 1.0,
     };
+
+    /// The amount of lightness at the brightest point in a day cycle
+    pub(crate) const MIDDAY_LIGHTNESS: f32 = 0.8;
 }
 
 /// Colors used for lighting


### PR DESCRIPTION
Played around with it, and landed on something that nicely (to me) matches the lightness of the hexes changing through a day cycle.

Including the moon celestial body into the lightness calculation was a bit wonky, and resulted in lightness shifts that felt really off. I added a Sun component to differentiate the two CelestialBody/DirectionalLight entities, as the visual background lighting really only feels like it should come from the sun.

I added a function on the CelestialBody to get the maximum illuminance for a given object, and refactored it a little to promote a bit of code reuse. This was to ensure we don't need a one-off constant of 100,000; to help with aligning the lightness of the Color with the calculated Illuminance. Made some other things constants, so they could all be linked without needing to remember 🧠. 

In the future, if CelestialBody declination is adjusted/dynamic, calculating the max illumination should all still work without needing to think about it (dark will always be dark, and light will always be at or under SKY_SUNNY lightness).