### PR TITLE
Don't run benchmarks in CI

### DIFF
--- a/emergence_lib/src/construction/terraform.rs
+++ b/emergence_lib/src/construction/terraform.rs
@@ -216,9 +216,13 @@ impl TerraformingCommandsExt for Commands<'_, '_> {
     }
 }
 
+/// A command to initialize a terraforming action.
 struct TerraformCommand {
+    /// The hex where the terraforming action is taking place.
     hex: Hex,
+    /// The terraforming action to perform.
     action: TerraformingAction,
+    /// Is this a preview of the terraforming action?
     preview: bool,
 }
 
@@ -288,7 +292,9 @@ impl Command for TerraformCommand {
     }
 }
 
+/// A command to cancel a terraforming action.
 struct CancelTerraformCommand {
+    /// The hex where the terraforming action is taking place.
     hex: Hex,
 }
 

--- a/emergence_lib/src/construction/zoning.rs
+++ b/emergence_lib/src/construction/zoning.rs
@@ -84,12 +84,12 @@ fn set_zoning(
         Tool::Terraform(terraform_tool) => match apply_zoning {
             true => {
                 for voxel_pos in relevant_tiles.iter() {
-                    commands.start_terraform(voxel_pos.hex, terraform_tool.clone().into());
+                    commands.start_terraform(voxel_pos.hex, (*terraform_tool).into());
                 }
             }
             false => {
                 for &voxel_pos in relevant_tiles.iter() {
-                    commands.preview_terraform(voxel_pos.hex, terraform_tool.clone().into());
+                    commands.preview_terraform(voxel_pos.hex, (*terraform_tool).into());
                 }
             }
         },

--- a/emergence_lib/src/geometry/indexing.rs
+++ b/emergence_lib/src/geometry/indexing.rs
@@ -914,7 +914,7 @@ impl MapGeometry {
         assert!(
             // The set of keys should be larger, because it accounts for all possible origins
             // Units and signals must be able to *leave* any voxel
-            walkable_voxels.difference(&walkable_neighbors_keys).into_iter().count() == 0,
+            walkable_voxels.difference(&walkable_neighbors_keys).count() == 0,
             "Walkable voxels and walkable neighbors keys have desynced. Found {:?} in walkable voxels but not in walkable neighbors keys.",
             walkable_voxels.difference(&walkable_neighbors_keys)
         );

--- a/emergence_lib/src/player_interaction/mod.rs
+++ b/emergence_lib/src/player_interaction/mod.rs
@@ -97,10 +97,8 @@ pub(crate) enum PlayerAction {
     /// If there is no structure there, the player's selection is cleared.
     Copy,
     /// Sets the zoning of all currently selected tiles to the currently selected structure.
-    ///
-    /// If no structure is selected to build, zoning will be set to [`Zoning::None`](crate::construction::zoning::Zoning::None).
     Paste,
-    /// Sets the zoning of all currently selected tiles to [`Zoning::None`](crate::construction::zoning::Zoning::None).
+    /// Cancels any planned actions (ghosts) selected.
     ClearZoning,
     /// Rotates the contents of the clipboard counterclockwise.
     RotateClipboardLeft,

--- a/emergence_lib/src/player_interaction/picking.rs
+++ b/emergence_lib/src/player_interaction/picking.rs
@@ -90,6 +90,7 @@ fn update_raycast_with_cursor(
     }
 }
 
+/// A marker that's used to identify meshes and sources for raycasting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
 pub(crate) struct PickableVoxel;
 

--- a/emergence_lib/src/structures/mod.rs
+++ b/emergence_lib/src/structures/mod.rs
@@ -208,7 +208,7 @@ mod tests {
     /// beginning at the origin and moving right one.
     ///
     /// This is a horizontal line, in the axial coordinate diagram shown here:
-    /// https://www.redblobgames.com/grids/hexagons/#coordinates
+    /// <https://www.redblobgames.com/grids/hexagons/#coordinates>
     fn two_tile_footprint() -> Footprint {
         let mut set = HashSet::new();
         set.insert(VoxelPos::ZERO);

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -112,7 +112,7 @@ fn main() {
 
     if what_to_run.contains(&Check::Test) {
         // Run tests (except doc tests and without building examples)
-        cmd!(sh, "cargo test --workspace --lib --bins --tests --benches")
+        cmd!(sh, "cargo test --workspace --lib --bins --tests")
             .run()
             .expect("Please fix failing tests in output above.");
     }


### PR DESCRIPTION
Introduced in Rust 1.80.

Fixes #980.