### PR TITLE
Update cargo-cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           toolchain: stable
           components: ${{ matrix.toolchain-components || null }}
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
@@ -53,4 +53,3 @@ jobs:
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
-              

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -20,7 +20,7 @@ jobs:
           toolchain: nightly
           override: true
       - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1.0.0
+        uses: Leafwing-Studios/cargo-cache@v1
       # We don't --force install to reduce CI times (drastically)
       # We fix the version so that it overwrites when we specify a new one
       # We need to remember to update the version from time to time


### PR DESCRIPTION
This PR changes the `cargo-cache` action version to `v1`.
This gives us access to the new `v1.1.0` version, which includes the Rust version in the cache key.

This should fix some instances where the cache gets stuck on an outdated version.