### PR TITLE
Merge columns into a single mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,11 +2193,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 [[package]]
 name = "hexx"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b6f98afa248722abf405fc7047b23ae778e8ba2f3f459aed1f7eb5b931d3d9"
+source = "git+https://github.com/ManevilleF/hexx/?branch=feat/mesh_builder#86dd7ff3a6e6ce3e086d599612e41cdcf33c4af1"
 dependencies = [
  "glam",
- "itertools",
  "serde",
 ]
 

--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -24,7 +24,7 @@ petitset = "0.2"
 serde = "1.0.152"
 leafwing_abilities = "0.4.0"
 derive_more = "0.99.17"
-hexx = { version = "0.5", features = ["ser_de"] }
+hexx = { git = "https://github.com/ManevilleF/hexx/", branch = "feat/mesh_builder", features = ["ser_de"] }
 bevy_mod_raycast = "0.8"
 itertools = "0.10.5"
 bevy_screen_diagnostics = "0.2"

--- a/emergence_lib/src/graphics/water.rs
+++ b/emergence_lib/src/graphics/water.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 
-use crate::simulation::geometry::{hexagonal_column, MapGeometry};
+use crate::simulation::geometry::{bounding_hexagonal_column, MapGeometry};
 
 use super::palette::environment::WATER;
 
@@ -38,7 +38,7 @@ fn init_water_handles(
         alpha_mode: AlphaMode::Blend,
         ..Default::default()
     });
