### PR TITLE
Water flows downhill and horizontally

### DIFF
--- a/emergence_lib/src/infovis.rs
+++ b/emergence_lib/src/infovis.rs
@@ -15,7 +15,7 @@ use crate::{
     graphics::palette::infovis::{WATER_TABLE_COLOR_HIGH, WATER_TABLE_COLOR_LOW},
     player_interaction::{selection::ObjectInteraction, InteractionSystem},
     signals::{SignalKind, SignalStrength, SignalType, Signals},
-    simulation::geometry::{MapGeometry, TilePos},
+    simulation::geometry::{Height, MapGeometry, TilePos},
     terrain::{terrain_assets::TerrainHandles, terrain_manifest::Terrain},
     units::unit_manifest::Unit,
     water::{DepthToWaterTable, WaterTable},
@@ -349,9 +349,13 @@ fn set_overlay_material(
                 }
                 OverlayType::HeightOfWaterTable => {
                     let water_table_height = water_table.get(tile_pos);
-                    // FIXME: use a dedicated color ramp for this. Currently, the colors are backwards.
-                    tile_overlay
-                        .get_water_table_material(DepthToWaterTable::Depth(water_table_height))
+                    // FIXME: use a dedicated color ramp for this, rather than hacking it
+                    // We subtract here to ensure that blue == wet and red == dry
+                    let inverted_height = DepthToWaterTable::Depth(
+                        Height(TileOverlay::MAX_DEPTH_TO_WATER_TABLE) - water_table_height,
+                    );
+
+                    tile_overlay.get_water_table_material(inverted_height)
                 }
             };
 

--- a/emergence_lib/src/infovis.rs
+++ b/emergence_lib/src/infovis.rs
@@ -88,7 +88,9 @@ pub(crate) enum OverlayType {
     /// The strongest signal in each cell is being visualized.
     StrongestSignal,
     /// The distance to the water table is being visualized.
-    WaterTable,
+    DepthToWaterTable,
+    /// The height of the water table is being visualized.
+    HeightOfWaterTable,
 }
 
 impl OverlayType {
@@ -340,10 +342,16 @@ fn set_overlay_material(
                         let signal_kind = signal_type.into();
                         tile_overlay.get_material(signal_kind, signal_strength)
                     }),
-                OverlayType::WaterTable => {
+                OverlayType::DepthToWaterTable => {
                     let depth_to_water_table =
                         water_table.depth_to_water_table(tile_pos, &map_geometry);
                     tile_overlay.get_water_table_material(depth_to_water_table)
+                }
+                OverlayType::HeightOfWaterTable => {
+                    let water_table_height = water_table.get(tile_pos);
+                    // FIXME: use a dedicated color ramp for this. Currently, the colors are backwards.
+                    tile_overlay
+                        .get_water_table_material(DepthToWaterTable::Depth(water_table_height))
                 }
             };
 

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -13,7 +13,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
     f32::consts::PI,
-    ops::{Add, AddAssign, Div, Sub, SubAssign},
+    ops::{Add, AddAssign, Div, Mul, Sub, SubAssign},
 };
 
 use crate::{
@@ -404,6 +404,22 @@ impl AddAssign for Height {
 impl SubAssign for Height {
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
+    }
+}
+
+impl Mul<f32> for Height {
+    type Output = Height;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Height(self.0 * rhs)
+    }
+}
+
+impl Mul<Height> for f32 {
+    type Output = Height;
+
+    fn mul(self, rhs: Height) -> Self::Output {
+        Height(self * rhs.0)
     }
 }
 

--- a/emergence_lib/src/ui/overlay.rs
+++ b/emergence_lib/src/ui/overlay.rs
@@ -56,11 +56,11 @@ fn select_overlay(
     }
 
     if player_actions.just_pressed(PlayerAction::ToggleWaterTableOverlay) {
-        if tile_overlay.overlay_type != OverlayType::WaterTable {
-            tile_overlay.overlay_type = OverlayType::WaterTable;
-        } else {
-            tile_overlay.overlay_type = OverlayType::None;
-        }
+        tile_overlay.overlay_type = match tile_overlay.overlay_type {
+            OverlayType::DepthToWaterTable => OverlayType::HeightOfWaterTable,
+            OverlayType::HeightOfWaterTable => OverlayType::None,
+            _ => OverlayType::DepthToWaterTable,
+        };
     }
 }
 
@@ -221,9 +221,21 @@ fn update_signal_type_display(
 
             legend.texture = Handle::default();
         }
