### PR TITLE
Plants need water to complete crafting

### DIFF
--- a/emergence_game/assets/manifests/base_game.item_manifest.json
+++ b/emergence_game/assets/manifests/base_game.item_manifest.json
@@ -3,15 +3,18 @@
   "items": {
     "acacia_leaf": {
       "stack_size": 8,
-      "compostable": true
+      "compostable": true,
+      "fluid": false
     },
     "leuco_chunk": {
       "stack_size": 6,
-      "compostable": false
+      "compostable": false,
+      "fluid": false
     },
     "ant_egg": {
       "stack_size": 3,
       "compostable": false,
+      "fluid": false,
       "seed": {
         "Unit": "ant"
       }
@@ -19,13 +22,20 @@
     "acacia_seed": {
       "stack_size": 12,
       "compostable": true,
+      "fluid": false,
       "seed": {
         "Structure": "acacia_seedling"
       }
     },
     "soil": {
       "stack_size": 3,
-      "compostable": false
+      "compostable": false,
+      "fluid": false
+    },
+    "water": {
+      "stack_size": 10,
+      "compostable": false,
+      "fluid": true
     }
   }
 }

--- a/emergence_game/assets/manifests/base_game.recipe_manifest.json
+++ b/emergence_game/assets/manifests/base_game.recipe_manifest.json
@@ -15,7 +15,9 @@
 		},
 		"acacia_leaf_production": {
 			"inputs": {
-				"Exact": {}
+				"Exact": {
+					"water": 1
+				}
 			},
 			"outputs": {
 				"acacia_leaf": 1
@@ -32,7 +34,9 @@
 		},
 		"mature_acacia_production": {
 			"inputs": {
-				"Exact": {}
+				"Exact": {
+					"water": 1
+				}
 			},
 			"outputs": {
 				"acacia_leaf": 1,

--- a/emergence_lib/src/crafting/components.rs
+++ b/emergence_lib/src/crafting/components.rs
@@ -162,8 +162,6 @@ impl InputInventory {
     }
 
     /// Does this inventory have space for at least one item with the provided `item_id`?
-    ///
-    /// If `required_tag` is `Some`, the item must have that tag.
     pub(crate) fn currently_accepts(
         &self,
         item_id: Id<Item>,

--- a/emergence_lib/src/crafting/item_tags.rs
+++ b/emergence_lib/src/crafting/item_tags.rs
@@ -17,6 +17,8 @@ pub enum ItemTag {
     Compostable,
     /// Items that will grow into something if left on the ground.
     Seed,
+    /// A fluid.
+    Fluid,
 }
 
 impl ItemTag {
@@ -25,6 +27,7 @@ impl ItemTag {
         match self {
             ItemTag::Compostable => "Compostable",
             ItemTag::Seed => "Seed",
+            ItemTag::Fluid => "Fluid",
         }
     }
 }

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -661,6 +661,7 @@ mod tests {
             ItemData {
                 stack_size: 10,
                 compostable: true,
+                fluid: false,
                 seed: None,
             },
         );
@@ -669,6 +670,7 @@ mod tests {
             ItemData {
                 stack_size: 10,
                 compostable: false,
+                fluid: false,
                 seed: None,
             },
         );

--- a/emergence_lib/src/items/item_manifest.rs
+++ b/emergence_lib/src/items/item_manifest.rs
@@ -26,6 +26,7 @@ impl ItemManifest {
         match tag {
             ItemTag::Compostable => data.compostable,
             ItemTag::Seed => data.seed.is_some(),
+            ItemTag::Fluid => data.fluid,
         }
     }
 
@@ -89,6 +90,8 @@ pub struct ItemData {
     pub stack_size: u32,
     /// Can this item be composted?
     pub compostable: bool,
+    /// Is this item a fluid?
+    pub fluid: bool,
     /// Is this item a seed?
     ///
     /// If so, what does it grow into when left as litter?
@@ -102,6 +105,8 @@ pub struct RawItemData {
     pub stack_size: u32,
     /// Can this item be composted?
     pub compostable: bool,
+    /// Is this item a fluid?
+    pub fluid: bool,
     /// Is this item a seed?
     ///
     /// If so, what does it grow into when left as litter?
@@ -113,6 +118,7 @@ impl From<RawItemData> for ItemData {
         Self {
             stack_size: raw.stack_size,
             compostable: raw.compostable,
+            fluid: raw.fluid,
             seed: raw.seed.map(OrganismId::from),
         }
     }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -813,6 +813,7 @@ mod tests {
             ItemData {
                 stack_size: 1,
                 compostable: false,
+                fluid: false,
                 seed: None,
             },
         );

--- a/emergence_lib/tests/serde_manifests.rs
+++ b/emergence_lib/tests/serde_manifests.rs
@@ -37,6 +37,7 @@ fn can_serialize_item_manifest() {
                 RawItemData {
                     stack_size: 1,
                     compostable: true,
+                    fluid: false,
                     seed: None,
                 },
             ),
@@ -45,7 +46,17 @@ fn can_serialize_item_manifest() {
                 RawItemData {
                     stack_size: 2,
                     compostable: false,
+                    fluid: false,
                     seed: Some(RawOrganismId::Structure("test_organism".to_string())),
+                },
+            ),
+            (
+                "water".to_string(),
+                RawItemData {
+                    stack_size: 100,
+                    compostable: false,
+                    fluid: true,
+                    seed: None,
                 },
             ),
         ]),


### PR DESCRIPTION
When water is absorbed by roots, it is now converted into water items.

These are used to craft the recipes plants make to stay alive.

Fixes #772.