### PR TITLE
Update CI workflows to match current arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,100 +13,35 @@ env:
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
 jobs:
-  check-format:
+  checks:
     runs-on: ubuntu-latest
+    strategy:
+      # Default is `true`
+      fail-fast: false
+      matrix:
+        ci-argument:
+          - clippy
+          - compilecheck
+          - doccheck
+          - doctest
+          - format
+          - test
+        include:
+          - ci-argument: clippy
+            toolchain-components: clippy
+          - ci-arguments: format
+            toolchain-components: rustfmt
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: rustfmt, clippy
+          components: ${{ matrix.toolchain-components }}
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- format
-
-  check-clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-      - name: CI job
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- clippy
-
-  check-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: Build & run tests
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- test
-
-  check-compiles:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: Check Compile
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- compilecheck
-
-  check-doccheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-        if: runner.os == 'linux'
-      - name: Build and check doc
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doccheck
-
-  check-doctest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-        if: runner.os == 'linux'
-      - name: Build and check doc
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doctest
-  #      - name: Installs cargo-deadlinks
-  #        run: cargo install --force cargo-deadlinks
-  #      - name: Checks dead links
-  #        run: cargo deadlinks
+        run: cargo run -p ci -- ${{ matrix.ci-argument }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: ${{ matrix.toolchain-components }}
+          # components: ${{ matrix.toolchain-components }}
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
 
-  check-doc:
+  check-doctest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
         if: runner.os == 'linux'
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doc
+        run: cargo run -p ci -- doctest
   #      - name: Installs cargo-deadlinks
   #        run: cargo install --force cargo-deadlinks
   #      - name: Checks dead links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,16 @@ jobs:
           - test
         include:
           - ci-argument: clippy
-            toolchain-components: foo
-          - ci-argument: compilecheck
-            toolchain-components: bar
-          - ci-argument: doccheck
-            toolchain-components: baz
-          - ci-argument: doctest
-            toolchain-components: quux
+            toolchain-components: clippy
           - ci-argument: format
-            toolchain-components: zugga
-          - ci-argument: test
-            toolchain-components: lugga
+            toolchain-components: rustfmt
 
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: ${{ matrix.toolchain-components }}
+          components: ${{ matrix.toolchain-components || null }}
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,24 @@ jobs:
           - test
         include:
           - ci-argument: clippy
-            toolchain-components: clippy
-          - ci-arguments: format
-            toolchain-components: rustfmt
+            toolchain-components: foo
+          - ci-argument: compilecheck
+            toolchain-components: bar
+          - ci-argument: doccheck
+            toolchain-components: baz
+          - ci-argument: doctest
+            toolchain-components: quux
+          - ci-argument: format
+            toolchain-components: zugga
+          - ci-argument: test
+            toolchain-components: lugga
 
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          # components: ${{ matrix.toolchain-components }}
+          components: ${{ matrix.toolchain-components }}
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             toolchain-components: clippy
           - ci-argument: format
             toolchain-components: rustfmt
-
+    name: CI check (${{ matrix.ci-argument }})
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
 jobs:
-  check-lints:
+  check-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,23 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- lints
+        run: cargo run -p ci -- format
+
+  check-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: CI job
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- clippy
 
   check-tests:
     runs-on: ubuntu-latest
@@ -57,7 +73,23 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- compile
+        run: cargo run -p ci -- compilecheck
+
+  check-doccheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+        if: runner.os == 'linux'
+      - name: Build and check doc
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- doccheck
 
   check-doctest:
     runs-on: ubuntu-latest

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -6,6 +6,8 @@
 //! - Official CI runs latest stable
 //! - Local runs use whatever the default Rust is locally
 
+use std::process;
+
 use bevy::utils::HashSet;
 use xshell::{cmd, Shell};
 
@@ -84,7 +86,7 @@ fn main() {
                     .collect::<Vec<&str>>()
                     .join(", "),
             );
-            return;
+            process::exit(1);
         }
     } else {
         Check::all()


### PR DESCRIPTION
[Recent changes](https://github.com/Leafwing-Studios/Emergence/pull/744) to the tools/ci package caused some of the CI checks to begin [failing silently](https://github.com/Leafwing-Studios/Emergence/actions/runs/4724055668/jobs/8380794176).

Included in this PR:

- Update the ci/tools app to provide an exit code if it detects an invalid check argument.
- Updates the CI workflow to pass currently expected arguments.
- Add a matrix to the CI workflow to reduce repetitiveness in jobs.