### PR TITLE
Add simple benchmarks for water dynamics

### DIFF
--- a/emergence_lib/Cargo.toml
+++ b/emergence_lib/Cargo.toml
@@ -41,3 +41,7 @@ criterion = "0.4"
 [[bench]]
 name = "signals"
 harness = false
+
+[[bench]]
+name = "water"
+harness = false

--- a/emergence_lib/benches/water.rs
+++ b/emergence_lib/benches/water.rs
@@ -1,0 +1,66 @@
+use bevy::prelude::*;
+use criterion::{criterion_group, criterion_main, Criterion};
+use emergence_lib::{
+    asset_management::manifest::Id,
+    simulation::geometry::{Height, MapGeometry, TilePos, Volume},
+    terrain::terrain_manifest::{Terrain, TerrainData, TerrainManifest},
+    water::{update_water_depth, WaterTable},
+};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    const MAP_RADIUS: u32 = 100;
+
+    let mut app = App::new();
+
+    let mut map_geometry = MapGeometry::new(MAP_RADIUS);
+    let mut water_table = WaterTable::default();
+    let mut terrain_manifest = TerrainManifest::default();
+    let porous = "porous".to_string();
+    let dense = "dense".to_string();
+
+    terrain_manifest.insert(
+        porous.clone(),
+        TerrainData {
+            water_capacity: 0.8,
+            ..Default::default()
+        },
+    );
+
+    terrain_manifest.insert(
+        dense.clone(),
+        TerrainData {
+            water_capacity: 0.2,
+            ..Default::default()
+        },
+    );
+
+    for tile_pos in map_geometry
+        .valid_tile_positions()
+        .collect::<Vec<TilePos>>()
+    {
+        // Make sure we cover a range of heights
+        let height = Height(tile_pos.x as f32);
+        let volume_per_tile = Volume(20.);
+        let terrain_string = if tile_pos.y % 2 == 0 { &porous } else { &dense };
+        let terrain_id = Id::<Terrain>::from_name(terrain_string.clone());
+
+        let terrain_entity = app.world.spawn((tile_pos, height, terrain_id)).id();
+
+        map_geometry.update_height(tile_pos, height);
+        map_geometry.add_terrain(tile_pos, terrain_entity);
+        water_table.add(tile_pos, volume_per_tile);
+    }
+
+    app.insert_resource(map_geometry);
+    app.insert_resource(water_table);
+    app.insert_resource(terrain_manifest);
+
+    app.add_system(update_water_depth);
+    // Run once to make sure system caches are populated
+    app.update();
+
+    c.bench_function("compute_water_depth", |b| b.iter(|| app.update()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/emergence_lib/benches/water.rs
+++ b/emergence_lib/benches/water.rs
@@ -39,7 +39,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .collect::<Vec<TilePos>>()
     {
         // Make sure we cover a range of heights
-        let height = Height(tile_pos.x as f32);
+        let height = Height(tile_pos.x.max(0) as f32);
         let volume_per_tile = Volume(20.);
         let terrain_string = if tile_pos.y % 2 == 0 { &porous } else { &dense };
         let terrain_id = Id::<Terrain>::from_name(terrain_string.clone());

--- a/emergence_lib/src/simulation/geometry.rs
+++ b/emergence_lib/src/simulation/geometry.rs
@@ -834,7 +834,7 @@ impl MapGeometry {
 
     /// Updates the height of the tile at `tile_pos`
     #[inline]
-    pub(crate) fn update_height(&mut self, tile_pos: TilePos, height: Height) {
+    pub fn update_height(&mut self, tile_pos: TilePos, height: Height) {
         assert!(
             self.is_valid(tile_pos),
             "Invalid tile position: {:?} with a radius of {:?}",
@@ -978,7 +978,7 @@ impl MapGeometry {
 
     /// Adds the provided `terrain_entity` to the terrain index at the provided `tile_pos`.
     #[inline]
-    pub(crate) fn add_terrain(&mut self, tile_pos: TilePos, terrain_entity: Entity) {
+    pub fn add_terrain(&mut self, tile_pos: TilePos, terrain_entity: Entity) {
         self.terrain_index.insert(tile_pos, terrain_entity);
     }
 

--- a/emergence_lib/src/terrain/terrain_manifest.rs
+++ b/emergence_lib/src/terrain/terrain_manifest.rs
@@ -42,6 +42,17 @@ pub struct TerrainData {
     pub water_evaporation_rate: f32,
 }
 
+impl Default for TerrainData {
+    fn default() -> Self {
+        Self {
+            walking_speed: 1.0,
+            water_capacity: 0.2,
+            water_flow_rate: 0.1,
+            water_evaporation_rate: 0.1,
+        }
+    }
+}
+
 /// The [`TerrainManifest`] as seen in the manifest file.
 #[derive(Debug, Clone, Serialize, Deserialize, TypeUuid, PartialEq)]
 #[uuid = "8d6b3b65-9b11-42a9-a795-f95b06653070"]

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -32,23 +32,23 @@ use self::{
 pub mod emitters;
 mod ocean;
 pub mod roots;
-mod water_dynamics;
+pub mod water_dynamics;
 
 /// Controls the key parameters of water movement and behavior.
 ///
 /// Note that soil properties are stored seperately for each soil type in [`TerrainData`](crate::terrain::terrain_manifest::TerrainData).
 #[derive(Resource, Debug, Clone, Copy)]
-pub(crate) struct WaterConfig {
+pub struct WaterConfig {
     /// The rate of evaporation per day from each tile.
-    evaporation_rate: Height,
+    pub evaporation_rate: Height,
     /// The rate of precipitation per day on each tile.
-    precipitation_rate: Height,
+    pub precipitation_rate: Height,
     /// The amount of water that is deposited per day on the tile of each water emitter.
-    emission_rate: Volume,
+    pub emission_rate: Volume,
     /// The amount of water that emitters can be covered with before they stop producing.
-    emission_pressure: Height,
+    pub emission_pressure: Height,
     /// The number of water items produced for each full tile of water.
-    water_items_per_tile: f32,
+    pub water_items_per_tile: f32,
     /// The rate at which water moves horizontally.
     ///
     /// The units are cubic tiles per day per tile of height difference.
@@ -56,16 +56,16 @@ pub(crate) struct WaterConfig {
     /// # Warning
     ///
     /// If this value becomes too large, the simulation may become unstable, with water alternating between fully flooded and fully dry tiles.
-    lateral_flow_rate: f32,
+    pub lateral_flow_rate: f32,
     /// Are oceans enabled?
-    pub(crate) enable_oceans: bool,
+    pub enable_oceans: bool,
     /// Controls the behavior of the tides.
-    tide_settings: TideSettings,
+    pub tide_settings: TideSettings,
 }
 
 impl WaterConfig {
     /// The default configuration for in-game water behavior.
-    const IN_GAME: Self = Self {
+    pub const IN_GAME: Self = Self {
         evaporation_rate: Height(2.0),
         precipitation_rate: Height(2.0),
         emission_rate: Volume(1e4),
@@ -81,8 +81,7 @@ impl WaterConfig {
     };
 
     /// A configuration that disables all water behavior.
-    #[allow(dead_code)]
-    const NULL: Self = Self {
+    pub const NULL: Self = Self {
         evaporation_rate: Height(0.0),
         precipitation_rate: Height(0.0),
         emission_rate: Volume(0.0),

--- a/emergence_lib/src/water/mod.rs
+++ b/emergence_lib/src/water/mod.rs
@@ -270,7 +270,7 @@ impl WaterTable {
     }
 
     /// Adds the given amount of water to the water table at the given tile.
-    pub(crate) fn add(&mut self, tile_pos: TilePos, amount: Volume) {
+    pub fn add(&mut self, tile_pos: TilePos, amount: Volume) {
         let height = self.get_volume(tile_pos);
         let new_height = height + amount;
         self.set_volume(tile_pos, new_height);
@@ -281,7 +281,7 @@ impl WaterTable {
     /// This will never return a height below zero.
     ///
     /// Returns the amount of water that was actually subtracted.
-    pub(crate) fn remove(&mut self, tile_pos: TilePos, amount: Volume) -> Volume {
+    pub fn remove(&mut self, tile_pos: TilePos, amount: Volume) -> Volume {
         let volume = self.get_volume(tile_pos);
         // We cannot take more water than there is.
         let water_drawn = amount.min(volume);
@@ -380,7 +380,7 @@ impl Display for WaterDepth {
 }
 
 /// Updates the depth of water at each tile based on the volume of water and soil properties.
-fn update_water_depth(
+pub fn update_water_depth(
     mut water_table: ResMut<WaterTable>,
     map_geometry: Res<MapGeometry>,
     query: Query<&Id<Terrain>>,

--- a/emergence_lib/src/water/ocean.rs
+++ b/emergence_lib/src/water/ocean.rs
@@ -11,13 +11,13 @@ use super::{WaterConfig, WaterTable};
 
 /// Controls the dynamics of [`tides`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(super) struct TideSettings {
+pub struct TideSettings {
     /// The amplitude of the tide.
-    pub(super) amplitude: Height,
+    pub amplitude: Height,
     /// The period of the tide.
-    pub(super) period: Days,
+    pub period: Days,
     /// The minimum water level of the ocean
-    pub(super) minimum: Height,
+    pub minimum: Height,
 }
 
 /// Controls the ebb and flow of the tides, raising and lowering the ocean level.

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -82,7 +82,7 @@ pub(super) fn precipitation(
 }
 
 /// Moves water from one tile to another, according to the relative height of the water table.
-pub(super) fn horizontal_water_movement(
+pub fn horizontal_water_movement(
     mut water_table: ResMut<WaterTable>,
     terrain_query: Query<&Id<Terrain>>,
     terrain_manifest: Res<TerrainManifest>,


### PR DESCRIPTION
Fixes #825.

Lateral water diffusion and height computation are the two expensive systems: so these are the only ones benched for now.