### PR TITLE
Cache neighbors on MapGeometry

### DIFF
--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -71,7 +71,7 @@ impl MapGeometry {
                 let mut neighbors = [None; 6];
 
                 for (i, neighboring_hex) in hex.all_neighbors().into_iter().enumerate() {
-                    if hex.distance_to(neighboring_hex) <= radius as i32 {
+                    if Hex::ZERO.distance_to(neighboring_hex) <= radius as i32 {
                         neighbors[i] = Some(TilePos {
                             hex: neighboring_hex,
                         })

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -543,25 +543,34 @@ impl MapGeometry {
     /// The set of adjacent tiles that are on the map.
     #[inline]
     #[must_use]
-    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self.valid_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
+        if let Some(array) = self.valid_neighbors.get(&tile_pos) {
+            array.iter().filter_map(|&x| x).collect()
+        } else {
+            Vec::new()
+        }
     }
 
     /// The set of tiles that can be walked to by a basket crab from `tile_pos`.
     #[inline]
     #[must_use]
-    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self.passable_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
+        if let Some(array) = self.passable_neighbors.get(&tile_pos) {
+            array.iter().filter_map(|&x| x).collect()
+        } else {
+            Vec::new()
+        }
     }
 
     /// The set of tiles that can be reached by a basket crab from `tile_pos`.
     #[inline]
     #[must_use]
-    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self
-            .reachable_neighbors
-            .get(&tile_pos)
-            .unwrap_or(&[None; 6])
+    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
+        if let Some(array) = self.reachable_neighbors.get(&tile_pos) {
+            array.iter().filter_map(|&x| x).collect()
+        } else {
+            Vec::new()
+        }
     }
 }
 

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -581,7 +581,7 @@ impl MapGeometry {
     pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
         self.valid_neighbors
             .get(&tile_pos)
-            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
+            .unwrap_or_else(|| panic!("Tile position {tile_pos:?} is not a valid tile position"))
     }
 
     /// The set of tiles that can be walked to by a basket crab from `tile_pos`.
@@ -594,7 +594,7 @@ impl MapGeometry {
     pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
         self.passable_neighbors
             .get(&tile_pos)
-            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
+            .unwrap_or_else(|| panic!("Tile position {tile_pos:?} is not a valid tile position"))
     }
 
     /// The set of tiles that can be reached by a basket crab from `tile_pos`.
@@ -607,14 +607,14 @@ impl MapGeometry {
     pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
         self.reachable_neighbors
             .get(&tile_pos)
-            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
+            .unwrap_or_else(|| panic!("Tile position {tile_pos:?} is not a valid tile position"))
     }
 
     /// Recomputes the set of passable neighbors for the provided `tile_pos`.
     ///
     /// This will update the provided tile and all of its neighbors.
     fn recompute_passable_neighbors(&mut self, tile_pos: TilePos) {
-        let neighbors = self.valid_neighbors(tile_pos).clone();
+        let neighbors = *self.valid_neighbors(tile_pos);
         let mut passable_neighbors: [Option<TilePos>; 6] = [None; 6];
 
         for (i, maybe_neighbor) in neighbors.iter().enumerate() {
@@ -656,7 +656,7 @@ impl MapGeometry {
     ///
     /// This will update the provided tile and all of its neighbors.
     fn recompute_reachable_neighbors(&mut self, tile_pos: TilePos) {
-        let neighbors = self.valid_neighbors(tile_pos).clone();
+        let neighbors = *self.valid_neighbors(tile_pos);
         let mut reachable_neighbors: [Option<TilePos>; 6] = [None; 6];
 
         for (i, maybe_neighbor) in neighbors.iter().enumerate() {
@@ -695,6 +695,7 @@ impl MapGeometry {
             .insert(tile_pos, reachable_neighbors);
     }
 
+    /// Can the tile at `ending_pos` be moved to from the tile at `starting_pos`?
     fn compute_passability(&self, starting_pos: TilePos, ending_pos: TilePos) -> bool {
         if !self.is_valid(ending_pos) {
             return false;
@@ -715,6 +716,7 @@ impl MapGeometry {
         }
     }
 
+    /// Can the tile at `ending_pos` be reached from the tile at `starting_pos`?
     fn compute_reachability(&self, starting_pos: TilePos, ending_pos: TilePos) -> bool {
         if !self.is_valid(ending_pos) {
             return false;

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -539,6 +539,30 @@ impl MapGeometry {
         let hex_ring = Hex::ZERO.ring(self.radius + 1);
         hex_ring.map(move |hex| TilePos { hex })
     }
+
+    /// The set of adjacent tiles that are on the map.
+    #[inline]
+    #[must_use]
+    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self.valid_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    }
+
+    /// The set of tiles that can be walked to by a basket crab from `tile_pos`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self.passable_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    }
+
+    /// The set of tiles that can be reached by a basket crab from `tile_pos`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self
+            .reachable_neighbors
+            .get(&tile_pos)
+            .unwrap_or(&[None; 6])
+    }
 }
 
 #[cfg(test)]

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -543,34 +543,25 @@ impl MapGeometry {
     /// The set of adjacent tiles that are on the map.
     #[inline]
     #[must_use]
-    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
-        if let Some(array) = self.valid_neighbors.get(&tile_pos) {
-            array.iter().filter_map(|&x| x).collect()
-        } else {
-            Vec::new()
-        }
+    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self.valid_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
     }
 
     /// The set of tiles that can be walked to by a basket crab from `tile_pos`.
     #[inline]
     #[must_use]
-    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
-        if let Some(array) = self.passable_neighbors.get(&tile_pos) {
-            array.iter().filter_map(|&x| x).collect()
-        } else {
-            Vec::new()
-        }
+    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self.passable_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
     }
 
     /// The set of tiles that can be reached by a basket crab from `tile_pos`.
     #[inline]
     #[must_use]
-    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> Vec<TilePos> {
-        if let Some(array) = self.reachable_neighbors.get(&tile_pos) {
-            array.iter().filter_map(|&x| x).collect()
-        } else {
-            Vec::new()
-        }
+    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
+        *self
+            .reachable_neighbors
+            .get(&tile_pos)
+            .unwrap_or(&[None; 6])
     }
 }
 

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -585,6 +585,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn map_geometry_is_initialized_successfully() {
+        let radius = 10;
+
+        let map_geometry = MapGeometry::new(radius);
+        let hexagon = hexagon(Hex::ZERO, radius);
+        let n = hexagon.len();
+
+        assert_eq!(map_geometry.radius, radius);
+        let n_valid_neighbors = map_geometry.valid_neighbors.iter().count();
+        assert_eq!(n_valid_neighbors, n);
+        let n_passable_neighbors = map_geometry.passable_neighbors.iter().count();
+        assert_eq!(n_passable_neighbors, n);
+        let n_reachable_neighbors = map_geometry.reachable_neighbors.iter().count();
+        assert_eq!(n_reachable_neighbors, n);
+
+        for hex in hexagon {
+            let tile_pos = TilePos { hex };
+            assert!(
+                map_geometry.valid_neighbors.contains_key(&tile_pos),
+                "{}",
+                tile_pos
+            );
+            assert!(
+                map_geometry.passable_neighbors.contains_key(&tile_pos),
+                "{}",
+                tile_pos
+            );
+            assert!(
+                map_geometry.reachable_neighbors.contains_key(&tile_pos),
+                "{}",
+                tile_pos
+            );
+        }
+
+        // All of the neighbors should be the same for a newly initialized map
+        assert_eq!(
+            map_geometry.valid_neighbors,
+            map_geometry.passable_neighbors
+        );
+        assert_eq!(
+            map_geometry.passable_neighbors,
+            map_geometry.reachable_neighbors
+        );
+    }
+
+    #[test]
     fn adding_multi_tile_structure_adds_to_index() {
         let mut map_geometry = MapGeometry::new(10);
 

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -798,7 +798,7 @@ mod tests {
         let footprint = Footprint::hexagon(1);
         let structure_entity = Entity::from_bits(42);
         let facing = Facing::default();
-        let center = TilePos::new(17, -2);
+        let center = TilePos::new(0, 0);
         let passable = false;
 
         map_geometry.add_structure(facing, center, &footprint, passable, structure_entity);
@@ -816,7 +816,7 @@ mod tests {
         let footprint = Footprint::hexagon(1);
         let structure_entity = Entity::from_bits(42);
         let facing = Facing::default();
-        let center = TilePos::new(17, -2);
+        let center = TilePos::new(3, -2);
         let passable = false;
 
         map_geometry.add_structure(facing, center, &footprint, passable, structure_entity);

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -585,42 +585,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn height_is_invertable() {
-        for i in u8::MIN..=u8::MAX {
-            let height = Height(i as f32);
-            let z = height.into_world_pos();
-            let remapped_height = Height::from_world_pos(z);
-
-            assert_eq!(height, remapped_height);
-        }
-    }
-
-    #[test]
-    fn height_clamps() {
-        assert_eq!(Height::MIN, Height::from_world_pos(0.));
-        assert_eq!(Height::MIN, Height::from_world_pos(-1.));
-        assert_eq!(Height::MAX, Height::from_world_pos(9000.));
-        assert_eq!(Height::MAX, Height::from_world_pos(f32::MAX));
-    }
-
-    #[test]
-    fn world_to_tile_pos_conversions_are_invertable() {
-        let mut map_geometry = MapGeometry::new(20);
-
-        for x in -10..=10 {
-            for y in -10..=10 {
-                let tile_pos = TilePos::new(x, y);
-                // Height chosen arbitrarily to reduce odds of this accidentally working
-                map_geometry.update_height(tile_pos, Height(17.));
-                let world_pos = tile_pos.into_world_pos(&map_geometry);
-                let remapped_tile_pos = TilePos::from_world_pos(world_pos, &map_geometry);
-
-                assert_eq!(tile_pos, remapped_tile_pos);
-            }
-        }
-    }
-
-    #[test]
     fn adding_multi_tile_structure_adds_to_index() {
         let mut map_geometry = MapGeometry::new(10);
 

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -619,6 +619,21 @@ mod tests {
             );
         }
 
+        for (tile_pos, valid_neighbors) in &map_geometry.valid_neighbors {
+            assert!(valid_neighbors.len() <= 6, "{}", tile_pos);
+            for maybe_neighbor in valid_neighbors {
+                if let Some(neighbor) = maybe_neighbor {
+                    assert!(map_geometry.is_valid(*neighbor), "{}", neighbor);
+
+                    assert!(
+                        map_geometry.valid_neighbors.contains_key(neighbor),
+                        "{}",
+                        neighbor
+                    );
+                }
+            }
+        }
+
         // All of the neighbors should be the same for a newly initialized map
         assert_eq!(
             map_geometry.valid_neighbors,

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -470,8 +470,8 @@ impl MapGeometry {
             // If that occurs, this fails silently, but that's intended behavior
             self.impassable_structure_tiles.remove(&tile_pos);
 
-            self.recompute_passable_neighbors(center);
-            self.recompute_reachable_neighbors(center);
+            self.recompute_passable_neighbors(tile_pos);
+            self.recompute_reachable_neighbors(tile_pos);
         }
 
         removed

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -541,27 +541,42 @@ impl MapGeometry {
     }
 
     /// The set of adjacent tiles that are on the map.
+    ///
+    /// # Panics
+    ///
+    /// The provided `tile_pos` must be a valid tile position.
     #[inline]
     #[must_use]
-    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self.valid_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    pub(crate) fn valid_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
+        self.valid_neighbors
+            .get(&tile_pos)
+            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
     }
 
     /// The set of tiles that can be walked to by a basket crab from `tile_pos`.
+    ///
+    /// # Panics
+    ///
+    /// The provided `tile_pos` must be a valid tile position.
     #[inline]
     #[must_use]
-    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self.passable_neighbors.get(&tile_pos).unwrap_or(&[None; 6])
+    pub(crate) fn passable_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
+        self.passable_neighbors
+            .get(&tile_pos)
+            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
     }
 
     /// The set of tiles that can be reached by a basket crab from `tile_pos`.
+    ///
+    /// # Panics
+    ///
+    /// The provided `tile_pos` must be a valid tile position.
     #[inline]
     #[must_use]
-    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> [Option<TilePos>; 6] {
-        *self
-            .reachable_neighbors
+    pub(crate) fn reachable_neighbors(&self, tile_pos: TilePos) -> &[Option<TilePos>; 6] {
+        self.reachable_neighbors
             .get(&tile_pos)
-            .unwrap_or(&[None; 6])
+            .unwrap_or_else(|| panic!("Tile position {:?} is not a valid tile position", tile_pos))
     }
 }
 

--- a/emergence_lib/src/geometry/position.rs
+++ b/emergence_lib/src/geometry/position.rs
@@ -534,3 +534,44 @@ impl Div<Volume> for Volume {
         self.0 / rhs.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn height_is_invertable() {
+        for i in u8::MIN..=u8::MAX {
+            let height = Height(i as f32);
+            let z = height.into_world_pos();
+            let remapped_height = Height::from_world_pos(z);
+
+            assert_eq!(height, remapped_height);
+        }
+    }
+
+    #[test]
+    fn height_clamps() {
+        assert_eq!(Height::MIN, Height::from_world_pos(0.));
+        assert_eq!(Height::MIN, Height::from_world_pos(-1.));
+        assert_eq!(Height::MAX, Height::from_world_pos(9000.));
+        assert_eq!(Height::MAX, Height::from_world_pos(f32::MAX));
+    }
+
+    #[test]
+    fn world_to_tile_pos_conversions_are_invertable() {
+        let mut map_geometry = MapGeometry::new(20);
+
+        for x in -10..=10 {
+            for y in -10..=10 {
+                let tile_pos = TilePos::new(x, y);
+                // Height chosen arbitrarily to reduce odds of this accidentally working
+                map_geometry.update_height(tile_pos, Height(17.));
+                let world_pos = tile_pos.into_world_pos(&map_geometry);
+                let remapped_tile_pos = TilePos::from_world_pos(world_pos, &map_geometry);
+
+                assert_eq!(tile_pos, remapped_tile_pos);
+            }
+        }
+    }
+}

--- a/emergence_lib/src/geometry/position.rs
+++ b/emergence_lib/src/geometry/position.rs
@@ -147,7 +147,6 @@ impl TilePos {
     /// # Warning
     ///
     /// This includes neighbors that are not on the map.
-    /// Use [`TilePos::all_valid_neighbors`] to get only valid neighbors.
     #[inline]
     #[must_use]
     pub(crate) fn all_neighbors(&self) -> impl IntoIterator<Item = TilePos> {

--- a/emergence_lib/src/geometry/rotation.rs
+++ b/emergence_lib/src/geometry/rotation.rs
@@ -186,10 +186,7 @@ mod tests {
             let flat_radians = direction.angle(&HexOrientation::flat());
             let flat_direction = direction_from_angle(flat_radians, HexOrientation::flat());
 
-            assert_eq!(
-                direction, pointy_direction,
-                "Failed for {pointy_radians:?}"
-            );
+            assert_eq!(direction, pointy_direction, "Failed for {pointy_radians:?}");
             assert_eq!(direction, flat_direction, "Failed for {flat_radians:?}");
         }
     }

--- a/emergence_lib/src/geometry/rotation.rs
+++ b/emergence_lib/src/geometry/rotation.rs
@@ -188,10 +188,9 @@ mod tests {
 
             assert_eq!(
                 direction, pointy_direction,
-                "Failed for {:?}",
-                pointy_radians
+                "Failed for {pointy_radians:?}"
             );
-            assert_eq!(direction, flat_direction, "Failed for {:?}", flat_radians);
+            assert_eq!(direction, flat_direction, "Failed for {flat_radians:?}");
         }
     }
 
@@ -206,8 +205,8 @@ mod tests {
             let large_direction = direction_from_angle(large_radians, HexOrientation::flat());
             let small_direction = direction_from_angle(small_radians, HexOrientation::flat());
 
-            assert_eq!(direction, large_direction, "Failed for {:?}", large_radians);
-            assert_eq!(direction, small_direction, "Failed for {:?}", small_radians);
+            assert_eq!(direction, large_direction, "Failed for {large_radians:?}");
+            assert_eq!(direction, small_direction, "Failed for {small_radians:?}");
         }
     }
 
@@ -225,8 +224,8 @@ mod tests {
             let large_direction = direction_from_angle(large_radians, HexOrientation::flat());
             let small_direction = direction_from_angle(small_radians, HexOrientation::flat());
 
-            assert_eq!(direction, large_direction, "Failed for {:?}", large_radians);
-            assert_eq!(direction, small_direction, "Failed for {:?}", small_radians);
+            assert_eq!(direction, large_direction, "Failed for {large_radians:?}");
+            assert_eq!(direction, small_direction, "Failed for {small_radians:?}");
         }
     }
 }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -259,7 +259,9 @@ impl Signals {
         let mut signal_strength_map = HashMap::with_capacity(7);
 
         signal_strength_map.insert(tile_pos, self.get(signal_type, tile_pos));
-        for neighbor in tile_pos.all_valid_neighbors(map_geometry) {
+        for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signal_strength_map.insert(neighbor, self.get(signal_type, neighbor));
         }
 
@@ -288,7 +290,7 @@ impl Signals {
                         .out_of_bounds_neighbors(map_geometry)
                         .into_iter()
                         .count() as f32;
-                    for neighboring_tile in occupied_tile.passable_neighbors(map_geometry) {
+                    for neighboring_tile in map_geometry.passable_neighbors(occupied_tile) {
                         num_neighbors += 1.0;
                         addition_map.push((neighboring_tile, amount_to_send_to_each_neighbor));
                     }
@@ -303,7 +305,8 @@ impl Signals {
                     original_map.subtract_signal(removal_pos, removal_strength)
                 }
 
-                for (addition_pos, addition_strength) in addition_map.into_iter() {
+                for (maybe_addition_pos, addition_strength) in addition_map.into_iter() {
+                    let Some(addition_pos) = maybe_addition_pos else { continue };
                     original_map.add_signal(addition_pos, addition_strength)
                 }
             });
@@ -873,7 +876,8 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for neighbor in TilePos::ZERO.all_valid_neighbors(&map_geometry) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
             signals.add_signal(SignalType::Push(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -901,7 +905,9 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for neighbor in TilePos::ZERO.all_valid_neighbors(&map_geometry) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -922,7 +928,9 @@ mod tests {
         let map_geometry = MapGeometry::new(1);
         let item_manifest = test_manifest();
 
-        for neighbor in TilePos::ZERO.all_valid_neighbors(&map_geometry) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -948,7 +956,9 @@ mod tests {
             SignalStrength(0.5),
         );
 
-        for neighbor in TilePos::ZERO.all_valid_neighbors(&map_geometry) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(1.));
         }
 

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -259,7 +259,9 @@ impl Signals {
         let mut signal_strength_map = HashMap::with_capacity(7);
 
         signal_strength_map.insert(tile_pos, self.get(signal_type, tile_pos));
-        for neighbor in map_geometry.valid_neighbors(tile_pos) {
+        for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signal_strength_map.insert(neighbor, self.get(signal_type, neighbor));
         }
 
@@ -303,7 +305,8 @@ impl Signals {
                     original_map.subtract_signal(removal_pos, removal_strength)
                 }
 
-                for (addition_pos, addition_strength) in addition_map.into_iter() {
+                for (maybe_addition_pos, addition_strength) in addition_map.into_iter() {
+                    let Some(addition_pos) = maybe_addition_pos else { continue };
                     original_map.add_signal(addition_pos, addition_strength)
                 }
             });
@@ -873,7 +876,8 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
             signals.add_signal(SignalType::Push(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -901,7 +905,9 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -922,7 +928,9 @@ mod tests {
         let map_geometry = MapGeometry::new(1);
         let item_manifest = test_manifest();
 
-        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -948,7 +956,9 @@ mod tests {
             SignalStrength(0.5),
         );
 
-        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
+            let Some(neighbor) = maybe_neighbor else { continue };
+
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(1.));
         }
 

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -260,7 +260,7 @@ impl Signals {
 
         signal_strength_map.insert(tile_pos, self.get(signal_type, tile_pos));
         for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+            let &Some(neighbor) = maybe_neighbor else { continue };
 
             signal_strength_map.insert(neighbor, self.get(signal_type, neighbor));
         }
@@ -306,7 +306,7 @@ impl Signals {
                 }
 
                 for (maybe_addition_pos, addition_strength) in addition_map.into_iter() {
-                    let Some(addition_pos) = maybe_addition_pos else { continue };
+                    let &Some(addition_pos) = maybe_addition_pos else { continue };
                     original_map.add_signal(addition_pos, addition_strength)
                 }
             });
@@ -877,7 +877,7 @@ mod tests {
         );
 
         for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+            let &Some(neighbor) = maybe_neighbor else { continue };
             signals.add_signal(SignalType::Push(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -906,7 +906,7 @@ mod tests {
         );
 
         for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+            let &Some(neighbor) = maybe_neighbor else { continue };
 
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
@@ -929,7 +929,7 @@ mod tests {
         let item_manifest = test_manifest();
 
         for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+            let &Some(neighbor) = maybe_neighbor else { continue };
 
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
@@ -957,7 +957,7 @@ mod tests {
         );
 
         for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+            let &Some(neighbor) = maybe_neighbor else { continue };
 
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(1.));
         }

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -259,9 +259,7 @@ impl Signals {
         let mut signal_strength_map = HashMap::with_capacity(7);
 
         signal_strength_map.insert(tile_pos, self.get(signal_type, tile_pos));
-        for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
-            let Some(neighbor) = maybe_neighbor else { continue };
-
+        for neighbor in map_geometry.valid_neighbors(tile_pos) {
             signal_strength_map.insert(neighbor, self.get(signal_type, neighbor));
         }
 
@@ -305,8 +303,7 @@ impl Signals {
                     original_map.subtract_signal(removal_pos, removal_strength)
                 }
 
-                for (maybe_addition_pos, addition_strength) in addition_map.into_iter() {
-                    let Some(addition_pos) = maybe_addition_pos else { continue };
+                for (addition_pos, addition_strength) in addition_map.into_iter() {
                     original_map.add_signal(addition_pos, addition_strength)
                 }
             });
@@ -876,8 +873,7 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
+        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
             signals.add_signal(SignalType::Push(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -905,9 +901,7 @@ mod tests {
             SignalStrength(1.),
         );
 
-        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
-
+        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -928,9 +922,7 @@ mod tests {
         let map_geometry = MapGeometry::new(1);
         let item_manifest = test_manifest();
 
-        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
-
+        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(0.5));
         }
 
@@ -956,9 +948,7 @@ mod tests {
             SignalStrength(0.5),
         );
 
-        for maybe_neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
-            let Some(neighbor) = maybe_neighbor else { continue };
-
+        for neighbor in map_geometry.valid_neighbors(TilePos::ZERO) {
             signals.add_signal(SignalType::Pull(test_item()), neighbor, SignalStrength(1.));
         }
 

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -730,7 +730,11 @@ impl CurrentAction {
             return CurrentAction::idle();
         }
 
-        for tile_pos in map_geometry.reachable_neighbors(unit_tile_pos) {
+        for maybe_tile_pos in map_geometry.reachable_neighbors(unit_tile_pos) {
+            let Some(tile_pos) = maybe_tile_pos else {
+                continue;
+            };
+
             for candidate in map_geometry.get_candidates(tile_pos, delivery_mode) {
                 match (delivery_mode, purpose) {
                     (DeliveryMode::PickUp, Purpose::Intrinsic) => {
@@ -847,7 +851,11 @@ impl CurrentAction {
         } else {
             let mut workplaces: Vec<(Entity, TilePos)> = Vec::new();
 
-            for neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
+            for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
+                let Some(neighbor) = maybe_neighbor else {
+                    continue;
+                };
+
                 if let Some(workplace) =
                     workplace_query.needs_work(unit_tile_pos, neighbor, workplace_id, map_geometry)
                 {
@@ -912,7 +920,11 @@ impl CurrentAction {
         } else {
             let mut demo_sites: Vec<(Entity, TilePos)> = Vec::new();
 
-            for neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
+            for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
+                let Some(neighbor) = maybe_neighbor else {
+                    continue;
+                };
+
                 if let Some(demo_site) = demolition_query.needs_demolition(
                     unit_tile_pos,
                     neighbor,
@@ -1250,7 +1262,11 @@ impl CurrentAction {
         let mut candidates = Vec::new();
 
         // Find all adjacent tiles that are shallower than the current tile.
-        for adjacent_tile in map_geometry.passable_neighbors(current_tile) {
+        for maybe_adjacent_tile in map_geometry.passable_neighbors(current_tile) {
+            let Some(adjacent_tile) = maybe_adjacent_tile else {
+                continue;
+            };
+
             let adjacent_terrain_entity = map_geometry.get_terrain(current_tile).unwrap();
             let adjacent_depth = water_depth_query
                 .get(adjacent_terrain_entity)

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -730,11 +730,7 @@ impl CurrentAction {
             return CurrentAction::idle();
         }
 
-        for maybe_tile_pos in map_geometry.reachable_neighbors(unit_tile_pos) {
-            let Some(tile_pos) = maybe_tile_pos else {
-                continue;
-            };
-
+        for tile_pos in map_geometry.reachable_neighbors(unit_tile_pos) {
             for candidate in map_geometry.get_candidates(tile_pos, delivery_mode) {
                 match (delivery_mode, purpose) {
                     (DeliveryMode::PickUp, Purpose::Intrinsic) => {
@@ -851,11 +847,7 @@ impl CurrentAction {
         } else {
             let mut workplaces: Vec<(Entity, TilePos)> = Vec::new();
 
-            for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
-                let Some(neighbor) = maybe_neighbor else {
-                    continue;
-                };
-
+            for neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
                 if let Some(workplace) =
                     workplace_query.needs_work(unit_tile_pos, neighbor, workplace_id, map_geometry)
                 {
@@ -920,11 +912,7 @@ impl CurrentAction {
         } else {
             let mut demo_sites: Vec<(Entity, TilePos)> = Vec::new();
 
-            for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
-                let Some(neighbor) = maybe_neighbor else {
-                    continue;
-                };
-
+            for neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
                 if let Some(demo_site) = demolition_query.needs_demolition(
                     unit_tile_pos,
                     neighbor,
@@ -1262,11 +1250,7 @@ impl CurrentAction {
         let mut candidates = Vec::new();
 
         // Find all adjacent tiles that are shallower than the current tile.
-        for maybe_adjacent_tile in map_geometry.passable_neighbors(current_tile) {
-            let Some(adjacent_tile) = maybe_adjacent_tile else {
-                continue;
-            };
-
+        for adjacent_tile in map_geometry.passable_neighbors(current_tile) {
             let adjacent_terrain_entity = map_geometry.get_terrain(current_tile).unwrap();
             let adjacent_depth = water_depth_query
                 .get(adjacent_terrain_entity)

--- a/emergence_lib/src/units/actions.rs
+++ b/emergence_lib/src/units/actions.rs
@@ -731,7 +731,7 @@ impl CurrentAction {
         }
 
         for maybe_tile_pos in map_geometry.reachable_neighbors(unit_tile_pos) {
-            let Some(tile_pos) = maybe_tile_pos else {
+            let &Some(tile_pos) = maybe_tile_pos else {
                 continue;
             };
 
@@ -852,7 +852,7 @@ impl CurrentAction {
             let mut workplaces: Vec<(Entity, TilePos)> = Vec::new();
 
             for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
-                let Some(neighbor) = maybe_neighbor else {
+                let &Some(neighbor) = maybe_neighbor else {
                     continue;
                 };
 
@@ -921,7 +921,7 @@ impl CurrentAction {
             let mut demo_sites: Vec<(Entity, TilePos)> = Vec::new();
 
             for maybe_neighbor in map_geometry.reachable_neighbors(unit_tile_pos) {
-                let Some(neighbor) = maybe_neighbor else {
+                let &Some(neighbor) = maybe_neighbor else {
                     continue;
                 };
 
@@ -1263,7 +1263,7 @@ impl CurrentAction {
 
         // Find all adjacent tiles that are shallower than the current tile.
         for maybe_adjacent_tile in map_geometry.passable_neighbors(current_tile) {
-            let Some(adjacent_tile) = maybe_adjacent_tile else {
+            let &Some(adjacent_tile) = maybe_adjacent_tile else {
                 continue;
             };
 

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -218,7 +218,9 @@ pub fn horizontal_water_movement(
     if water_config.enable_oceans {
         for tile_pos in map_geometry.ocean_tiles() {
             // Don't bother flowing to and from ocean tiles
-            for valid_neighbor in tile_pos.all_valid_neighbors(&map_geometry) {
+            for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
+                let Some(valid_neighbor) = maybe_neighbor else { continue };
+
                 let neighbor_entity = map_geometry.get_terrain(valid_neighbor).unwrap();
                 let neighbor_query_item = terrain_query.get(neighbor_entity).unwrap();
 

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -218,7 +218,9 @@ pub fn horizontal_water_movement(
     if water_config.enable_oceans {
         for tile_pos in map_geometry.ocean_tiles() {
             // Don't bother flowing to and from ocean tiles
-            for valid_neighbor in map_geometry.valid_neighbors(tile_pos) {
+            for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
+                let Some(valid_neighbor) = maybe_neighbor else { continue };
+
                 let neighbor_entity = map_geometry.get_terrain(valid_neighbor).unwrap();
                 let neighbor_query_item = terrain_query.get(neighbor_entity).unwrap();
 

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -637,25 +637,25 @@ mod tests {
                     let map_geometry = app.world.resource::<MapGeometry>();
 
                     for (&tile_pos, &water_volume) in water_query.iter(&app.world) {
-                        if water_table_strategy.starting_water_volume(tile_pos, &map_geometry)
+                        if water_table_strategy.starting_water_volume(tile_pos, map_geometry)
                             > WaterVolume::ZERO
                         {
                             assert!(
-                                water_volume < water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                                water_volume < water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                                 "Water level {:?} at tile position {} is greater than or equal to the starting water level of {:?} in {:?}",
                                 water_volume,
                                 tile_pos,
-                                water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                                water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                                 scenario
                             );
                         } else {
                             assert_eq!(
                                 water_volume,
-                                water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                                water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                                 "Water level {:?} at tile position {} is not equal to the starting water level of {:?} in {:?}",
                                 water_volume,
                                 tile_pos,
-                                water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                                water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                                 scenario
                             );
                         }
@@ -690,11 +690,11 @@ mod tests {
 
                     for (&tile_pos, &water_volume) in water_query.iter(&app.world) {
                         assert!(
-                            water_volume > water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                            water_volume > water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                             "Water level {:?} at tile position {} is less than the starting water level of {:?} in {:?}",
                             water_volume,
                             tile_pos,
-                            water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                            water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                             scenario
                         );
                     }
@@ -741,10 +741,7 @@ mod tests {
 
                 assert!(
                     final_total_water > starting_total_water,
-                    "Water level {:?} is not greater than the initial water level of {:?} in {:?}",
-                    final_total_water,
-                    starting_total_water,
-                    scenario
+                    "Water level {final_total_water:?} is not greater than the initial water level of {starting_total_water:?} in {scenario:?}"
                 );
 
                 let mut water_query = app.world.query::<(&TilePos, &WaterVolume)>();
@@ -752,11 +749,11 @@ mod tests {
 
                 for (&tile_pos, &water_volume) in water_query.iter(&app.world) {
                     assert!(
-                            water_volume > water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                            water_volume > water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                             "Water level {:?} at tile position {} is less than or equal to the starting water level of {:?} in {:?}",
                             water_volume,
                             tile_pos,
-                            water_table_strategy.starting_water_volume(tile_pos, &map_geometry),
+                            water_table_strategy.starting_water_volume(tile_pos, map_geometry),
                             scenario
                         );
                 }
@@ -805,9 +802,7 @@ mod tests {
 
             assert!(
                 height.abs_diff(average_water_height) < EPSILON_HEIGHT,
-                "Water level {:?} is not equal to the average water level of {:?}",
-                height,
-                average_water_height,
+                "Water level {height:?} is not equal to the average water level of {average_water_height:?}",
             )
         }
     }
@@ -853,9 +848,7 @@ mod tests {
 
             assert!(
                 height.abs_diff(average_water_height) < EPSILON_HEIGHT,
-                "Water level {:?} is not equal to the average water level of {:?}",
-                height,
-                average_water_height,
+                "Water level {height:?} is not equal to the average water level of {average_water_height:?}",
             )
         }
     }
@@ -901,9 +894,7 @@ mod tests {
 
             assert!(
                 water_height.abs_diff(water_height_of_arbitrary_neighbor) < EPSILON_HEIGHT,
-                "Water level is not equal between neighbor: {:?} vs. {:?}",
-                water_height,
-                water_height_of_arbitrary_neighbor,
+                "Water level is not equal between neighbor: {water_height:?} vs. {water_height_of_arbitrary_neighbor:?}",
             )
         }
     }
@@ -945,10 +936,7 @@ mod tests {
         for (water_volume, tile_pos) in water_volume_query.iter(&app.world) {
             assert!(
                 water_volume.abs_diff(desired_water_volume) < EPSILON_VOLUME,
-                "Water level is not level: found {:?} at {} but expected {:?}",
-                water_volume,
-                tile_pos,
-                desired_water_volume,
+                "Water level is not level: found {water_volume:?} at {tile_pos} but expected {desired_water_volume:?}",
             )
         }
     }
@@ -987,10 +975,7 @@ mod tests {
 
                     assert!(
                         final_total_water == starting_total_water,
-                        "Total water at the end ({:?}) is not equal to the amount of water that we started with ({:?}) in {:?}",
-                        final_total_water,
-                        starting_total_water,
-                        scenario
+                        "Total water at the end ({final_total_water:?}) is not equal to the amount of water that we started with ({starting_total_water:?}) in {scenario:?}"
                     );
                 }
             }
@@ -1036,10 +1021,7 @@ mod tests {
 
                     assert!(
                         water_difference < EPSILON,
-                        "Total water at the end ({:?}) is not equal to the amount of water that we started with ({:?}) in {:?}",
-                        final_total_water,
-                        starting_total_water,
-                        scenario
+                        "Total water at the end ({final_total_water:?}) is not equal to the amount of water that we started with ({starting_total_water:?}) in {scenario:?}"
                     );
                 }
             }
@@ -1084,10 +1066,7 @@ mod tests {
 
                     assert!(
                         water_difference < EPSILON,
-                        "Total water at the end ({:?}) is not equal to the amount of water that we started with ({:?}) in {:?}",
-                        final_total_water,
-                        final_total_water,
-                        scenario
+                        "Total water at the end ({final_total_water:?}) is not equal to the amount of water that we started with ({final_total_water:?}) in {scenario:?}"
                     );
                 }
             }
@@ -1110,8 +1089,7 @@ mod tests {
 
         assert!(
             water_transferred > Volume::ZERO,
-            "{:?} water was transferred",
-            water_transferred
+            "{water_transferred:?} water was transferred"
         )
     }
 
@@ -1198,18 +1176,14 @@ mod tests {
 
         assert!(
             surface_water_flow > subsurface_water_flow,
-            "Surface water flow ({:?}) is not faster than subsurface water flow ({:?})",
-            surface_water_flow,
-            subsurface_water_flow
+            "Surface water flow ({surface_water_flow:?}) is not faster than subsurface water flow ({subsurface_water_flow:?})"
         );
 
         assert_eq!(surface_to_soil_flow, soil_to_surface_flow);
 
         assert!(
             surface_to_soil_flow < surface_water_flow,
-            "Surface to soil water flow ({:?}) is not slower than surface water flow ({:?})",
-            surface_to_soil_flow,
-            surface_water_flow
+            "Surface to soil water flow ({surface_to_soil_flow:?}) is not slower than surface water flow ({surface_water_flow:?})"
         );
     }
 
@@ -1239,9 +1213,7 @@ mod tests {
 
         assert!(
             large_height_difference > small_height_difference,
-            "Large height difference ({:?}) does not flow faster than small height difference ({:?})",
-            large_height_difference,
-            small_height_difference
+            "Large height difference ({large_height_difference:?}) does not flow faster than small height difference ({small_height_difference:?})"
         );
     }
 
@@ -1280,8 +1252,7 @@ mod tests {
             );
 
             println!(
-                "Water transferred A to B: {:?}, Water transferred B to A: {:?}",
-                water_transferred_a_to_b, water_transferred_b_to_a
+                "Water transferred A to B: {water_transferred_a_to_b:?}, Water transferred B to A: {water_transferred_b_to_a:?}"
             );
 
             water_height_a += water_transferred_b_to_a.into_height();
@@ -1293,14 +1264,11 @@ mod tests {
             let current_water = water_height_a + water_height_b;
             assert!(
                 current_water == initial_water,
-                "Water was not conserved, starting with {:?} and ending with {:?}",
-                initial_water,
-                current_water
+                "Water was not conserved, starting with {initial_water:?} and ending with {current_water:?}"
             );
 
             println!(
-                "Water height A: {:?}, Water height B: {:?}",
-                water_height_a, water_height_b
+                "Water height A: {water_height_a:?}, Water height B: {water_height_b:?}"
             )
         }
 
@@ -1308,8 +1276,7 @@ mod tests {
 
         assert!(
             water_difference < EPSILON_HEIGHT,
-            "Water levels did not stabilize, ending with a height difference of ({:?}) ",
-            water_difference
+            "Water levels did not stabilize, ending with a height difference of ({water_difference:?}) "
         );
     }
 }

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -1267,9 +1267,7 @@ mod tests {
                 "Water was not conserved, starting with {initial_water:?} and ending with {current_water:?}"
             );
 
-            println!(
-                "Water height A: {water_height_a:?}, Water height B: {water_height_b:?}"
-            )
+            println!("Water height A: {water_height_a:?}, Water height B: {water_height_b:?}")
         }
 
         let water_difference = water_height_a.abs_diff(water_height_b);

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -218,9 +218,7 @@ pub fn horizontal_water_movement(
     if water_config.enable_oceans {
         for tile_pos in map_geometry.ocean_tiles() {
             // Don't bother flowing to and from ocean tiles
-            for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
-                let Some(valid_neighbor) = maybe_neighbor else { continue };
-
+            for valid_neighbor in map_geometry.valid_neighbors(tile_pos) {
                 let neighbor_entity = map_geometry.get_terrain(valid_neighbor).unwrap();
                 let neighbor_query_item = terrain_query.get(neighbor_entity).unwrap();
 

--- a/emergence_lib/src/water/water_dynamics.rs
+++ b/emergence_lib/src/water/water_dynamics.rs
@@ -219,7 +219,7 @@ pub fn horizontal_water_movement(
         for tile_pos in map_geometry.ocean_tiles() {
             // Don't bother flowing to and from ocean tiles
             for maybe_neighbor in map_geometry.valid_neighbors(tile_pos) {
-                let Some(valid_neighbor) = maybe_neighbor else { continue };
+                let &Some(valid_neighbor) = maybe_neighbor else { continue };
 
                 let neighbor_entity = map_geometry.get_terrain(valid_neighbor).unwrap();
                 let neighbor_query_item = terrain_query.get(neighbor_entity).unwrap();


### PR DESCRIPTION
Fixes #905.

Before:

```
     Running benches/signals.rs (target/release/deps/signals-30d4a35bfd3f0270)
signal_diffusion_minimal
                        time:   [357.65 ns 357.97 ns 358.35 ns]
                        change: [-51.894% -51.730% -51.574%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

signal_diffusion_tiny   time:   [322.70 µs 322.79 µs 322.87 µs]
                        change: [-32.461% -32.418% -32.377%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

signal_diffusion_modest time:   [43.607 ms 44.476 ms 45.376 ms]
                        change: [-38.289% -36.284% -34.191%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running benches/water.rs (target/release/deps/water-ca1b56ed19609812)
compute_water_depth     time:   [45.560 µs 45.851 µs 46.168 µs]
                        change: [-5.1109% -4.2784% -3.4423%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

lateral_water_movement  time:   [13.270 ms 13.307 ms 13.351 ms]
                        change: [-11.621% -11.060% -10.534%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
  ```
  
  (on speedy machine)