### PR TITLE
Reduce risk of oscillations in water dynamics

### DIFF
--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -76,9 +76,9 @@ impl WaterConfig {
         emission_rate: Volume(1e4),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
-        relative_soil_water_capacity: 0.0,
+        relative_soil_water_capacity: 0.02,
         lateral_flow_rate: 1e3,
-        soil_lateral_flow_ratio: 0.0,
+        soil_lateral_flow_ratio: 0.1,
         enable_oceans: true,
         tide_settings: TideSettings {
             amplitude: Height(3.0),

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -76,9 +76,9 @@ impl WaterConfig {
         emission_rate: Volume(1e4),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
-        relative_soil_water_capacity: 0.3,
+        relative_soil_water_capacity: 0.0,
         lateral_flow_rate: 1e3,
-        soil_lateral_flow_ratio: 0.2,
+        soil_lateral_flow_ratio: 0.0,
         enable_oceans: true,
         tide_settings: TideSettings {
             amplitude: Height(3.0),

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -76,9 +76,9 @@ impl WaterConfig {
         emission_rate: Volume(1e4),
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
-        relative_soil_water_capacity: 0.02,
-        lateral_flow_rate: 1e5,
-        soil_lateral_flow_ratio: 0.1,
+        relative_soil_water_capacity: 0.2,
+        lateral_flow_rate: 1e3,
+        soil_lateral_flow_ratio: 0.2,
         enable_oceans: true,
         tide_settings: TideSettings {
             amplitude: Height(3.0),

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -77,7 +77,7 @@ impl WaterConfig {
         emission_pressure: Height(1.0),
         water_items_per_tile: 50.0,
         relative_soil_water_capacity: 0.02,
-        lateral_flow_rate: 1e3,
+        lateral_flow_rate: 1e5,
         soil_lateral_flow_ratio: 0.1,
         enable_oceans: true,
         tide_settings: TideSettings {

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -1029,4 +1029,52 @@ mod tests {
             water_difference
         );
     }
+
+    #[test]
+    fn lateral_flow_should_not_result_in_higher_neighbor() {
+        let water_config: WaterConfig = WaterConfig {
+            lateral_flow_rate: 1e5,
+            ..WaterConfig::NULL
+        };
+
+        // This is a very high transfer rate, to ensure that the water transfer is maximized
+        let base_water_transfer_amount = 1e10;
+
+        let mut water_height_a = Height(2.0);
+        let mut water_height_b = Height(1.0);
+
+        let tile_height_a = Height(0.0);
+        let tile_height_b = Height(0.0);
+
+        let water_transferred_a_to_b = lateral_flow(
+            base_water_transfer_amount,
+            &water_config,
+            tile_height_a,
+            tile_height_b,
+            water_height_a,
+            water_height_b,
+        );
+
+        let water_transferred_b_to_a = lateral_flow(
+            base_water_transfer_amount,
+            &water_config,
+            tile_height_b,
+            tile_height_a,
+            water_height_b,
+            water_height_a,
+        );
+
+        water_height_a += water_transferred_b_to_a.into_height();
+        water_height_a -= water_transferred_a_to_b.into_height();
+
+        water_height_b += water_transferred_a_to_b.into_height();
+        water_height_b -= water_transferred_b_to_a.into_height();
+
+        assert!(
+            water_height_a >= water_height_b,
+            "Water height A ({:?}) should be greater than or equal to water height B ({:?}) as it started higher.",
+            water_height_a,
+            water_height_b
+        );
+    }
 }

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -254,7 +254,9 @@ fn lateral_flow(
         delta_water_height * medium_coefficient * base_water_transfer_amount / 2.,
     );
     assert!(proposed_amount >= Volume::ZERO);
-    let max_allowable_volume = Volume::from_height(delta_water_height);
+    // We don't want to move more than half the difference in water height.
+    // We *could* move up to the full difference, but that would cause the water to oscillate.
+    let max_allowable_volume = Volume::from_height(delta_water_height / 2.);
 
     proposed_amount.min(max_allowable_volume)
 }

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -147,7 +147,7 @@ impl Default for GenerationConfig {
         structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
-            map_radius: 80,
+            map_radius: 40,
             number_of_burn_in_ticks: 0,
             unit_chances,
             landmark_chances,

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -147,7 +147,7 @@ impl Default for GenerationConfig {
         structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
-            map_radius: 40,
+            map_radius: 60,
             number_of_burn_in_ticks: 0,
             unit_chances,
             landmark_chances,


### PR DESCRIPTION
Each step should avoid transferring more than half the difference in water height to its neighbor. This eliminates oscillation in two-container systems.

Unfortunately this still doesn't solve the issue completely: if when transferring to *all* neighbors the water height of the source ends up lower than the highest neighbor we get nonphysical behavior and oscillations still occur.

See [these rubberducking notes](https://discord.com/channels/1027393534627692645/1037821799091683449/1103780737599152189) for ideas on how to improve this further. None seem particularly promising, but if you have ideas, feel free to submit PRs.

I've included some settings to reproduce the problems in the commits below.