-        OverlayType::WaterTable => {
+        OverlayType::DepthToWaterTable => {
             text.sections = vec![TextSection {
                 value: "Depth to water table".to_string(),
+                style: TextStyle {
+                    font: fonts.regular.clone_weak(),
+                    font_size,
+                    color: Color::WHITE,
+                },
+            }];
+
+            legend.texture = tile_overlay.water_table_legend_image_handle();
+        }
+        OverlayType::HeightOfWaterTable => {
+            text.sections = vec![TextSection {
+                value: "Height of water table".to_string(),
                 style: TextStyle {
                     font: fonts.regular.clone_weak(),
                     font_size,

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -23,6 +23,7 @@ impl Plugin for WaterPlugin {
             (
                 evaporation,
                 precipitation,
+                horizontal_water_movement,
                 update_surface_water_map_geometry,
             )
                 .in_set(SimulationSet)
@@ -179,6 +180,45 @@ fn precipitation(
 
     for tile_pos in map_geometry.valid_tile_positions() {
         water_table.add(tile_pos, precipitation_rate);
+    }
+}
+
+/// Moves water from one tile to another, according to the relative height of the water table.
+fn horizontal_water_movement(
+    mut water_table: ResMut<WaterTable>,
+    map_geometry: Res<MapGeometry>,
+    fixed_time: Res<FixedTime>,
+    in_game_time: Res<InGameTime>,
+) {
+    /// The rate of water transfer between adjacent tiles.
+    ///
+    /// The units are cubic tiles per day per tile of height difference.
+    const WATER_FLOW_RATE: f32 = 0.5;
+    let water_flow_coefficient =
+        WATER_FLOW_RATE / in_game_time.seconds_per_day() * fixed_time.period.as_secs_f32();
+
+    // We must use a working copy of the water table to avoid effects due to the order of evaluation.
+    let mut delta_water_flow = WaterTable::default();
+    for tile_pos in map_geometry.valid_tile_positions() {
+        let height = water_table.get(tile_pos);
+        let neighbors = tile_pos.all_neighbors(&map_geometry);
+        for neighbor in neighbors {
+            let neighbor_height = water_table.get(neighbor);
+            // FIXME: this is non-conservative; water can be moved even from tiles that end up being overdrawn
+            // If the water is higher than the neighbor, move water from the tile to the neighbor
+            // at a rate proportional to the height difference.
+            // If the water is lower than the neighbor, the flow direction is reversed.
+            // The rate is halved as we do the same computation in both directions.
+            let delta_water_height = height - neighbor_height;
+            let water_transfer = delta_water_height * water_flow_coefficient / 2.;
+            delta_water_flow.subtract(tile_pos, water_transfer);
+            delta_water_flow.add(neighbor, water_transfer);
+        }
+    }
+
+    // Apply the changes
+    for tile_pos in map_geometry.valid_tile_positions() {
+        water_table.add(tile_pos, delta_water_flow.get(tile_pos));
     }
 }
 

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -193,9 +193,9 @@ fn horizontal_water_movement(
     /// The rate of water transfer between adjacent tiles.
     ///
     /// The units are cubic tiles per day per tile of height difference.
-    const WATER_FLOW_RATE: f32 = 0.5;
+    const LATERAL_WATER_FLOW_RATE: f32 = 0.5;
     let water_flow_coefficient =
-        WATER_FLOW_RATE / in_game_time.seconds_per_day() * fixed_time.period.as_secs_f32();
+        LATERAL_WATER_FLOW_RATE / in_game_time.seconds_per_day() * fixed_time.period.as_secs_f32();
 
     // We must use a working copy of the water table to avoid effects due to the order of evaluation.
     let mut delta_water_flow = WaterTable::default();

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -193,7 +193,7 @@ fn horizontal_water_movement(
     /// The rate of water transfer between adjacent tiles.
     ///
     /// The units are cubic tiles per day per tile of height difference.
-    const LATERAL_WATER_FLOW_RATE: f32 = 0.5;
+    const LATERAL_WATER_FLOW_RATE: f32 = 5.0;
     let water_flow_coefficient =
         LATERAL_WATER_FLOW_RATE / in_game_time.seconds_per_day() * fixed_time.period.as_secs_f32();
 

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -96,6 +96,7 @@ impl Plugin for GenerationPlugin {
         app.insert_resource(self.config.clone()).add_systems(
             (
                 generate_terrain,
+                apply_system_buffers,
                 initialize_water_table,
                 apply_system_buffers,
                 generate_organisms,


### PR DESCRIPTION
Fixes #773.

Very simple lateral water movement model, with a speed bonus for water travelling in the air rather than the soil.

Still, gets us really cool drainage effects!

Also fixed a bug where the initial water table was not being set correctly, and added an overlay for water table height.