### PR TITLE
Divide time of day into discrete segments

### DIFF
--- a/emergence_lib/src/graphics/atmosphere.rs
+++ b/emergence_lib/src/graphics/atmosphere.rs
@@ -2,34 +2,18 @@
 
 use bevy::prelude::*;
 
-use crate::{
-    graphics::palette::environment::{MIDDAY_LIGHTNESS, SKY_SUNNY},
-    simulation::light::TotalLight,
-};
+use crate::simulation::time::InGameTime;
 
 /// Logic and resources to modify the sky and atmosphere.
 pub(super) struct AtmospherePlugin;
 
 impl Plugin for AtmospherePlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(ClearColor(SKY_SUNNY))
-            .add_system(animate_sky_color);
+        app.add_system(animate_sky_color);
     }
 }
 
-/// Changes the `ClearColor` resource which drives the sky color based on the illuminance from the Sun.
-fn animate_sky_color(mut clear_color: ResMut<ClearColor>, total_light: Res<TotalLight>) {
-    let [hue, saturation, _, alpha] = clear_color.0.as_hsla_f32();
-
-    // The midday lightness is the ideal lightness at noon.
-    let lightness = total_light.normalized_illuminance().0 * MIDDAY_LIGHTNESS;
-
-    let new_sky = Color::Hsla {
-        hue,
-        saturation,
-        lightness,
-        alpha,
-    };
-
-    clear_color.0 = new_sky;
+/// Changes the `ClearColor` resource which drives the sky color based on the time of day.
+fn animate_sky_color(mut clear_color: ResMut<ClearColor>, in_game_time: Res<InGameTime>) {
+    clear_color.0 = in_game_time.time_of_day().sky_color();
 }

--- a/emergence_lib/src/graphics/palette.rs
+++ b/emergence_lib/src/graphics/palette.rs
@@ -153,19 +153,24 @@ pub(crate) mod infovis {
 pub(crate) mod environment {
     use bevy::prelude::Color;
 
+    use crate::simulation::time::TimeOfDay;
+
     /// The color used for columns of dirt underneath tiles
     pub(crate) const COLUMN_COLOR: Color = Color::hsl(21., 0.6, 0.15);
 
-    /// The color of a clear and sunny sky.
-    pub(crate) const SKY_SUNNY: Color = Color::Hsla {
-        hue: 202.,
-        saturation: 0.8,
-        lightness: MIDDAY_LIGHTNESS,
-        alpha: 1.0,
-    };
-
-    /// The amount of lightness at the brightest point in a day cycle
-    pub(crate) const MIDDAY_LIGHTNESS: f32 = 0.8;
+    impl TimeOfDay {
+        /// The color of the sky at the given time of day.
+        pub(crate) const fn sky_color(&self) -> Color {
+            match self {
+                TimeOfDay::Dawn => Color::hsl(180., 0.3, 0.6),
+                TimeOfDay::Morning => Color::hsl(190., 0.3, 0.7),
+                TimeOfDay::Noon => Color::hsl(209., 0.7, 0.8),
+                TimeOfDay::Afternoon => Color::hsl(212., 0.55, 0.7),
+                TimeOfDay::Evening => Color::hsl(220., 0.4, 0.3),
+                TimeOfDay::Midnight => Color::hsl(232., 0.2, 0.1),
+            }
+        }
+    }
 
     /// The color of the surface water.
     pub(crate) const WATER: Color = Color::Hsla {

--- a/emergence_lib/src/simulation/time.rs
+++ b/emergence_lib/src/simulation/time.rs
@@ -195,9 +195,10 @@ impl Display for InGameTime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} days elapsed\n{:.2}h",
+            "{} days elapsed\n{:.2}h ({})",
             self.rounded_elapsed_days(),
-            self.twenty_four_hour_time()
+            self.twenty_four_hour_time(),
+            self.time_of_day()
         )
     }
 }

--- a/emergence_lib/src/simulation/time.rs
+++ b/emergence_lib/src/simulation/time.rs
@@ -207,7 +207,7 @@ impl Default for InGameTime {
     fn default() -> Self {
         InGameTime {
             elapsed_time: Days(0.0),
-            seconds_per_day: 300.,
+            seconds_per_day: 30.,
         }
     }
 }

--- a/emergence_lib/src/simulation/time.rs
+++ b/emergence_lib/src/simulation/time.rs
@@ -124,23 +124,12 @@ impl TimeOfDay {
     /// Returns the time of day that is closest to the given fraction of a day.
     ///
     /// Values outside of [0.0, 1.0] are modulo'd to fit the range.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use emergence_lib::simulation::time::TimeOfDay;
-    ///
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.0), TimeOfDay::Dawn);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.16), TimeOfDay::Morning);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.33), TimeOfDay::Noon);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.5), TimeOfDay::Afternoon);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.66), TimeOfDay::Evening);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(0.83), TimeOfDay::Midnight);
-    /// assert_eq!(TimeOfDay::from_fraction_of_day(1.0), TimeOfDay::Dawn);
-    /// ```
     pub fn from_fraction_of_day(fraction: f32) -> Self {
         let cleaned_fraction = fraction.rem_euclid(1.0);
         let scaled_fraction = cleaned_fraction * 6.0;
-        match scaled_fraction.round() as u32 {
+        // We want to ensure that noon is centered at 0.5.
+        let shifted_fraction = scaled_fraction + 0.5;
+        match shifted_fraction.round() as u32 {
             0 => TimeOfDay::Dawn,
             1 => TimeOfDay::Morning,
             2 => TimeOfDay::Noon,
@@ -164,11 +153,7 @@ impl InGameTime {
 
     /// How far are we through the day?
     ///
-    /// - 0.0 is dawn
-    /// - 0.25 is noon
-    /// - 0.5 is dusk
-    /// - 0.75 is midnight
-    /// - 0.999 is just before dawn
+    /// This begins at dawn, and ends at dawn the next day.
     pub fn fraction_of_day(&self) -> f32 {
         self.elapsed_time.0 % 1.0
     }

--- a/emergence_lib/src/simulation/time.rs
+++ b/emergence_lib/src/simulation/time.rs
@@ -192,7 +192,7 @@ impl Default for InGameTime {
     fn default() -> Self {
         InGameTime {
             elapsed_time: Days(0.0),
-            seconds_per_day: 30.,
+            seconds_per_day: 300.,
         }
     }
 }

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -382,7 +382,10 @@ fn update_water_depth(
     for tile_pos in map_geometry.valid_tile_positions() {
         let soil_height = map_geometry.get_height(tile_pos).unwrap_or_default();
         let water_volume = water_table.get_volume(tile_pos);
-        let terrain_entity = map_geometry.get_terrain(tile_pos).unwrap();
+        let Some(terrain_entity) = map_geometry.get_terrain(tile_pos) else {
+            continue;
+        };
+
         let terrain_id = *query.get(terrain_entity).unwrap();
 
         let relative_soil_water_capacity = terrain_manifest.get(terrain_id).water_capacity;

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -147,7 +147,7 @@ impl Default for GenerationConfig {
         structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
-            map_radius: 60,
+            map_radius: 20,
             number_of_burn_in_ticks: 0,
             unit_chances,
             landmark_chances,


### PR DESCRIPTION
Fixes #538.

Transitions for sky color are crude, but it works for now.