### PR TITLE
Add toon shader from `bevy_toon_shader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_toon_shader"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a314af8d43fd4241aa248f6ebb6d37410a8a78175db86434b7e19f4f016584b2"
+dependencies = [
+ "bevy",
+]
+
+[[package]]
 name = "bevy_transform"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1702,7 @@ dependencies = [
  "bevy_mod_billboard",
  "bevy_mod_raycast",
  "bevy_screen_diagnostics",
+ "bevy_toon_shader",
  "criterion",
  "debug_tools",
  "derive_more",

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1.0.69"
 serde_json = "1.0.94"
 hashbrown = { version = "0.12", features = ["rayon"] }
 rayon = "1.7.0"
+bevy_toon_shader = "0.1.0"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/emergence_lib/src/graphics/lighting.rs
+++ b/emergence_lib/src/graphics/lighting.rs
@@ -3,6 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::prelude::*;
+use bevy_toon_shader::ToonShaderSun;
 
 use crate::{
     graphics::palette::lighting::{LIGHT_MOON, LIGHT_STARS, LIGHT_SUN},
@@ -146,7 +147,9 @@ fn spawn_celestial_bodies(mut commands: Commands) {
             ..default()
         })
         .insert(sun)
-        .insert(PrimaryCelestialBody);
+        .insert(PrimaryCelestialBody)
+        // This causes the light direction to be updated automatically for the toon shaded materials
+        .insert(ToonShaderSun);
 
     let moon = CelestialBody::moon();
     commands

--- a/emergence_lib/src/player_interaction/camera.rs
+++ b/emergence_lib/src/player_interaction/camera.rs
@@ -9,6 +9,7 @@ use bevy::input::mouse::MouseMotion;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
 use bevy_mod_raycast::RaycastSource;
+use bevy_toon_shader::ToonShaderMainCamera;
 use leafwing_input_manager::orientation::Rotation;
 use leafwing_input_manager::prelude::ActionState;
 
@@ -78,6 +79,7 @@ fn setup_camera(mut commands: Commands) {
         })
         .insert(settings)
         .insert(focus)
+        .insert(ToonShaderMainCamera)
         .insert(RaycastSource::<Terrain>::new())
         .insert(RaycastSource::<Structure>::new())
         .insert(RaycastSource::<Unit>::new())


### PR DESCRIPTION
To do:

- [ ] do asset preprocessing to swap out all materials from loaded scenes to use the equivalent toon-shaded material

Blockers:

- [ ] it does not appear possible to adjust the overall light intensity