-    let mesh = hexagonal_column(&map_geometry.layout, 1.0);
+    let mesh = bounding_hexagonal_column(&map_geometry.layout, 1.0);
     let mesh_handle = meshes.add(mesh);
     commands.insert_resource(WaterHandles {
         material,

--- a/emergence_lib/src/infovis.rs
+++ b/emergence_lib/src/infovis.rs
@@ -324,7 +324,7 @@ fn set_overlay_material(
 
     for (&tile_pos, children) in terrain_query.iter() {
         // This is promised to be the correct entity in the initialization of the terrain's children
-        let overlay_entity = children[1];
+        let overlay_entity = children[0];
 
         if let Ok((mut overlay_material, mut overlay_visibility)) =
             overlay_query.get_mut(overlay_entity)
@@ -383,7 +383,7 @@ fn display_tile_overlay(
 ) {
     for (children, object_interaction) in terrain_query.iter() {
         // This is promised to be the correct entity in the initialization of the terrain's children
-        let overlay_entity = children[1];
+        let overlay_entity = children[0];
 
         let (mut overlay_material, mut overlay_visibility) =
             overlay_query.get_mut(overlay_entity).unwrap();

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -324,32 +324,6 @@ impl Height {
         }
     }
 
-    /// Computes the correct [`Transform`] of the column underneath a tile of this height at this position
-    #[inline]
-    #[must_use]
-    pub(crate) fn column_transform(&self) -> Transform {
-        let y_scale = self.into_world_pos();
-        let scale = Vec3 {
-            x: 1.,
-            y: y_scale,
-            z: 1.,
-        };
-
-        // This is x and z aligned with the parent
-        let translation = Vec3 {
-            x: 0.,
-            // We want this to start below the parent
-            y: -y_scale,
-            z: 0.,
-        };
-
-        Transform {
-            translation,
-            rotation: Default::default(),
-            scale,
-        }
-    }
-
     /// Raises the height by a single terrain step.
     ///
     /// Clamps the height to [`Height::MIN`] if it would go below it.

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -1081,10 +1081,7 @@ impl RotationDirection {
 /// Constructs the mesh for a single hexagonal column with the specified height.
 #[must_use]
 pub(crate) fn hexagonal_column(hex_layout: &HexLayout, hex_height: f32) -> Mesh {
-    let mesh_info = ColumnMeshBuilder::new(hex_layout, hex_height)
-        .without_bottom_face()
-        .without_top_face()
-        .build();
+    let mesh_info = ColumnMeshBuilder::new(hex_layout, hex_height).build();
 
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices.to_vec());

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -8,7 +8,7 @@ use bevy::{
 };
 use core::fmt::Display;
 use derive_more::{Add, AddAssign, Display, Sub, SubAssign};
-use hexx::{shapes::hexagon, Direction, Hex, HexLayout, MeshInfo};
+use hexx::{shapes::hexagon, ColumnMeshBuilder, Direction, Hex, HexLayout};
 use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1081,7 +1081,11 @@ impl RotationDirection {
 /// Constructs the mesh for a single hexagonal column with the specified height.
 #[must_use]
 pub(crate) fn hexagonal_column(hex_layout: &HexLayout, hex_height: f32) -> Mesh {
-    let mesh_info = MeshInfo::hexagonal_column(hex_layout, Hex::ZERO, hex_height);
+    let mesh_info = ColumnMeshBuilder::new(hex_layout, hex_height)
+        .without_bottom_face()
+        .without_top_face()
+        .build();
+
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices.to_vec());
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals.to_vec());

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -1078,15 +1078,17 @@ impl RotationDirection {
     }
 }
 
-/// Constructs the mesh for a single hexagonal column with the specified height.
+/// Constructs the bounding mesh for a single hexagonal column with the specified height.
+///
+/// # Warning
+///
+/// This mesh does not have normals and UVs, and should not be used for lit or textured meshes.
 #[must_use]
-pub(crate) fn hexagonal_column(hex_layout: &HexLayout, hex_height: f32) -> Mesh {
+pub(crate) fn bounding_hexagonal_column(hex_layout: &HexLayout, hex_height: f32) -> Mesh {
     let mesh_info = ColumnMeshBuilder::new(hex_layout, hex_height).build();
 
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices.to_vec());
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals.to_vec());
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs.to_vec());
     mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
     mesh
 }

--- a/emergence_lib/src/structures/structure_assets.rs
+++ b/emergence_lib/src/structures/structure_assets.rs
@@ -4,7 +4,7 @@ use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
     enum_iter::IterableEnum,
     player_interaction::selection::ObjectInteraction,
-    simulation::geometry::{hexagonal_column, MapGeometry},
+    simulation::geometry::{bounding_hexagonal_column, MapGeometry},
     structures::structure_manifest::{Structure, StructureManifest},
 };
 use bevy::{asset::LoadState, prelude::*, utils::HashMap};
@@ -28,7 +28,7 @@ impl Loadable for StructureHandles {
         const PICKING_HEIGHT: f32 = 1.0;
 
         let map_geometry = world.resource::<MapGeometry>();
-        let picking_mesh_object = hexagonal_column(&map_geometry.layout, PICKING_HEIGHT);
+        let picking_mesh_object = bounding_hexagonal_column(&map_geometry.layout, PICKING_HEIGHT);
         let mut mesh_assets = world.resource_mut::<Assets<Mesh>>();
         let picking_mesh = mesh_assets.add(picking_mesh_object);
 

--- a/emergence_lib/src/terrain/commands.rs
+++ b/emergence_lib/src/terrain/commands.rs
@@ -113,9 +113,8 @@ impl<'w, 's> TerrainCommandsExt for Commands<'w, 's> {
 /// Constructs a new [`Terrain`] entity.
 ///
 /// The order of the chidlren *must* be:
-/// 0: column
-/// 1: overlay
-/// 2: scene root
+/// 0: overlay
+/// 1: scene root
 pub(crate) struct SpawnTerrainCommand {
     /// The position to spawn the tile
     pub(crate) tile_pos: TilePos,
@@ -148,18 +147,6 @@ impl Command for SpawnTerrainCommand {
                 map_geometry,
             ))
             .id();
-
-        // Spawn the column as the 0th child of the tile entity
-        // The scene bundle will be added as the first child
-        let handles = world.resource::<TerrainHandles>();
-        let column_bundle = PbrBundle {
-            mesh: handles.column_mesh.clone_weak(),
-            material: handles.column_material.clone_weak(),
-            ..Default::default()
-        };
-
-        let hex_column = world.spawn(column_bundle).id();
-        world.entity_mut(terrain_entity).add_child(hex_column);
 
         let handles = world.resource::<TerrainHandles>();
         /// Makes the overlays ever so slightly larger than their base to avoid z-fighting.

--- a/emergence_lib/src/terrain/terrain_assets.rs
+++ b/emergence_lib/src/terrain/terrain_assets.rs
@@ -8,7 +8,7 @@ use crate::{
     graphics::palette::environment::COLUMN_COLOR,
     items::inventory::InventoryState,
     player_interaction::selection::ObjectInteraction,
-    simulation::geometry::{hexagonal_column, Height, MapGeometry},
+    simulation::geometry::{bounding_hexagonal_column, Height, MapGeometry},
     terrain::terrain_manifest::{Terrain, TerrainManifest},
 };
 
@@ -56,8 +56,9 @@ impl Loadable for TerrainHandles {
         );
 
         let map_geometry = world.resource::<MapGeometry>();
-        let column_mesh_object = hexagonal_column(&map_geometry.layout, 1.0);
-        let topper_mesh_object = hexagonal_column(&map_geometry.layout, Height::TOPPER_THICKNESS);
+        let column_mesh_object = bounding_hexagonal_column(&map_geometry.layout, 1.0);
+        let topper_mesh_object =
+            bounding_hexagonal_column(&map_geometry.layout, Height::TOPPER_THICKNESS);
         let mut mesh_assets = world.resource_mut::<Assets<Mesh>>();
         let column_mesh = mesh_assets.add(column_mesh_object);
         let topper_mesh = mesh_assets.add(topper_mesh_object);

--- a/emergence_lib/src/terrain/terrain_assets.rs
+++ b/emergence_lib/src/terrain/terrain_assets.rs
@@ -19,8 +19,6 @@ pub(crate) struct TerrainHandles {
     pub(crate) scenes: HashMap<Id<Terrain>, Handle<Scene>>,
     /// The mesh used for raycasting the terrain topper
     pub(crate) topper_mesh: Handle<Mesh>,
-    /// The mesh of the column underneath each terrain topper
-    pub(crate) column_mesh: Handle<Mesh>,
     /// The material of the column underneath each terrain topper
     pub(crate) column_material: Handle<StandardMaterial>,
     /// The materials used to display player interaction with terrain tiles
@@ -56,11 +54,9 @@ impl Loadable for TerrainHandles {
         );
 
         let map_geometry = world.resource::<MapGeometry>();
-        let column_mesh_object = bounding_hexagonal_column(&map_geometry.layout, 1.0);
         let topper_mesh_object =
             bounding_hexagonal_column(&map_geometry.layout, Height::TOPPER_THICKNESS);
         let mut mesh_assets = world.resource_mut::<Assets<Mesh>>();
-        let column_mesh = mesh_assets.add(column_mesh_object);
         let topper_mesh = mesh_assets.add(topper_mesh_object);
 
         let mut material_assets = world.resource_mut::<Assets<StandardMaterial>>();
@@ -80,7 +76,6 @@ impl Loadable for TerrainHandles {
         world.insert_resource(TerrainHandles {
             scenes,
             topper_mesh,
-            column_mesh,
             column_material,
             interaction_materials,
             litter_models,

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -1055,7 +1055,7 @@ impl CurrentAction {
         terrain_manifest: &TerrainManifest,
         map_geometry: &MapGeometry,
     ) -> Self {
-        let required_direction = unit_tile_pos.direction_to(target_tile_pos.hex);
+        let required_direction = unit_tile_pos.main_direction_to(target_tile_pos.hex);
 
         if required_direction == facing.direction {
             CurrentAction::move_forward(
@@ -1087,7 +1087,7 @@ impl CurrentAction {
         unit_tile_pos: TilePos,
         output_tile_pos: TilePos,
     ) -> Self {
-        let required_direction = unit_tile_pos.direction_to(output_tile_pos.hex);
+        let required_direction = unit_tile_pos.main_direction_to(output_tile_pos.hex);
 
         if required_direction == facing.direction {
             CurrentAction {
@@ -1111,7 +1111,7 @@ impl CurrentAction {
         unit_tile_pos: TilePos,
         input_tile_pos: TilePos,
     ) -> Self {
-        let required_direction = unit_tile_pos.direction_to(input_tile_pos.hex);
+        let required_direction = unit_tile_pos.main_direction_to(input_tile_pos.hex);
 
         if required_direction == facing.direction {
             CurrentAction {

--- a/emergence_lib/src/units/unit_assets.rs
+++ b/emergence_lib/src/units/unit_assets.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asset_management::{manifest::Id, AssetState, Loadable},
-    simulation::geometry::{hexagonal_column, MapGeometry},
+    simulation::geometry::{bounding_hexagonal_column, MapGeometry},
     units::unit_manifest::{Unit, UnitManifest},
 };
 use bevy::{asset::LoadState, prelude::*, utils::HashMap};
@@ -26,7 +26,7 @@ impl Loadable for UnitHandles {
         const PICKING_HEIGHT: f32 = 1.0;
 
         let map_geometry = world.resource::<MapGeometry>();
-        let picking_mesh_object = hexagonal_column(&map_geometry.layout, PICKING_HEIGHT);
+        let picking_mesh_object = bounding_hexagonal_column(&map_geometry.layout, PICKING_HEIGHT);
         let mut mesh_assets = world.resource_mut::<Assets<Mesh>>();
         let picking_mesh = mesh_assets.add(picking_mesh_object);
 

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -147,7 +147,7 @@ impl Default for GenerationConfig {
         structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
-            map_radius: 60,
+            map_radius: 20,
             number_of_burn_in_ticks: 1e2 as u32,
             unit_chances,
             landmark_chances,


### PR DESCRIPTION
Experimenting with https://github.com/ManevilleF/hexx/pull/80.

> Mesh merging with its current API is not very useful at all:
> - it's very easy to hit the u16::MAX limit
> - there's no way to specify the translation offsets of the meshes in advance, so they end up collapsed into an overlapping pile
> - I really want to be able to call .reduce with merge_mesh but the type signature is wrong

Experiments towards #769.
