### PR TITLE
switching to format in tools/ci and removing fmt action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           toolchain: stable
           components: ${{ matrix.toolchain-components || null }}
-      # - name: Cache Cargo build files
-      #   uses: Leafwing-Studios/cargo-cache@v1.0.0
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ci-argument:
+          - format
           - clippy
           - compilecheck
           - doccheck
@@ -29,6 +30,8 @@ jobs:
         include:
           - ci-argument: clippy
             toolchain-components: clippy
+          - ci-argument: format
+            toolchain-components: rustfmt            
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -42,15 +45,3 @@ jobs:
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- ${{ matrix.ci-argument }}
-  formatting:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # Ensure rustfmt is installed and setup problem matcher
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
-      - name: Rustfmt Check
-        uses: actions-rust-lang/rustfmt@v1
-              

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           toolchain: stable
           components: ${{ matrix.toolchain-components || null }}
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+      # - name: Cache Cargo build files
+      #   uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job


### PR DESCRIPTION
The `- format` wasn't working because the `rustfmt` wasn't being installed by the `dtolnay/rust-toolchain`

Added that and removed the gh action for rustfmt.