### PR TITLE
Flatten tiles before trying to generate structures on them

### DIFF
--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -611,11 +611,10 @@ pub(super) fn validate_ghost_structures(
         return;
     }
 
-    for (&tile_pos, &structure_id, &facing) in ghost_query.iter() {
+    for (&tile_pos, &structure_id, facing) in ghost_query.iter() {
         let structure_details = structure_manifest.get(structure_id);
-        let footprint = structure_details.footprint.rotated(facing);
 
-        if !map_geometry.can_build(tile_pos, &footprint) {
+        if !map_geometry.can_build(tile_pos, &structure_details.footprint, facing) {
             commands.despawn_ghost_structure(tile_pos);
         }
     }

--- a/emergence_lib/src/construction/ghosts.rs
+++ b/emergence_lib/src/construction/ghosts.rs
@@ -615,7 +615,7 @@ pub(super) fn validate_ghost_structures(
         let structure_details = structure_manifest.get(structure_id);
         let footprint = structure_details.footprint.rotated(facing);
 
-        if !map_geometry.can_build(tile_pos, footprint) {
+        if !map_geometry.can_build(tile_pos, &footprint) {
             commands.despawn_ghost_structure(tile_pos);
         }
     }

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -223,7 +223,7 @@ fn mark_based_on_zoning(
                 let footprint =
                     structure_manifest.construction_footprint(clipboard_data.structure_id);
 
-                if map_geometry.can_build(tile_pos, footprint.rotated(clipboard_data.facing)) {
+                if map_geometry.can_build(tile_pos, &footprint.rotated(clipboard_data.facing)) {
                     commands.spawn_ghost_structure(tile_pos, clipboard_data.clone())
                 } else {
                     *zoning = Zoning::None;

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -223,7 +223,7 @@ fn mark_based_on_zoning(
                 let footprint =
                     structure_manifest.construction_footprint(clipboard_data.structure_id);
 
-                if map_geometry.can_build(tile_pos, &footprint.rotated(clipboard_data.facing)) {
+                if map_geometry.can_build(tile_pos, &footprint, &clipboard_data.facing) {
                     commands.spawn_ghost_structure(tile_pos, clipboard_data.clone())
                 } else {
                     *zoning = Zoning::None;

--- a/emergence_lib/src/crafting/components.rs
+++ b/emergence_lib/src/crafting/components.rs
@@ -70,6 +70,17 @@ pub(crate) enum CraftingState {
     NoRecipe,
 }
 
+impl CraftingState {
+    pub(crate) fn randomize(&mut self, rng: &mut ThreadRng, recipe_data: &RecipeData) {
+        let distribution = Uniform::new(Duration::ZERO, recipe_data.craft_time);
+        let progress = distribution.sample(rng);
+        *self = CraftingState::InProgress {
+            progress,
+            required: recipe_data.craft_time,
+        };
+    }
+}
+
 impl Display for CraftingState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let string = match self {
@@ -253,7 +264,7 @@ impl InputInventory {
     /// Randomizes the contents of this inventory so that each slot is somewhere between empty and full.
     ///
     /// Note that this only works for [`InputInventory::Exact`].
-    pub(super) fn randomize(&mut self, rng: &mut ThreadRng) {
+    pub(crate) fn randomize(&mut self, rng: &mut ThreadRng) {
         if let InputInventory::Exact { inventory } = self {
             for item_slot in inventory.iter_mut() {
                 item_slot.randomize(rng);
@@ -300,7 +311,7 @@ pub(crate) struct OutputInventory {
 
 impl OutputInventory {
     /// Randomizes the contents of this inventory so that each slot is somewhere between empty and full.
-    pub(super) fn randomize(&mut self, rng: &mut ThreadRng) {
+    pub(crate) fn randomize(&mut self, rng: &mut ThreadRng) {
         for item_slot in self.iter_mut() {
             item_slot.randomize(rng);
         }
@@ -528,49 +539,6 @@ impl CraftingBundle {
                 emitter: Emitter::default(),
                 workers_present: WorkersPresent::new(max_workers),
             }
-        }
-    }
-
-    /// Generates a new crafting bundle that is at a random point in its cycle.
-    pub(crate) fn randomized(
-        structure_id: Id<Structure>,
-        starting_recipe: ActiveRecipe,
-        recipe_manifest: &RecipeManifest,
-        item_manifest: &ItemManifest,
-        structure_manifest: &StructureManifest,
-        rng: &mut ThreadRng,
-    ) -> Self {
-        if let Some(recipe_id) = starting_recipe.0 {
-            let recipe = recipe_manifest.get(recipe_id);
-
-            let mut input_inventory = recipe.input_inventory(item_manifest);
-            input_inventory.randomize(rng);
-            let mut output_inventory = recipe.output_inventory(item_manifest);
-            output_inventory.randomize(rng);
-
-            let distribution = Uniform::new(Duration::ZERO, recipe.craft_time);
-            let progress = distribution.sample(rng);
-            let max_workers = structure_manifest.get(structure_id).max_workers;
-
-            Self {
-                input_inventory,
-                output_inventory,
-                active_recipe: ActiveRecipe(Some(recipe_id)),
-                craft_state: CraftingState::InProgress {
-                    progress,
-                    required: recipe.craft_time,
-                },
-                emitter: Emitter::default(),
-                workers_present: WorkersPresent::new(max_workers),
-            }
-        } else {
-            CraftingBundle::new(
-                structure_id,
-                starting_recipe,
-                recipe_manifest,
-                item_manifest,
-                structure_manifest,
-            )
         }
     }
 }

--- a/emergence_lib/src/organisms/lifecycle.rs
+++ b/emergence_lib/src/organisms/lifecycle.rs
@@ -303,7 +303,7 @@ pub(super) fn sprout_seeds(
                 let variety = structure_manifest.get(structure_id);
                 let footprint = variety.footprint.rotated(facing);
 
-                if !map_geometry.can_build(tile_pos, footprint) {
+                if !map_geometry.can_build(tile_pos, &footprint) {
                     // We can't germinate here
                     continue;
                 }

--- a/emergence_lib/src/organisms/lifecycle.rs
+++ b/emergence_lib/src/organisms/lifecycle.rs
@@ -218,14 +218,13 @@ pub(super) fn transform_when_lifecycle_complete(
     map_geometry: Res<MapGeometry>,
     mut commands: Commands,
 ) {
-    for (entity, lifecycle, &tile_pos, &facing, maybe_unit) in query.iter() {
+    for (entity, lifecycle, &tile_pos, facing, maybe_unit) in query.iter() {
         for new_form in lifecycle.new_forms() {
             // Make sure that there's a valid place to spawn the new form.
             if let OrganismId::Structure(structure_id) = new_form {
                 let variety = structure_manifest.get(structure_id);
-                let footprint = variety.footprint.rotated(facing);
 
-                if !map_geometry.can_transform(entity, tile_pos, footprint) {
+                if !map_geometry.can_transform(entity, tile_pos, &variety.footprint, facing) {
                     // Look for another viable form to transform into.
                     continue;
                 }
@@ -242,7 +241,7 @@ pub(super) fn transform_when_lifecycle_complete(
                 OrganismId::Structure(structure_id) => {
                     let data = ClipboardData {
                         structure_id,
-                        facing,
+                        facing: *facing,
                         active_recipe: structure_manifest
                             .get(structure_id)
                             .starting_recipe()
@@ -301,9 +300,8 @@ pub(super) fn sprout_seeds(
             // Make sure that there's a valid place to spawn the new form.
             if let OrganismId::Structure(structure_id) = organism_id {
                 let variety = structure_manifest.get(structure_id);
-                let footprint = variety.footprint.rotated(facing);
 
-                if !map_geometry.can_build(tile_pos, &footprint) {
+                if !map_geometry.can_build(tile_pos, &variety.footprint, &facing) {
                     // We can't germinate here
                     continue;
                 }

--- a/emergence_lib/src/player_interaction/clipboard.rs
+++ b/emergence_lib/src/player_interaction/clipboard.rs
@@ -9,7 +9,7 @@ use crate::{
     construction::{ghosts::Preview, terraform::TerraformingTool},
     crafting::components::ActiveRecipe,
     simulation::geometry::{Facing, MapGeometry, TilePos},
-    structures::structure_manifest::Structure,
+    structures::structure_manifest::{Structure, StructureManifest},
 };
 
 use super::{
@@ -87,6 +87,27 @@ pub(crate) struct ClipboardData {
     pub(crate) facing: Facing,
     /// The recipe that this structure makes, if any
     pub(crate) active_recipe: ActiveRecipe,
+}
+
+impl ClipboardData {
+    /// Creates a new [`ClipboardData`] for the given `structure_id`.
+    ///
+    /// The starting properties are determined by the `structure_manifest`.
+    /// This is intended to be used during world generation.
+    #[must_use]
+    pub(crate) fn generate_from_id(
+        structure_id: Id<Structure>,
+        structure_manifest: &StructureManifest,
+    ) -> Self {
+        Self {
+            structure_id,
+            facing: Facing::default(),
+            active_recipe: structure_manifest
+                .get(structure_id)
+                .starting_recipe()
+                .clone(),
+        }
+    }
 }
 
 impl Tool {

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -716,7 +716,7 @@ fn emit_signals(
         match maybe_structure_id {
             // Signals should be emitted from all tiles in the footprint of a structure.
             Some(structure_id) => {
-                let facing = *maybe_facing.expect("Structures must have a facing");
+                let facing = maybe_facing.expect("Structures must have a facing");
                 let footprint = &structure_manifest
                     .get(*structure_id)
                     .footprint

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -424,7 +424,6 @@ impl MapGeometry {
     /// Returns the list of valid tile positions.
     #[inline]
     #[must_use]
-    #[cfg(test)]
     pub fn valid_tile_positions(&self) -> impl Iterator<Item = TilePos> + '_ {
         hexagon(Hex::ZERO, self.radius).map(|hex| TilePos { hex })
     }

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -447,6 +447,7 @@ impl MapGeometry {
         facing: &Facing,
     ) -> bool {
         footprint
+            .rotated(facing)
             .in_world_space(tile_pos)
             .iter()
             .all(|tile_pos| self.is_valid(*tile_pos))
@@ -508,10 +509,14 @@ impl MapGeometry {
         footprint: &Footprint,
         facing: &Facing,
     ) -> bool {
-        footprint.in_world_space(center).iter().all(|tile_pos| {
-            let entity = self.get_structure(*tile_pos);
-            entity.is_none() || entity == Some(existing_entity)
-        })
+        footprint
+            .rotated(facing)
+            .in_world_space(center)
+            .iter()
+            .all(|tile_pos| {
+                let entity = self.get_structure(*tile_pos);
+                entity.is_none() || entity == Some(existing_entity)
+            })
     }
 
     /// Are all of the terrain tiles in the provided `footprint` flat?
@@ -526,6 +531,7 @@ impl MapGeometry {
         let height = self.get_height(center).unwrap();
 
         footprint
+            .rotated(facing)
             .in_world_space(center)
             .iter()
             .all(|tile_pos| self.get_height(*tile_pos) == Ok(height))

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -485,13 +485,13 @@ impl MapGeometry {
     #[must_use]
     pub(crate) fn is_space_available(
         &self,
-        center: TilePos,
+        tile_pos: TilePos,
         footprint: &Footprint,
         facing: &Facing,
     ) -> bool {
         footprint
             .rotated(facing)
-            .in_world_space(center)
+            .in_world_space(tile_pos)
             .iter()
             .all(|tile_pos| self.get_structure(*tile_pos).is_none())
     }
@@ -625,6 +625,22 @@ impl MapGeometry {
         let starting_height = self.get_height(starting_pos)?;
         let ending_height = self.get_height(ending_pos)?;
         Ok(Height(starting_height.abs_diff(ending_height.0)))
+    }
+
+    /// Flattens the terrain in the `footprint` around `tile_pos` to the height at that location.
+    ///
+    /// This footprint is rotated by the supplied `facing`.
+    pub(crate) fn flatten_height(
+        &mut self,
+        tile_pos: TilePos,
+        footprint: &Footprint,
+        facing: &Facing,
+    ) {
+        let height = self.get_height(tile_pos).unwrap();
+        let rotated_footprint = footprint.rotated(facing);
+        for tile_pos in rotated_footprint.in_world_space(tile_pos) {
+            self.update_height(tile_pos, height);
+        }
     }
 
     /// Gets the [`Entity`] at the provided `tile_pos` that might have or want an item.

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -478,7 +478,7 @@ impl MapGeometry {
     /// Is there enough space for a structure with the provided `footprint` located at the `center` tile?
     #[inline]
     #[must_use]
-    fn is_space_available(&self, center: TilePos, footprint: &Footprint) -> bool {
+    pub(crate) fn is_space_available(&self, center: TilePos, footprint: &Footprint) -> bool {
         footprint
             .in_world_space(center)
             .iter()
@@ -505,7 +505,7 @@ impl MapGeometry {
     /// Are all of the terrain tiles in the provided `footprint` flat?
     #[inline]
     #[must_use]
-    fn is_terrain_flat(&self, center: TilePos, footprint: &Footprint) -> bool {
+    pub(crate) fn is_terrain_flat(&self, center: TilePos, footprint: &Footprint) -> bool {
         let height = self.get_height(center).unwrap();
 
         footprint
@@ -526,7 +526,7 @@ impl MapGeometry {
     /// - all tiles match the provided allowable terrain list
     #[inline]
     #[must_use]
-    pub(crate) fn can_build(&self, center: TilePos, footprint: Footprint) -> bool {
+    pub(crate) fn can_build(&self, center: TilePos, footprint: &Footprint) -> bool {
         self.is_footprint_valid(center, &footprint)
             && self.is_terrain_flat(center, &footprint)
             && self.is_space_available(center, &footprint)

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -632,14 +632,20 @@ impl MapGeometry {
     /// This footprint is rotated by the supplied `facing`.
     pub(crate) fn flatten_height(
         &mut self,
+        height_query: &mut Query<&mut Height>,
         tile_pos: TilePos,
         footprint: &Footprint,
         facing: &Facing,
     ) {
-        let height = self.get_height(tile_pos).unwrap();
+        let Ok(target_height) = self.get_height(tile_pos) else { return };
         let rotated_footprint = footprint.rotated(facing);
         for tile_pos in rotated_footprint.in_world_space(tile_pos) {
-            self.update_height(tile_pos, height);
+            if let Some(entity) = self.get_terrain(tile_pos) {
+                if let Ok(mut height) = height_query.get_mut(entity) {
+                    *height = target_height;
+                    self.update_height(tile_pos, target_height);
+                }
+            }
         }
     }
 

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -4,7 +4,6 @@ use bevy::{
     ecs::system::Command,
     prelude::{warn, Commands, DespawnRecursiveExt, Mut, World},
 };
-use rand::thread_rng;
 
 use crate::{
     construction::ghosts::{GhostHandles, GhostKind, GhostStructureBundle, StructurePreviewBundle},
@@ -128,7 +127,6 @@ impl Command for SpawnStructureCommand {
             .id();
 
         // PERF: these operations could be done in a single archetype move with more branching
-        let rng = &mut thread_rng();
         if let Some(organism_details) = &structure_variety.organism_variety {
             let energy_pool = organism_details.energy_pool.clone();
 

--- a/emergence_lib/src/structures/commands.rs
+++ b/emergence_lib/src/structures/commands.rs
@@ -130,27 +130,49 @@ impl Command for SpawnStructureCommand {
         let structure_variety = manifest.get(structure_id).clone();
 
         // Check that the tiles needed are appropriate.
-        let rotated_footprint = structure_variety.footprint.rotated(self.data.facing);
-
-        if !geometry.can_build(self.tile_pos, &rotated_footprint) {
+        if !geometry.can_build(
+            self.tile_pos,
+            &structure_variety.footprint,
+            &self.data.facing,
+        ) {
             if self.fix_terrain {
-                if !geometry.is_footprint_valid(self.tile_pos, &rotated_footprint) {
+                if !geometry.is_footprint_valid(
+                    self.tile_pos,
+                    &structure_variety.footprint,
+                    &self.data.facing,
+                ) {
                     // Nothing we can do about out-of-bounds :(
                     return;
                 }
 
-                if !geometry.is_space_available(self.tile_pos, &rotated_footprint) {
+                if !geometry.is_space_available(
+                    self.tile_pos,
+                    &structure_variety.footprint,
+                    &self.data.facing,
+                ) {
                     // Don't try to remove existing structures.
                     // Instead, generate structures in order of importance.
                     return;
                 }
 
-                if !geometry.is_terrain_flat(self.tile_pos, &rotated_footprint) {
+                if !geometry.is_terrain_flat(
+                    self.tile_pos,
+                    &structure_variety.footprint,
+                    &self.data.facing,
+                ) {
                     // Flatten the terrain if it's not flat.
-                    geometry.flatten_terrain(self.tile_pos, &rotated_footprint);
+                    geometry.flatten_terrain(
+                        self.tile_pos,
+                        &structure_variety.footprint,
+                        &self.data.facing,
+                    );
                 }
 
-                assert!(geometry.can_build(self.tile_pos, &rotated_footprint));
+                assert!(geometry.can_build(
+                    self.tile_pos,
+                    &structure_variety.footprint,
+                    &self.data.facing,
+                ));
             } else {
                 // Most of the time, we should just give up if the terrain is wrong.
                 return;
@@ -290,10 +312,7 @@ impl Command for SpawnStructureGhostCommand {
         let construction_footprint = manifest.construction_footprint(structure_id);
 
         // Check that the tiles needed are appropriate.
-        if !geometry.can_build(
-            self.tile_pos,
-            &construction_footprint.rotated(self.data.facing),
-        ) {
+        if !geometry.can_build(self.tile_pos, &construction_footprint, &self.data.facing) {
             return;
         }
 
@@ -397,7 +416,8 @@ impl Command for SpawnStructurePreviewCommand {
         // Check that the tiles needed are appropriate.
         let forbidden = !geometry.can_build(
             self.tile_pos,
-            &structure_variety.footprint.rotated(self.data.facing),
+            &structure_variety.footprint,
+            &self.data.facing,
         );
 
         // Fetch the scene and material to use

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -129,10 +129,10 @@ impl Footprint {
     }
 
     /// Rotates the footprint by the provided [`Facing`].
-    pub(crate) fn rotated(&self, facing: Facing) -> Self {
+    pub(crate) fn rotated(&self, facing: &Facing) -> Self {
         let mut set = HashSet::new();
         for &tile_pos in self.set.iter() {
-            set.insert(tile_pos.rotated(facing));
+            set.insert(tile_pos.rotated(*facing));
         }
 
         Footprint { set }

--- a/emergence_lib/src/ui/ui_assets.rs
+++ b/emergence_lib/src/ui/ui_assets.rs
@@ -52,10 +52,13 @@ pub(crate) struct Icons<D: Send + Sync + 'static> {
     map: HashMap<D, Handle<Image>>,
 }
 
-impl<D: Send + Sync + 'static + Hash + Eq> Icons<D> {
+impl<D: Send + Sync + 'static + Hash + Eq + Debug> Icons<D> {
     /// Returns a weakly cloned handle to the image of the icon corresponding to `key`.
     pub(crate) fn get(&self, key: D) -> Handle<Image> {
-        self.map.get(&key).unwrap().clone_weak()
+        self.map
+            .get(&key)
+            .unwrap_or_else(|| panic!("Key {key:?} was not found in map of loaded icons."))
+            .clone_weak()
     }
 }
 

--- a/emergence_lib/src/ui/ui_assets.rs
+++ b/emergence_lib/src/ui/ui_assets.rs
@@ -220,6 +220,7 @@ impl FromWorld for Icons<GoalKind> {
             GoalKind::Wander,
             asset_server.load("icons/goals/wander.png"),
         );
+        map.insert(GoalKind::Work, asset_server.load("icons/goals/work.png"));
 
         Icons { map }
     }

--- a/emergence_lib/src/ui/wheel_menu.rs
+++ b/emergence_lib/src/ui/wheel_menu.rs
@@ -122,7 +122,7 @@ pub(super) fn select_hex<D: Choice>(
 }
 
 /// A choice that can be used in a wheel menu.
-pub(super) trait Choice: Clone + Hash + Eq + Send + Sync + 'static {
+pub(super) trait Choice: Clone + Hash + Eq + Debug + Send + Sync + 'static {
     /// The action that is pressed to bring up this wheel menu
     const ACTIVATION: PlayerAction;
 }
@@ -221,7 +221,7 @@ struct HexMenuIconBundle {
 
 impl HexMenuIconBundle {
     /// Create a new icon with the appropriate positioning and appearance.
-    fn new<D: Hash + Eq + Send + Sync + 'static>(
+    fn new<D: Hash + Eq + Debug + Send + Sync + 'static>(
         data: D,
         hex: Hex,
         icons: &Icons<D>,

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -238,6 +238,7 @@ fn generate_organisms(
     unit_handles: Res<UnitHandles>,
     unit_manifest: Res<UnitManifest>,
     structure_manifest: Res<StructureManifest>,
+    mut height_query: Query<&mut Height>,
     mut map_geometry: ResMut<MapGeometry>,
 ) {
     info!("Generating organisms...");
@@ -258,7 +259,7 @@ fn generate_organisms(
                     && map_geometry.is_space_available(tile_pos, footprint, &facing)
                 {
                     // Flatten the terrain under the structure before spawning it
-                    map_geometry.flatten_height(tile_pos, footprint, &facing);
+                    map_geometry.flatten_height(&mut height_query, tile_pos, footprint, &facing);
                     commands.spawn_structure(
                         tile_pos,
                         ClipboardData::generate_from_id(structure_id, &*structure_manifest),

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -276,7 +276,7 @@ fn generate_organisms(
                 .clone(),
         };
 
-        commands.spawn_randomized_structure(position, item, rng);
+        commands.generate_structure(position, item, rng);
     }
 
     // Fungi
@@ -293,7 +293,7 @@ fn generate_organisms(
                 .clone(),
         };
 
-        commands.spawn_randomized_structure(position, item, rng);
+        commands.generate_structure(position, item, rng);
     }
 
     // Hives
@@ -310,7 +310,7 @@ fn generate_organisms(
                 .clone(),
         };
 
-        commands.spawn_randomized_structure(position, item, rng);
+        commands.generate_structure(position, item, rng);
     }
 }
 

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -51,12 +51,12 @@ impl Default for GenerationConfig {
         terrain_weights.insert(Id::from_name("rocky".to_string()), 0.2);
 
         let mut unit_chances: HashMap<Id<Unit>, f32> = HashMap::new();
-        unit_chances.insert(Id::from_name("ant".to_string()), 0.1);
+        unit_chances.insert(Id::from_name("ant".to_string()), 1e-2);
 
         let mut structure_chances: HashMap<Id<Structure>, f32> = HashMap::new();
-        structure_chances.insert(Id::from_name("ant_hive".to_string()), 0.02);
-        structure_chances.insert(Id::from_name("acacia".to_string()), 0.02);
-        structure_chances.insert(Id::from_name("leuco".to_string()), 0.02);
+        structure_chances.insert(Id::from_name("ant_hive".to_string()), 1e-3);
+        structure_chances.insert(Id::from_name("acacia".to_string()), 2e-2);
+        structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
             map_radius: 40,


### PR DESCRIPTION
Fixes #628.

The main effect is that hives are now placed properly!

Along the way:
- fixed a panic due to a missing GoalKind::Work icon
- Fixes #723.
- cleaned up structure spawning code by moving randomization into a system
- 