### PR TITLE
Improve stability of lateral water dynamics

### DIFF
--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -547,6 +547,14 @@ impl Div<f32> for Volume {
     }
 }
 
+impl Div<Volume> for Volume {
+    type Output = f32;
+
+    fn div(self, rhs: Volume) -> Self::Output {
+        self.0 / rhs.0
+    }
+}
+
 /// The overall size and arrangement of the map.
 #[derive(Debug, Resource)]
 pub struct MapGeometry {

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -600,7 +600,7 @@ impl MapGeometry {
 
     /// Returns the list of valid tile positions.
     #[inline]
-    pub fn valid_tile_positions(&self) -> impl Iterator<Item = TilePos> + '_ {
+    pub fn valid_tile_positions(&self) -> impl ExactSizeIterator<Item = TilePos> + '_ {
         hexagon(Hex::ZERO, self.radius).map(|hex| TilePos { hex })
     }
 

--- a/emergence_lib/src/ui/production_statistics.rs
+++ b/emergence_lib/src/ui/production_statistics.rs
@@ -75,8 +75,8 @@ fn update_production_statistics(
     text.sections[1].value = format!("Weather: {}\n", current_weather.get());
     text.sections[2].value = format!("{}\n", *total_light);
     text.sections[3].value = format!(
-        "{} average depth of water table \n",
-        water_table.average_height(&map_geometry)
+        "{} average volume of water per tile \n",
+        water_table.average_volume(&map_geometry)
     );
     text.sections[4].value = format!("{}", *census);
 }

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -233,6 +233,14 @@ impl WaterTable {
             .unwrap_or_default()
     }
 
+    /// Computes the average height of the water table.
+    #[allow(dead_code)]
+    pub(crate) fn average_height(&self, map_geometry: &MapGeometry) -> Height {
+        let total_water = self.total_water();
+        let total_area = map_geometry.valid_tile_positions().count() as f32;
+        (total_water / total_area).into_height()
+    }
+
     /// Compute the average amount of water per tile.
     pub(crate) fn average_volume(&self, map_geometry: &MapGeometry) -> Volume {
         let total_water = self.total_water();

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -57,13 +57,13 @@ pub(crate) struct WaterConfig {
 impl WaterConfig {
     /// The default configuration for in-game water behavior.
     const IN_GAME: Self = Self {
-        evaporation_rate: Height(2.0),
+        evaporation_rate: Height(0.0),
         soil_evaporation_ratio: 0.2,
-        precipitation_rate: Height(2.0),
-        emission_rate: Volume(1e3),
+        precipitation_rate: Height(0.0),
+        emission_rate: Volume(0e3),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
-        relative_soil_water_capacity: 0.3,
+        relative_soil_water_capacity: 0.0,
         lateral_flow_rate: 1e3,
         soil_lateral_flow_ratio: 0.2,
     };

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -216,11 +216,11 @@ impl WaterTable {
     ///
     /// Returns the amount of water that was actually subtracted.
     pub(crate) fn remove(&mut self, tile_pos: TilePos, amount: Volume) -> Volume {
-        let height = self.get_volume(tile_pos);
+        let volume = self.get_volume(tile_pos);
         // We cannot take more water than there is.
-        let water_drawn = amount.min(height);
-        let new_height = height - water_drawn;
-        self.set_volume(tile_pos, new_height);
+        let water_drawn = amount.min(volume);
+        let new_volume = volume - water_drawn;
+        self.set_volume(tile_pos, new_volume);
         water_drawn
     }
 

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -233,13 +233,6 @@ impl WaterTable {
             .unwrap_or_default()
     }
 
-    /// Computes the average height of the water table.
-    pub(crate) fn average_height(&self, map_geometry: &MapGeometry) -> Height {
-        let total_water = self.total_water();
-        let total_area = map_geometry.valid_tile_positions().count() as f32;
-        (total_water / total_area).into_height()
-    }
-
     /// Compute the average amount of water per tile.
     pub(crate) fn average_volume(&self, map_geometry: &MapGeometry) -> Volume {
         let total_water = self.total_water();

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -334,3 +334,38 @@ fn update_water_depth(
         water_table.water_depth.insert(tile_pos, water_depth);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn water_depth_returns_dry_when_volume_is_zero() {
+        let water_depth = WaterDepth::compute(Volume::ZERO, Height::ZERO, 0.5);
+
+        assert_eq!(water_depth, WaterDepth::Dry);
+
+        let water_depth = WaterDepth::compute(Volume::ZERO, Height(1.0), 0.5);
+        assert_eq!(water_depth, WaterDepth::Dry);
+    }
+
+    #[test]
+    fn water_depth_returns_underground_when_volume_is_less_than_soil_capacity() {
+        let water_depth: WaterDepth =
+            WaterDepth::compute(Volume::from_height(Height(0.1)), Height(1.0), 0.5);
+        assert_eq!(water_depth, WaterDepth::Underground(Height(0.8)));
+
+        let water_depth = WaterDepth::compute(Volume::from_height(Height(0.5)), Height(1.0), 0.5);
+        assert_eq!(water_depth, WaterDepth::Underground(Height(0.0)));
+    }
+
+    #[test]
+    fn water_depth_returns_flooded_when_volume_is_greater_than_soil_capacity() {
+        let water_depth: WaterDepth =
+            WaterDepth::compute(Volume::from_height(Height(1.0)), Height(1.0), 0.5);
+        assert_eq!(water_depth, WaterDepth::Flooded(Height(0.5)));
+
+        let water_depth = WaterDepth::compute(Volume::from_height(Height(0.7)), Height(1.0), 0.0);
+        assert_eq!(water_depth, WaterDepth::Flooded(Height(0.7)));
+    }
+}

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -57,13 +57,13 @@ pub(crate) struct WaterConfig {
 impl WaterConfig {
     /// The default configuration for in-game water behavior.
     const IN_GAME: Self = Self {
-        evaporation_rate: Height(0.0),
+        evaporation_rate: Height(2.0),
         soil_evaporation_ratio: 0.2,
-        precipitation_rate: Height(0.0),
-        emission_rate: Volume(0e3),
+        precipitation_rate: Height(2.0),
+        emission_rate: Volume(1e3),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
-        relative_soil_water_capacity: 0.0,
+        relative_soil_water_capacity: 0.3,
         lateral_flow_rate: 1e3,
         soil_lateral_flow_ratio: 0.2,
     };

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -49,6 +49,10 @@ pub(crate) struct WaterConfig {
     /// The rate at which water moves horizontally.
     ///
     /// The units are cubic tiles per day per tile of height difference.
+    ///
+    /// # Warning
+    ///
+    /// If this value becomes too large, the simulation may become unstable, with water alternating between fully flooded and fully dry tiles.
     lateral_flow_rate: f32,
     /// The relative rate at which water moves horizontally through soil.
     soil_lateral_flow_ratio: f32,

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -64,7 +64,7 @@ impl WaterConfig {
         evaporation_rate: Height(2.0),
         soil_evaporation_ratio: 0.2,
         precipitation_rate: Height(2.0),
-        emission_rate: Volume(1e3),
+        emission_rate: Volume(1e4),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
         relative_soil_water_capacity: 0.3,

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -239,6 +239,13 @@ impl WaterTable {
         let total_area = map_geometry.valid_tile_positions().count() as f32;
         (total_water / total_area).into_height()
     }
+
+    /// Compute the average amount of water per tile.
+    pub(crate) fn average_volume(&self, map_geometry: &MapGeometry) -> Volume {
+        let total_water = self.total_water();
+        let total_area = map_geometry.valid_tile_positions().count() as f32;
+        total_water / total_area
+    }
 }
 
 impl Id<Item> {

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -505,6 +505,7 @@ mod tests {
                     water_table_strategy,
                     water_config: WaterConfig {
                         emission_rate: Volume(1.0),
+                        emission_pressure: Height(5.0),
                         lateral_flow_rate: 1000.,
                         soil_lateral_flow_ratio: 0.5,
                         ..WaterConfig::NULL

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -449,7 +449,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "This seeems to have reproduced https://github.com/Leafwing-Studios/Emergence/issues/799"]
     fn emission_increases_water_levels() {
         for map_size in MapSize::variants() {
             for water_table_strategy in WaterTableStrategy::variants() {
@@ -648,7 +647,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "This test seems to be failing due to instability in water simulation."]
     fn extremely_high_lateral_flow_conserves_water() {
         for map_size in MapSize::variants() {
             for map_shape in MapShape::variants() {

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -77,7 +77,7 @@ pub(super) fn horizontal_water_movement(
         for neighbor in neighbors {
             let neighbor_water_height = water_table.get_height(neighbor, &map_geometry);
 
-            let water_transfer = compute_lateral_flow_to_neighbor(
+            let proposed_water_transfer = compute_lateral_flow_to_neighbor(
                 base_water_transfer_amount,
                 &water_config,
                 map_geometry.get_height(tile_pos).unwrap(),
@@ -86,8 +86,8 @@ pub(super) fn horizontal_water_movement(
                 neighbor_water_height,
             );
 
-            water_table.remove(tile_pos, water_transfer);
-            water_table.add(neighbor, water_transfer);
+            let actual_water_transfer = water_table.remove(tile_pos, proposed_water_transfer);
+            water_table.add(neighbor, actual_water_transfer);
         }
     }
 }


### PR DESCRIPTION
Three key changes:

1. Divide water evenly between all neighbors.
2. Be more carefuly to ensure water is being conserved.
3. Compute all of the lateral water movement in a batch.

Fixes #799: I can no longer reproduce this.