### PR TITLE
Fix signal propagation

### DIFF
--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -273,11 +273,7 @@ impl Signals {
         self.maps
             .par_iter_mut()
             .for_each(|(_signal_type, signal_map)| {
-                for (&occupied_tile, original_strength) in signal_map
-                    .current
-                    .iter()
-                    .filter(|(_, signal_strength)| SignalStrength::ZERO.ne(signal_strength))
-                {
+                for (&occupied_tile, original_strength) in signal_map.current.iter() {
                     let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
 
                     for maybe_neighboring_tile in map_geometry.passable_neighbors(occupied_tile) {

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -275,7 +275,11 @@ impl Signals {
         self.maps
             .par_iter_mut()
             .for_each(|(_signal_type, signal_map)| {
-                for (&occupied_tile, original_strength) in signal_map.current.iter() {
+                for (&occupied_tile, original_strength) in signal_map
+                    .current
+                    .iter()
+                    .filter(|(_, &strength)| strength != SignalStrength::ZERO)
+                {
                     let amount_to_send_to_each_neighbor = *original_strength * diffusion_fraction;
 
                     for maybe_neighboring_tile in map_geometry.passable_neighbors(occupied_tile) {

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -785,6 +785,11 @@ mod tests {
         let mut signals = Signals::default();
         let map_geometry = MapGeometry::new(1);
 
+        let passable_neighbors = map_geometry.passable_neighbors(TilePos::ZERO);
+        for maybe_neighbor in passable_neighbors {
+            assert!(maybe_neighbor.is_some());
+        }
+
         signals.add_signal(
             SignalType::Contains(test_item()),
             TilePos::ZERO,

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -781,6 +781,40 @@ mod tests {
     }
 
     #[test]
+    fn signals_diffuse() {
+        let mut signals = Signals::default();
+        let map_geometry = MapGeometry::new(1);
+
+        signals.add_signal(
+            SignalType::Contains(test_item()),
+            TilePos::ZERO,
+            SignalStrength(1.),
+        );
+
+        assert_eq!(
+            signals.get(SignalType::Contains(test_item()), TilePos::ZERO),
+            SignalStrength(1.)
+        );
+
+        signals.diffuse(&map_geometry, 0.5);
+
+        assert_eq!(signals.maps.len(), 1);
+        let signal_map = signals.maps.values().next().unwrap();
+        dbg!(&signal_map);
+
+        let current_signals = signal_map.current.clone();
+
+        assert_eq!(
+            current_signals.len(),
+            7,
+            "Signal should have diffused to all 7 neigboring tiles"
+        );
+        for (_, &signal_strength) in current_signals.iter() {
+            assert!(signal_strength > SignalStrength::ZERO);
+        }
+    }
+
+    #[test]
     fn neighboring_signals_checks_origin_tile() {
         let mut signals = Signals::default();
         let map_geometry = MapGeometry::new(1);

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -270,7 +270,7 @@ impl Signals {
 
     /// Diffuses signals from one cell into the next
     pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
-        assert!((0.0..=1 / 0 / 6.0).contains(&diffusion_fraction));
+        assert!((0.0..=1.0 / 6.0).contains(&diffusion_fraction));
 
         self.maps
             .par_iter_mut()

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -270,7 +270,7 @@ impl Signals {
 
     /// Diffuses signals from one cell into the next
     pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
-        assert!(diffusion_fraction >= 0.0 && diffusion_fraction <= 1.0 / 6.0);
+        assert!((0.0..=1 / 0 / 6.0).contains(&diffusion_fraction));
 
         self.maps
             .par_iter_mut()

--- a/emergence_lib/src/signals.rs
+++ b/emergence_lib/src/signals.rs
@@ -270,6 +270,8 @@ impl Signals {
 
     /// Diffuses signals from one cell into the next
     pub fn diffuse(&mut self, map_geometry: &MapGeometry, diffusion_fraction: f32) {
+        assert!(diffusion_fraction >= 0.0 && diffusion_fraction <= 1.0 / 6.0);
+
         self.maps
             .par_iter_mut()
             .for_each(|(_signal_type, signal_map)| {
@@ -814,7 +816,7 @@ mod tests {
             SignalStrength(1.)
         );
 
-        signals.diffuse(&map_geometry, 0.5);
+        signals.diffuse(&map_geometry, 0.1);
 
         assert_eq!(signals.maps.len(), 1);
         let signal_map = signals.maps.values().next().unwrap();


### PR DESCRIPTION
Reverses many of the performance gains in #950: we managed to somehow turn off all signal diffusion with a stray .filter :/