### PR TITLE
Ensure soil is conserved during terraforming operations

### DIFF
--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -58,7 +58,7 @@ impl TerraformingAction {
             Self::Raise => InputInventory::Exact {
                 inventory: Inventory::new_from_item(soil_id, Self::N_ITEMS),
             },
-            Self::Lower => InputInventory::default(),
+            Self::Lower => InputInventory::NULL,
             Self::Change(_terrain) => InputInventory::Exact {
                 inventory: Inventory::new_from_item(soil_id, Self::N_ITEMS),
             },
@@ -71,7 +71,7 @@ impl TerraformingAction {
         let soil_id = Id::<Item>::from_name("soil".to_string());
 
         match self {
-            Self::Raise => OutputInventory::default(),
+            Self::Raise => OutputInventory::NULL,
             Self::Lower => OutputInventory {
                 inventory: Inventory::full_from_item(soil_id, Self::N_ITEMS),
             },

--- a/emergence_lib/src/crafting/inventories.rs
+++ b/emergence_lib/src/crafting/inventories.rs
@@ -104,6 +104,11 @@ impl Default for InputInventory {
 }
 
 impl InputInventory {
+    /// An input inventory with no slots.
+    pub(crate) const NULL: Self = Self::Exact {
+        inventory: Inventory::NULL,
+    };
+
     /// Returns a reference the underlying [`Inventory`].
     pub fn inventory(&self) -> &Inventory {
         match self {
@@ -285,6 +290,11 @@ pub(crate) struct OutputInventory {
 }
 
 impl OutputInventory {
+    /// An output inventory with no slots.
+    pub(crate) const NULL: Self = Self {
+        inventory: Inventory::NULL,
+    };
+
     /// Randomizes the contents of this inventory so that each slot is somewhere between empty and full.
     pub(crate) fn randomize(&mut self, rng: &mut ThreadRng) {
         for item_slot in self.iter_mut() {

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -988,6 +988,46 @@ mod tests {
             }
 
             #[test]
+            fn adding_to_an_empty_inventory_should_be_fine() {
+                let mut inventory = Inventory::new(1, None);
+
+                assert_eq!(
+                    inventory.add_item_all_or_nothing(
+                        &ItemCount::new(Id::from_name("leaf".to_string()), 1),
+                        &item_manifest()
+                    ),
+                    Ok(())
+                );
+                assert_eq!(inventory.item_count(Id::from_name("leaf".to_string())), 1);
+            }
+
+            #[test]
+            fn adding_to_an_inventory_full_of_something_else_fails() {
+                let mut inventory = Inventory::new(1, None);
+                inventory
+                    .add_item_all_or_nothing(
+                        &ItemCount::new(Id::from_name("mushroom".to_string()), 1),
+                        &item_manifest(),
+                    )
+                    .unwrap();
+
+                assert_eq!(
+                    inventory.add_item_all_or_nothing(
+                        &ItemCount::new(Id::from_name("leaf".to_string()), 1),
+                        &item_manifest()
+                    ),
+                    Err(AddOneItemError {
+                        excess_count: ItemCount::new(Id::from_name("leaf".to_string()), 1)
+                    })
+                );
+
+                assert_eq!(
+                    inventory.item_count(Id::from_name("mushroom".to_string())),
+                    1
+                );
+            }
+
+            #[test]
             fn should_not_add_anything_if_not_enough_space() {
                 let mut inventory = Inventory {
                     reserved_for: None,

--- a/emergence_lib/src/items/inventory.rs
+++ b/emergence_lib/src/items/inventory.rs
@@ -69,6 +69,13 @@ impl InventoryState {
 
 #[allow(dead_code)]
 impl Inventory {
+    /// An inventory with no slots.
+    pub const NULL: Inventory = Inventory {
+        reserved_for: None,
+        slots: Vec::new(),
+        max_slot_count: 0,
+    };
+
     /// Create an empty inventory with the given amount of slots.
     pub fn new(max_slot_count: usize, reserved_for: Option<Id<Item>>) -> Self {
         Self {

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -548,6 +548,7 @@ pub(super) fn finish_actions(
                             .add_item_all_or_nothing(&item_count, item_manifest)
                             .is_ok()
                         {
+                            // FIXME: this seems to be leaking items
                             unit.unit_inventory.held_item = None;
                         }
                     }

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -548,7 +548,6 @@ pub(super) fn finish_actions(
                             .add_item_all_or_nothing(&item_count, item_manifest)
                             .is_ok()
                         {
-                            // FIXME: this seems to be leaking items
                             unit.unit_inventory.held_item = None;
                         }
                     }

--- a/emergence_lib/src/world_gen/mod.rs
+++ b/emergence_lib/src/world_gen/mod.rs
@@ -147,7 +147,7 @@ impl Default for GenerationConfig {
         structure_chances.insert(Id::from_name("leuco".to_string()), 1e-2);
 
         GenerationConfig {
-            map_radius: 60,
+            map_radius: 30,
             number_of_burn_in_ticks: 0,
             unit_chances,
             landmark_chances,


### PR DESCRIPTION
Fixes #879.

This was actually specific to soil and terraforming: additional inventory slots were being created due to the change to the Default impl on Inventory. This led to e.g. the "Lower" terraforming action being able to store assorted goods, which turned out to be a great place to drop off the dirt being created.